### PR TITLE
Add animated template previews and accordion groups

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -193,6 +193,25 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
 .tpl-item.active { background: var(--card-inset); color: var(--fg); }
 .tpl-name { flex: 1; }
 .tpl-chevron { width: 12px; height: 12px; color: var(--fg-faint); display: grid; place-items: center; }
+.tpl-accordion { width: 100%; }
+.tpl-accordion-chevron {
+  width: 12px; height: 12px; color: var(--fg-faint); display: grid; place-items: center;
+  transition: transform 180ms ease, color var(--t-fast);
+}
+.tpl-accordion.open .tpl-accordion-chevron { transform: rotate(90deg); color: var(--fg); }
+.tpl-grid-accordion {
+  padding: 10px 0 18px;
+  animation: tpl-accordion-in 180ms ease-out both;
+  transform-origin: top center;
+}
+@keyframes tpl-accordion-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tpl-accordion-chevron { transition: none; }
+  .tpl-grid-accordion { animation: none; }
+}
 .tpl-item.soon { opacity: 0.45; cursor: default; }
 .tpl-soon { font-size: 9px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg-faint); border: 1px solid var(--line); border-radius: var(--r-chip); padding: 2px 5px; }
 .tpl-foot { padding: 12px 16px 16px; }
@@ -243,6 +262,20 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
   background: var(--frame); overflow: hidden;
 }
 .tpl-thumb-el { position: absolute; background: #c9c9c9; }
+.tpl-thumb.is-previewing .tpl-thumb-el { will-change: transform, opacity; }
+.tpl-thumb::after {
+  content: '';
+  position: absolute; right: 7px; bottom: 7px; z-index: 50;
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--fg-faint); opacity: 0;
+  transition: opacity var(--t-fast), background var(--t-fast);
+}
+.tpl-card:hover .tpl-thumb::after,
+.tpl-card:focus-visible .tpl-thumb::after { opacity: 0.65; }
+.tpl-thumb.is-previewing::after { opacity: 1; background: var(--fg); }
+@media (prefers-reduced-motion: reduce) {
+  .tpl-thumb::after { display: none; }
+}
 .tpl-card-label { font-size: var(--fs-meta); line-height: 16.5px; color: var(--fg-muted); text-align: center; }
 
 /* ============================================================

--- a/components/TemplateThumb.tsx
+++ b/components/TemplateThumb.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Template } from '@/lib/types';
 import { defaultsFor, easingFor } from '@/templates';
 import { resolveEasing } from '@/lib/easing';
@@ -8,7 +8,8 @@ import { resolveEasing } from '@/lib/easing';
 // Live template thumbnail: run the template's own transform at a fixed frame
 // and render the resulting card layout as plain divs. Because it uses the real
 // transform + declared defaults, thumbs always match the actual motion.
-const THUMB_FRAME = 40;              // ~1.3s in — mid-motion pose
+const THUMB_FRAME = 40;              // ~1.3s in — useful idle pose
+const PREVIEW_FPS = 30;
 const CTX_BASE = { fps: 30, width: 810, height: 1080, duration: 8, totalFrames: 240 }; // 3:4 preview space, nominal 8s clip
 const TEX_W = 480, TEX_H = 600;      // placeholder texture proportions
 const SPRITE_BASE = 340;
@@ -19,6 +20,68 @@ interface CardPose {
 }
 
 export default function TemplateThumb({ template }: { template: Template }) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [frame, setFrame] = useState(THUMB_FRAME);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+
+  // Only the hovered or keyboard-focused card gets an animation loop. Every
+  // other thumbnail remains a cheap static pose.
+  useEffect(() => {
+    const root = rootRef.current;
+    const card = root?.closest<HTMLElement>('.tpl-card');
+    if (!card) return;
+
+    let raf = 0;
+    let running = false;
+    let startedAt = 0;
+    let lastFrame = -1;
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    const tick = (now: number) => {
+      if (!running) return;
+      const nextFrame = Math.floor(((now - startedAt) / 1000) * PREVIEW_FPS) % CTX_BASE.totalFrames;
+      if (nextFrame !== lastFrame) {
+        lastFrame = nextFrame;
+        setFrame(nextFrame);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+
+    const start = () => {
+      if (running || reducedMotion.matches) return;
+      running = true;
+      startedAt = performance.now();
+      lastFrame = -1;
+      setIsPreviewing(true);
+      raf = requestAnimationFrame(tick);
+    };
+
+    const stop = () => {
+      if (!running) return;
+      running = false;
+      cancelAnimationFrame(raf);
+      setIsPreviewing(false);
+      setFrame(THUMB_FRAME);
+    };
+
+    const stopAfterFocus = (event: FocusEvent) => {
+      if (!card.contains(event.relatedTarget as Node | null)) stop();
+    };
+
+    card.addEventListener('pointerenter', start);
+    card.addEventListener('pointerleave', stop);
+    card.addEventListener('focusin', start);
+    card.addEventListener('focusout', stopAfterFocus);
+    return () => {
+      running = false;
+      cancelAnimationFrame(raf);
+      card.removeEventListener('pointerenter', start);
+      card.removeEventListener('pointerleave', stop);
+      card.removeEventListener('focusin', start);
+      card.removeEventListener('focusout', stopAfterFocus);
+    };
+  }, []);
+
   const poses = useMemo<CardPose[]>(() => {
     const v = defaultsFor(template.meta.id);
     const count = Math.max(1, Math.min(20, Math.round(v.count ?? 6)));
@@ -31,7 +94,7 @@ export default function TemplateThumb({ template }: { template: Template }) {
     };
     const out: CardPose[] = [];
     for (let i = 0; i < count; i++) {
-      const t = template.transform(THUMB_FRAME, i, count, v, ctx);
+      const t = template.transform(frame, i, count, v, ctx);
       const w = TEX_W * norm * t.scale * (t.scaleX ?? 1);
       const h = TEX_H * norm * t.scale * (t.scaleY ?? 1);
       out.push({
@@ -44,11 +107,11 @@ export default function TemplateThumb({ template }: { template: Template }) {
       });
     }
     return out;
-  }, [template]);
+  }, [frame, template]);
 
   // scale preview space → thumbnail space (thumb is 3:4 like CTX)
   return (
-    <div className="tpl-thumb">
+    <div ref={rootRef} className={`tpl-thumb ${isPreviewing ? 'is-previewing' : ''}`} aria-hidden="true">
       {poses.map((p, i) => (
         <div
           key={i}

--- a/components/TemplatesCard.tsx
+++ b/components/TemplatesCard.tsx
@@ -44,8 +44,6 @@ export default function TemplatesCard() {
   const matches = templateList.filter(
     (t) => t.meta.name.toLowerCase().includes(q) || t.meta.group.toLowerCase().includes(q)
   );
-  const group = templateGroups.find((g) => g.group === openGroup);
-
   return (
     <section className="card templates">
       <div className="tpl-head">
@@ -110,42 +108,39 @@ export default function TemplatesCard() {
               </button>
             ))}
           </div>
-        ) : group ? (
-          // drill-in: back header + 2-col variant grid
-          <>
-            <div className="tpl-group-head">
-              <button className="tpl-back" onClick={() => setOpenGroup(null)}>
-                <Chevron dir="left" />
-              </button>
-              <span className="tpl-group-title">{group.group}</span>
-            </div>
-            <div className="tpl-grid">
-              {group.items.map((t) => (
-                <button
-                  key={t.meta.id}
-                  className={`tpl-card ${activeTemplateId === t.meta.id ? 'active' : ''}`}
-                  onClick={() => setActiveTemplate(t.meta.id)}
-                >
-                  <TemplateThumb template={t} />
-                  <span className="tpl-card-label">{t.meta.name}</span>
-                </button>
-              ))}
-            </div>
-          </>
         ) : (
-          // root: group rows
+          // Accordion: keep catalogue context while showing one group's models.
           <>
             {templateGroups.map(({ group: name, items }) => {
               const activeHere = items.some((t) => t.meta.id === activeTemplateId);
+              const isOpen = openGroup === name;
+              const panelId = `template-group-${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
               return (
-                <button
-                  key={name}
-                  className={`tpl-item ${activeHere ? 'active' : ''}`}
-                  onClick={() => setOpenGroup(name)}
-                >
-                  <span className="tpl-name">{name}</span>
-                  <Chevron />
-                </button>
+                <div key={name} className={`tpl-accordion ${isOpen ? 'open' : ''}`}>
+                  <button
+                    className={`tpl-item ${activeHere || isOpen ? 'active' : ''}`}
+                    onClick={() => setOpenGroup(isOpen ? null : name)}
+                    aria-expanded={isOpen}
+                    aria-controls={panelId}
+                  >
+                    <span className="tpl-name">{name}</span>
+                    <span className="tpl-accordion-chevron"><Chevron /></span>
+                  </button>
+                  {isOpen && (
+                    <div id={panelId} className="tpl-grid tpl-grid-accordion">
+                      {items.map((t) => (
+                        <button
+                          key={t.meta.id}
+                          className={`tpl-card ${activeTemplateId === t.meta.id ? 'active' : ''}`}
+                          onClick={() => setActiveTemplate(t.meta.id)}
+                        >
+                          <TemplateThumb template={t} />
+                          <span className="tpl-card-label">{t.meta.name}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
               );
             })}
           </>


### PR DESCRIPTION
## Overview

This pull request improves template navigation by replacing the separate group drill-down screen with an inline accordion.

Users can now expand a template category directly inside the main list and view its available models without leaving the catalogue context.

## Changes

- Template categories expand directly below their respective rows.
- Only one category remains expanded at a time.
- Opening another category automatically closes the previous one.
- Clicking an expanded category collapses it.
- Removed the separate category screen and back-navigation requirement.
- Added rotating chevrons to communicate the expanded state.
- Preserved active-template highlighting inside categories.
- Added a subtle opening transition without shifting unrelated interface elements.

## Performance

Template thumbnails are only mounted for the currently expanded category. Closed categories do not keep their preview components in the DOM, reducing unnecessary rendering and animation work.

## Accessibility

- Added `aria-expanded` to every category button.
- Added `aria-controls` connecting each button to its content.
- Categories remain fully accessible through keyboard navigation.
- Accordion transitions respect the system’s `prefers-reduced-motion` setting.
- Existing visible focus states are preserved.

## Validation

- TypeScript type checking passes.
- Next.js production build passes.
- Opening a category renders its templates directly below the row.
- Opening another category closes the previous one.
- Only one category remains expanded at a time.
- Animated previews continue working inside the expanded category.
- No runtime errors were detected during browser testing.