### PR TITLE
Stacked motion layers and a multi-project workspace

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,7 +46,10 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
   height: 100vh;
   display: grid;
   grid-template-columns: var(--rail-w) var(--templates-col) minmax(0, 1fr) var(--controls-col) var(--right-col);
-  grid-template-rows: 1fr var(--bottom-h);
+  /* `auto` rather than a fixed --bottom-h: the transport row keeps that exact
+     height on its own, and the row grows only when the motion-layer lanes are
+     expanded below it. */
+  grid-template-rows: minmax(0, 1fr) auto;
   grid-template-areas:
     "rail templates stage controls right"
     "rail bottom bottom bottom bottom";
@@ -105,6 +108,15 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
 }
 .rail-item:hover { color: var(--fg-muted); }
 .rail-item.active { background: var(--card-inset); color: var(--fg); }
+/* "Novo" is an action, not a section — it reads as the primary affordance and
+   never carries the active state, so a hairline separates it from the nav. */
+.rail-item.rail-action {
+  color: var(--fg-label);
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  margin-bottom: 8px; padding-bottom: 4px;
+}
+.rail-item.rail-action:hover { color: var(--fg); background: var(--card-inset); }
 .rail-ico { width: 20px; height: 20px; display: grid; place-items: center; }
 .rail-label { font-size: 8px; line-height: 10px; font-weight: 600; }
 .rail-bottom { padding: 8px; border-top: 1px solid var(--line); }
@@ -581,7 +593,11 @@ select.field { padding-right: 26px; }
    9px time labels, 4px #e5e7eb track, #374151 playhead line + chip
    ============================================================ */
 .bottom { grid-area: bottom; border-top: 1px solid var(--line); }
-.timeline { display: flex; align-items: center; gap: 16px; padding: 0 var(--pad-sect); height: 100%; }
+/* The shell stacks the transport row and (when open) the motion-layer lanes.
+   --tl-axis-left / --tl-axis-w are measured and written by Timeline.tsx so the
+   lane bars share the scrubber's exact coordinate space. */
+.timeline-shell { display: flex; flex-direction: column; --tl-axis-left: 0px; --tl-axis-w: 100%; }
+.timeline { display: flex; align-items: center; gap: 16px; padding: 0 var(--pad-sect); height: var(--bottom-h); flex: 0 0 auto; }
 .play-btn {
   width: 36px; height: 36px; border-radius: var(--r-ctrl); background: var(--inverse-bg);
   color: var(--inverse-fg); display: grid; place-items: center; flex: 0 0 auto;
@@ -631,6 +647,178 @@ select.field { padding-right: 26px; }
   transition: opacity var(--t-fast);
 }
 .export-btn:hover { opacity: 0.9; }
+
+/* ============================================================
+   MOTION LAYER LANES — the track stack under the transport row.
+   One lane per track; the bar's x-extent IS its window on the clip, so the
+   geometry the user drags is the geometry the renderer plays.
+   ============================================================ */
+.tl-lanes-btn {
+  height: var(--ctl-h); padding: 0 12px; background: var(--card-inset); color: var(--fg-label);
+  border-radius: var(--r-seg); display: flex; align-items: center; gap: 6px;
+  font-size: var(--fs-ui); flex: 0 0 auto; transition: background var(--t-fast), color var(--t-fast);
+}
+.tl-lanes-btn:hover { background: var(--card-thumb); color: var(--fg); }
+.tl-lanes-btn.active { background: var(--seg-active-bg); color: var(--seg-active-fg); }
+.tl-lanes-count {
+  font-size: var(--fs-micro); font-variant-numeric: tabular-nums;
+  padding: 1px 4px; background: var(--card); color: var(--fg-muted); line-height: 12px;
+}
+.tl-lanes-btn.active .tl-lanes-count { background: var(--card-inset); color: var(--fg-label); }
+
+.tl-lanes {
+  position: relative; border-top: 1px solid var(--line);
+  padding: 8px var(--pad-sect) 0;
+  display: flex; flex-direction: column; gap: 3px;
+  max-height: 44vh; overflow-y: auto;
+}
+
+.tl-lane {
+  display: flex; align-items: center; gap: 8px;
+  height: var(--tl-lane-h); flex: 0 0 auto; cursor: default;
+}
+.tl-lane.hidden { opacity: 0.45; }
+
+.tl-lane-gutter {
+  /* right-aligned into the space left of the shared time axis, so the bars
+     start exactly where the ruler starts */
+  width: calc(var(--tl-axis-left) - var(--pad-sect) - 8px);
+  min-width: var(--tl-gutter-w);
+  display: flex; align-items: center; justify-content: flex-end; gap: 2px; flex: 0 0 auto;
+}
+.tl-lane-eye {
+  width: 22px; height: 22px; display: grid; place-items: center; flex: 0 0 auto;
+  color: var(--fg-faint); transition: color var(--t-fast);
+}
+.tl-lane-eye:hover { color: var(--fg); }
+.tl-lane.active .tl-lane-eye { color: var(--fg-label); }
+.tl-lane-order { display: flex; flex-direction: column; flex: 0 0 auto; }
+.tl-lane-arrow {
+  width: 16px; height: 12px; display: grid; place-items: center;
+  color: var(--fg-faint); transition: color var(--t-fast);
+}
+.tl-lane-arrow:hover:not(:disabled) { color: var(--fg); }
+.tl-lane-arrow:disabled { opacity: 0.3; cursor: default; }
+
+.tl-lane-bars { position: relative; flex: 1; height: 100%; min-width: 0; }
+
+.tl-bar {
+  --tl-bar-fill: var(--tl-bar-idle);
+  position: absolute; top: 2px; bottom: 2px;
+  background: var(--tl-bar-fill); color: var(--tl-bar-idle-fg);
+  border-radius: var(--r-seg); overflow: hidden;
+  display: flex; align-items: center;
+  cursor: grab; touch-action: none;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+.tl-bar:active { cursor: grabbing; }
+.tl-lane.active .tl-bar { --tl-bar-fill: var(--tl-bar-on); color: var(--tl-bar-on-fg); }
+
+/* the alpha envelope the renderer applies at the window edges, drawn to scale */
+.tl-bar-fade { position: absolute; inset: 0; pointer-events: none; }
+
+.tl-bar-spark {
+  position: absolute; inset: 0; width: 100%; height: 100%;
+  pointer-events: none; opacity: 0.9;
+}
+.tl-bar-spark path { fill: none; stroke: var(--tl-spark); stroke-width: 1.25; vector-effect: non-scaling-stroke; }
+.tl-lane.active .tl-bar-spark path { stroke: var(--tl-spark-on); }
+.tl-bar-spark .tl-bar-spark-y { stroke-dasharray: 2 2; opacity: 0.65; }
+
+.tl-bar-label {
+  position: relative; display: flex; align-items: baseline; gap: 6px;
+  padding: 0 9px; min-width: 0; pointer-events: none;
+  font-size: var(--fs-meta); line-height: 1; white-space: nowrap;
+}
+.tl-bar-label b { font-weight: 500; overflow: hidden; text-overflow: ellipsis; }
+.tl-bar-label em { font-style: normal; opacity: 0.6; }
+
+/* 6px grab strips; the cursor is the affordance — no extra chrome in the bar */
+.tl-bar-edge {
+  position: absolute; top: 0; bottom: 0; width: 6px;
+  cursor: ew-resize; touch-action: none;
+}
+.tl-bar-edge.in { left: 0; }
+.tl-bar-edge.out { right: 0; }
+.tl-bar-edge:hover { background: var(--line-soft); }
+
+.tl-bar-actions {
+  position: absolute; right: 8px; top: 0; bottom: 0;
+  display: none; align-items: center; gap: 2px;
+}
+.tl-bar:hover .tl-bar-actions { display: flex; }
+.tl-bar-actions button {
+  width: 18px; height: 18px; display: grid; place-items: center;
+  color: currentColor; opacity: 0.55; transition: opacity var(--t-fast);
+}
+.tl-bar-actions button:hover { opacity: 1; }
+
+.tl-lanes-playhead {
+  position: absolute; top: 0; bottom: 34px; width: 2px; margin-left: -1px;
+  background: var(--chip-bg); pointer-events: none;
+}
+
+.tl-lanes-foot {
+  display: flex; align-items: center; gap: 12px;
+  height: 34px; flex: 0 0 auto;
+}
+.tl-add-track {
+  height: 24px; padding: 0 10px; background: var(--card-inset); color: var(--fg-label);
+  border-radius: var(--r-seg); display: flex; align-items: center; gap: 5px;
+  font-size: var(--fs-ui); flex: 0 0 auto; transition: background var(--t-fast), color var(--t-fast);
+}
+.tl-add-track:hover { background: var(--card-thumb); color: var(--fg); }
+.tl-lanes-hint { font-size: var(--fs-meta); color: var(--fg-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ---- track inspector (active layer's own properties) ---- */
+.trk-name {
+  max-width: 130px; border: none; text-align: right;
+  font-size: var(--fs-ui); color: var(--fg-label); background: var(--card-inset);
+}
+.trk-name:focus { color: var(--fg); }
+.trk-assets { display: flex; flex-wrap: wrap; gap: 4px; }
+.trk-asset {
+  width: 26px; height: 26px; display: grid; place-items: center; flex: 0 0 auto;
+  background: var(--card-inset); color: var(--fg-faint); border-radius: var(--r-seg);
+  font-size: var(--fs-meta); font-variant-numeric: tabular-nums;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+.trk-asset:hover { background: var(--card-thumb); color: var(--fg-label); }
+.trk-asset.on { background: var(--seg-active-bg); color: var(--seg-active-fg); }
+
+/* ============================================================
+   PROJECTS PANEL — the project list in the left column
+   ============================================================ */
+.prj-sub { font-size: var(--fs-meta); color: var(--fg-faint); padding: 6px 0 2px; }
+.prj-list { padding: 6px 0; }
+.prj-item {
+  position: relative; display: flex; align-items: center; gap: 4px;
+  padding: 0 var(--pad-card); min-height: 48px;
+  border-left: 2px solid transparent;
+  transition: background var(--t-fast);
+}
+.prj-item:hover { background: var(--card-soft); }
+.prj-item.active { border-left-color: var(--fg); background: var(--card-soft); }
+.prj-open {
+  flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px;
+  text-align: left; padding: 8px 0;
+}
+.prj-name {
+  font-size: var(--fs-label); color: var(--fg-label);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.prj-item.active .prj-name { color: var(--fg); font-weight: 500; }
+.prj-meta { font-size: var(--fs-meta); color: var(--fg-faint); }
+.prj-meta b { color: var(--fg-muted); font-weight: 500; }
+.prj-rename { flex: 1; min-width: 0; height: 30px; }
+.prj-actions { display: none; align-items: center; gap: 2px; flex: 0 0 auto; }
+.prj-item:hover .prj-actions,
+.prj-item.active .prj-actions { display: flex; }
+.prj-actions .icon-btn.danger { color: var(--gz-x); }
+.prj-confirm {
+  position: absolute; left: var(--pad-card); right: var(--pad-card); bottom: 2px;
+  font-size: var(--fs-micro); color: var(--gz-x); line-height: 1.3;
+}
 
 /* ============================================================
    MODAL

--- a/app/globals.css
+++ b/app/globals.css
@@ -684,14 +684,18 @@ select.field { padding-right: 26px; }
      start exactly where the ruler starts */
   width: calc(var(--tl-axis-left) - var(--pad-sect) - 8px);
   min-width: var(--tl-gutter-w);
-  display: flex; align-items: center; justify-content: flex-end; gap: 2px; flex: 0 0 auto;
+  display: flex; align-items: center; justify-content: flex-end; gap: 1px; flex: 0 0 auto;
 }
-.tl-lane-eye {
+/* every per-layer control: visibility, stacking, duplicate, remove */
+.tl-lane-btn {
   width: 22px; height: 22px; display: grid; place-items: center; flex: 0 0 auto;
-  color: var(--fg-faint); transition: color var(--t-fast);
+  color: var(--fg-faint); border-radius: var(--r-seg);
+  transition: color var(--t-fast), background var(--t-fast);
 }
-.tl-lane-eye:hover { color: var(--fg); }
-.tl-lane.active .tl-lane-eye { color: var(--fg-label); }
+.tl-lane-btn:hover:not(:disabled) { color: var(--fg); background: var(--card-inset); }
+.tl-lane-btn:disabled { opacity: 0.28; cursor: default; }
+.tl-lane-btn.danger:hover:not(:disabled) { color: var(--gz-x); }
+.tl-lane.active .tl-lane-btn { color: var(--fg-label); }
 .tl-lane-order { display: flex; flex-direction: column; flex: 0 0 auto; }
 .tl-lane-arrow {
   width: 16px; height: 12px; display: grid; place-items: center;
@@ -717,14 +721,6 @@ select.field { padding-right: 26px; }
 /* the alpha envelope the renderer applies at the window edges, drawn to scale */
 .tl-bar-fade { position: absolute; inset: 0; pointer-events: none; }
 
-.tl-bar-spark {
-  position: absolute; inset: 0; width: 100%; height: 100%;
-  pointer-events: none; opacity: 0.9;
-}
-.tl-bar-spark path { fill: none; stroke: var(--tl-spark); stroke-width: 1.25; vector-effect: non-scaling-stroke; }
-.tl-lane.active .tl-bar-spark path { stroke: var(--tl-spark-on); }
-.tl-bar-spark .tl-bar-spark-y { stroke-dasharray: 2 2; opacity: 0.65; }
-
 .tl-bar-label {
   position: relative; display: flex; align-items: baseline; gap: 6px;
   padding: 0 9px; min-width: 0; pointer-events: none;
@@ -741,17 +737,6 @@ select.field { padding-right: 26px; }
 .tl-bar-edge.in { left: 0; }
 .tl-bar-edge.out { right: 0; }
 .tl-bar-edge:hover { background: var(--line-soft); }
-
-.tl-bar-actions {
-  position: absolute; right: 8px; top: 0; bottom: 0;
-  display: none; align-items: center; gap: 2px;
-}
-.tl-bar:hover .tl-bar-actions { display: flex; }
-.tl-bar-actions button {
-  width: 18px; height: 18px; display: grid; place-items: center;
-  color: currentColor; opacity: 0.55; transition: opacity var(--t-fast);
-}
-.tl-bar-actions button:hover { opacity: 1; }
 
 .tl-lanes-playhead {
   position: absolute; top: 0; bottom: 34px; width: 2px; margin-left: -1px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -498,7 +498,19 @@ select.field { padding-right: 26px; }
 /* ============================================================
    CANVAS STAGE
    ============================================================ */
-.stage-col { grid-area: stage; position: relative; display: flex; align-items: center; justify-content: center; min-width: 0; min-height: 0; background: var(--stage); }
+/* The dot grid marks the backdrop as "not the canvas", so the frame edge stays
+   readable even when the scene background is the same colour as the stage —
+   which the defaults are, in dark mode. Any mode that fills the stage (board,
+   3D) paints over it. */
+.stage-col {
+  grid-area: stage; position: relative;
+  display: flex; align-items: center; justify-content: center;
+  min-width: 0; min-height: 0;
+  background-color: var(--stage);
+  background-image: radial-gradient(var(--stage-dot) 1px, transparent 1px);
+  background-size: 12px 12px;
+  background-position: center;
+}
 .panel-toggle {
   position: absolute; top: 50%; z-index: 50;
   width: 32px; height: 44px;
@@ -517,7 +529,13 @@ select.field { padding-right: 26px; }
 .app:not(.left-collapsed) .panel-toggle-left svg { transform: rotate(180deg); }
 .app.right-collapsed .panel-toggle-right svg { transform: rotate(180deg); }
 .stage-wrap { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; min-height: 0; padding: 48px; }
-.stage-canvas { max-width: 100%; max-height: 100%; width: auto; height: auto; border-radius: var(--r-ctrl); }
+/* box-shadow rather than border: the canvas is sized by max-width/max-height,
+   and a border would add to its box and shrink the drawing area. */
+.stage-canvas {
+  max-width: 100%; max-height: 100%; width: auto; height: auto;
+  border-radius: var(--r-ctrl);
+  box-shadow: 0 0 0 1px var(--stage-edge), 0 4px 18px var(--stage-shadow);
+}
 
 /* ---- Board mode: DOM cards posed from the rAF loop ---- */
 .board-stage {
@@ -587,6 +605,24 @@ select.field { padding-right: 26px; }
   transition: color var(--t-fast);
 }
 .stage-fs:hover { color: var(--fg-body); }
+
+/* Undo / redo, floating at the top-left of the stage. Carries its own surface
+   because the stage backdrop can be any colour the user sets — the same reason
+   .panel-toggle does. */
+.stage-history {
+  position: absolute; left: 10px; top: 10px; z-index: 40;
+  display: flex; align-items: center;
+  background: color-mix(in srgb, var(--card) 92%, transparent);
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+  backdrop-filter: blur(8px);
+}
+.stage-hist-btn {
+  width: 30px; height: 30px; display: grid; place-items: center;
+  color: var(--fg-muted); transition: color var(--t-fast), background var(--t-fast);
+}
+.stage-hist-btn:hover:not(:disabled) { color: var(--fg); background: var(--card-inset); }
+.stage-hist-btn:disabled { opacity: 0.32; cursor: default; }
+.stage-hist-sep { width: 1px; height: 16px; background: var(--line); flex: 0 0 auto; }
 
 /* ============================================================
    TIMELINE — 56px white bar, top border; play 36px #111827;

--- a/app/globals.css
+++ b/app/globals.css
@@ -507,7 +507,16 @@ select.field { padding-right: 26px; }
   display: flex; align-items: center; justify-content: center;
   min-width: 0; min-height: 0;
   background-color: var(--stage);
-  background-image: radial-gradient(var(--stage-dot) 1px, transparent 1px);
+  /* A grid of isolated 2px SQUARES — square rather than round because every
+     --r-* token in this design system is 0.
+     Gradients can't intersect to make a 2D mark, so this is two layers: the
+     bottom one paints a full-width 2px band across the top of each cell, and
+     the top one covers all but the last 2px of that band with opaque --stage.
+     What survives is a 2x2 square. Order matters: the first background listed
+     paints on top. */
+  background-image:
+    linear-gradient(90deg, var(--stage) 10px, transparent 10px),
+    linear-gradient(var(--stage-dot) 2px, transparent 2px);
   background-size: 12px 12px;
   background-position: center;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,8 @@ import CanvasPanel from '@/components/CanvasPanel';
 import EffectsPanel from '@/components/EffectsPanel';
 import AssetsPanel from '@/components/AssetsPanel';
 import Timeline from '@/components/Timeline';
+import BoardPanel from '@/components/BoardPanel';
+import BoardExportBar from '@/components/BoardExportBar';
 import WelcomeDialog from '@/components/WelcomeDialog';
 import Effects3DPanel from '@/components/Effects3DPanel';
 import Effect3DControls from '@/components/Effect3DControls';
@@ -32,6 +34,8 @@ const PreviewStage = dynamic(() => import('@/components/PreviewStage'), { ssr: f
 const ThreeStage3D = dynamic(() => import('@/components/ThreeStage3D'), { ssr: false });
 // Web mode compiles user source in the browser — client-only too.
 const WebStage = dynamic(() => import('@/components/WebStage'), { ssr: false });
+// Board mode poses DOM cards from a rAF loop — client-only too.
+const BoardStage = dynamic(() => import('@/components/BoardStage'), { ssr: false });
 
 export default function Home() {
   const nav = useUIStore((s) => s.nav);
@@ -41,6 +45,7 @@ export default function Home() {
   const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
   const is3D = nav === '3d';
   const isWeb = nav === 'web';
+  const isBoard = nav === 'board';
   // Projects swaps the left column for the project list; the stage, scene column
   // and timeline keep showing the open project, so switching is a live preview.
   const isProjects = nav === 'projects';
@@ -57,7 +62,7 @@ export default function Home() {
   }, []);
 
   return (
-    <div className={`app ${is3D ? 'app-3d' : ''} ${isWeb ? 'app-web' : ''} ${tplCollapsed ? 'app-tpl-collapsed' : ''} ${leftCollapsed ? 'left-collapsed' : ''} ${rightCollapsed ? 'right-collapsed' : ''}`}>
+    <div className={`app ${is3D ? 'app-3d' : ''} ${isWeb || isBoard ? 'app-web' : ''} ${tplCollapsed ? 'app-tpl-collapsed' : ''} ${leftCollapsed ? 'left-collapsed' : ''} ${rightCollapsed ? 'right-collapsed' : ''}`}>
 
       <IconRail />
 
@@ -66,12 +71,12 @@ export default function Home() {
           Web and board reuse the template list wholesale: the templates are
           pure frame→pose functions, so the picker doesn't care what renders
           them. */}
-      {tplCollapsed ? <CollapsedStrip /> : isProjects ? <ProjectsPanel /> : is3D ? <Effects3DPanel /> : <TemplatesCard />}
+      {tplCollapsed ? <CollapsedStrip /> : isProjects ? <ProjectsPanel /> : is3D ? <Effects3DPanel /> : <TemplatesCard controlsInline={isBoard} />}
 
       {/* middle SCENE column — 2D only. 3D, web and board fold everything into
           the single right sidebar rather than run two 280px panels side by
           side. */}
-      {!is3D && !isWeb && (
+      {!is3D && !isWeb && !isBoard && (
         <section className="card controls card-scroll">
           <ScenePanel />
           <div className="hairline" />
@@ -80,7 +85,9 @@ export default function Home() {
       )}
 
       <main className="stage-col">
-        {isWeb ? (
+        {isBoard ? (
+          <BoardStage />
+        ) : isWeb ? (
           <WebStage />
         ) : is3D ? (
           <ThreeStage3D />
@@ -114,7 +121,9 @@ export default function Home() {
 
       {/* right column — canvas/assets (2D) or current 3D effect controls */}
       <section className="card right card-scroll">
-        {isWeb ? (
+        {isBoard ? (
+          <BoardPanel />
+        ) : isWeb ? (
           <>
             {/* what animates, then how it moves */}
             <WebSelectionPanel />
@@ -144,7 +153,7 @@ export default function Home() {
         {/* Video export is a 2D/3D product; web mode's deliverable is a zip
             of the user's component, which doesn't exist yet. Its source
             controls take that slot. */}
-        <Timeline showExport={!isWeb} extra={isWeb ? <WebSourceBar /> : undefined} />
+        <Timeline showExport={!isWeb && !isBoard} extra={isWeb ? <WebSourceBar /> : isBoard ? <BoardExportBar /> : undefined} />
       </footer>
 
       <WelcomeDialog />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,13 +19,12 @@ import WebScenePanel from '@/components/WebScenePanel';
 import WebSelectionPanel from '@/components/WebSelectionPanel';
 import WebCodeModal from '@/components/WebCodeModal';
 import WebSourceBar from '@/components/WebSourceBar';
-import BoardPanel from '@/components/BoardPanel';
-import BoardExportBar from '@/components/BoardExportBar';
 import { CollapsedStrip } from '@/components/TplCollapse';
 import { useUIStore } from '@/store/useUIStore';
-import { useSceneStore } from '@/store/useSceneStore';
-import { loadScene, startSceneAutosave } from '@/lib/scenePersist';
+import { useProjectStore } from '@/store/useProjectStore';
+import { startSceneAutosave } from '@/lib/scenePersist';
 import { useWebStore } from '@/store/useWebStore';
+import ProjectsPanel from '@/components/ProjectsPanel';
 
 // Pixi must run client-side only.
 const PreviewStage = dynamic(() => import('@/components/PreviewStage'), { ssr: false });
@@ -33,8 +32,6 @@ const PreviewStage = dynamic(() => import('@/components/PreviewStage'), { ssr: f
 const ThreeStage3D = dynamic(() => import('@/components/ThreeStage3D'), { ssr: false });
 // Web mode compiles user source in the browser — client-only too.
 const WebStage = dynamic(() => import('@/components/WebStage'), { ssr: false });
-// Board mode poses DOM cards from a rAF loop — client-only too.
-const BoardStage = dynamic(() => import('@/components/BoardStage'), { ssr: false });
 
 export default function Home() {
   const nav = useUIStore((s) => s.nav);
@@ -44,22 +41,23 @@ export default function Home() {
   const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
   const is3D = nav === '3d';
   const isWeb = nav === 'web';
-  const isBoard = nav === 'new';
+  // Projects swaps the left column for the project list; the stage, scene column
+  // and timeline keep showing the open project, so switching is a live preview.
+  const isProjects = nav === 'projects';
   const codeOpen = useWebStore((s) => s.codeOpen);
   const tplCollapsed = useUIStore((s) => s.tplCollapsed);
 
-  // Restore the saved scene on mount (after hydration, so no SSR mismatch), then
-  // start throttled auto-save. Uploaded media urls are rebuilt from IndexedDB.
+  // Open the active project on mount (after hydration, so no SSR mismatch), then
+  // start throttled auto-save into it. bootstrap() also migrates a pre-projects
+  // scene into a project and rebuilds uploaded media urls from IndexedDB.
   useEffect(() => {
     useUIStore.getState().hydratePreferences();
-    const saved = loadScene();
-    if (saved) useSceneStore.getState().hydrate(saved);
-    void useSceneStore.getState().rehydrateUploads();
+    useProjectStore.getState().bootstrap();
     return startSceneAutosave();
   }, []);
 
   return (
-    <div className={`app ${is3D ? 'app-3d' : ''} ${isWeb || isBoard ? 'app-web' : ''} ${tplCollapsed ? 'app-tpl-collapsed' : ''} ${leftCollapsed ? 'left-collapsed' : ''} ${rightCollapsed ? 'right-collapsed' : ''}`}>
+    <div className={`app ${is3D ? 'app-3d' : ''} ${isWeb ? 'app-web' : ''} ${tplCollapsed ? 'app-tpl-collapsed' : ''} ${leftCollapsed ? 'left-collapsed' : ''} ${rightCollapsed ? 'right-collapsed' : ''}`}>
 
       <IconRail />
 
@@ -68,12 +66,12 @@ export default function Home() {
           Web and board reuse the template list wholesale: the templates are
           pure frame→pose functions, so the picker doesn't care what renders
           them. */}
-      {tplCollapsed ? <CollapsedStrip /> : is3D ? <Effects3DPanel /> : <TemplatesCard controlsInline={isBoard} />}
+      {tplCollapsed ? <CollapsedStrip /> : isProjects ? <ProjectsPanel /> : is3D ? <Effects3DPanel /> : <TemplatesCard />}
 
       {/* middle SCENE column — 2D only. 3D, web and board fold everything into
           the single right sidebar rather than run two 280px panels side by
           side. */}
-      {!is3D && !isWeb && !isBoard && (
+      {!is3D && !isWeb && (
         <section className="card controls card-scroll">
           <ScenePanel />
           <div className="hairline" />
@@ -82,9 +80,7 @@ export default function Home() {
       )}
 
       <main className="stage-col">
-        {isBoard ? (
-          <BoardStage />
-        ) : isWeb ? (
+        {isWeb ? (
           <WebStage />
         ) : is3D ? (
           <ThreeStage3D />
@@ -118,9 +114,7 @@ export default function Home() {
 
       {/* right column — canvas/assets (2D) or current 3D effect controls */}
       <section className="card right card-scroll">
-        {isBoard ? (
-          <BoardPanel />
-        ) : isWeb ? (
+        {isWeb ? (
           <>
             {/* what animates, then how it moves */}
             <WebSelectionPanel />
@@ -150,7 +144,7 @@ export default function Home() {
         {/* Video export is a 2D/3D product; web mode's deliverable is a zip
             of the user's component, which doesn't exist yet. Its source
             controls take that slot. */}
-        <Timeline showExport={!isWeb && !isBoard} extra={isWeb ? <WebSourceBar /> : isBoard ? <BoardExportBar /> : undefined} />
+        <Timeline showExport={!isWeb} extra={isWeb ? <WebSourceBar /> : undefined} />
       </footer>
 
       <WelcomeDialog />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,9 +24,11 @@ import WebSourceBar from '@/components/WebSourceBar';
 import { CollapsedStrip } from '@/components/TplCollapse';
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
+import { useHistoryStore } from '@/store/useHistoryStore';
 import { startSceneAutosave } from '@/lib/scenePersist';
 import { useWebStore } from '@/store/useWebStore';
 import ProjectsPanel from '@/components/ProjectsPanel';
+import HistoryControls from '@/components/HistoryControls';
 
 // Pixi must run client-side only.
 const PreviewStage = dynamic(() => import('@/components/PreviewStage'), { ssr: false });
@@ -58,7 +60,30 @@ export default function Home() {
   useEffect(() => {
     useUIStore.getState().hydratePreferences();
     useProjectStore.getState().bootstrap();
-    return startSceneAutosave();
+    // History starts AFTER bootstrap, so the loaded scene is the baseline and
+    // the first undo can't rewind into the pre-load default state.
+    const stopHistory = useHistoryStore.getState().start();
+    const stopAutosave = startSceneAutosave();
+    return () => { stopHistory(); stopAutosave(); };
+  }, []);
+
+  // Undo/redo shortcuts. Skipped while typing so ⌘Z keeps its normal meaning
+  // inside a text field (project names, layer names, exact slider values).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
+      const k = e.key.toLowerCase();
+      if (k !== 'z' && k !== 'y') return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT' || t.isContentEditable)) return;
+      e.preventDefault();
+      const h = useHistoryStore.getState();
+      // ⌘⇧Z and ⌘Y both redo — the Mac and Windows idioms respectively.
+      if (k === 'y' || e.shiftKey) h.redo();
+      else h.undo();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
   }, []);
 
   return (
@@ -99,6 +124,8 @@ export default function Home() {
             </button>
           </>
         )}
+        {/* scene-level undo/redo, floating top-left of the stage */}
+        <HistoryControls />
         <button
           className="panel-toggle panel-toggle-left"
           onClick={toggleLeftPanel}

--- a/components/Effects3DPanel.tsx
+++ b/components/Effects3DPanel.tsx
@@ -2,7 +2,6 @@
 
 import { threeEffects } from '@/three3d';
 import { use3DStore } from '@/store/use3DStore';
-import { CollapseButton } from './TplCollapse';
 
 // Left column in 3D mode — replaces the motion-template list. Picks the active
 // 3D effect (ASCII, …). Its controls render in the right panel.
@@ -22,7 +21,6 @@ export default function Effects3DPanel() {
               <span className="beta-tag">BETA</span>
             </button>
           </div>
-          <CollapseButton />
         </div>
         <p className="beta-note">Work in progress — expect rough edges and bugs.</p>
       </div>

--- a/components/HistoryControls.tsx
+++ b/components/HistoryControls.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useHistoryStore } from '@/store/useHistoryStore';
+
+// Undo / redo, floating over the stage. It sits here rather than in the
+// transport row because it acts on the scene, not on the clock — and the stage
+// already owns the floating-control idiom (fullscreen, panel toggles).
+export default function HistoryControls() {
+  const canUndo = useHistoryStore((s) => s.canUndo);
+  const canRedo = useHistoryStore((s) => s.canRedo);
+  const undo = useHistoryStore((s) => s.undo);
+  const redo = useHistoryStore((s) => s.redo);
+
+  return (
+    <div className="stage-history">
+      <button
+        className="stage-hist-btn"
+        onClick={undo}
+        disabled={!canUndo}
+        title="Undo (Ctrl/⌘Z)"
+        aria-label="Undo"
+      >
+        <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><path d="M3 7h6.5a3.5 3.5 0 010 7H6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/><path d="M5.5 4.5L3 7l2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+      </button>
+      <span className="stage-hist-sep" />
+      <button
+        className="stage-hist-btn"
+        onClick={redo}
+        disabled={!canRedo}
+        title="Redo (Ctrl/⌘⇧Z)"
+        aria-label="Redo"
+      >
+        <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><path d="M13 7H6.5a3.5 3.5 0 000 7H10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/><path d="M10.5 4.5L13 7l-2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+      </button>
+    </div>
+  );
+}

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -1,8 +1,17 @@
 'use client';
 
 import { useUIStore } from '@/store/useUIStore';
+import { useProjectStore } from '@/store/useProjectStore';
 
+// Board mode (nav id 'board') was removed from this list on request. Its code is
+// still on disk — components/Board*.tsx, store/useBoardStore.ts, lib/board*.ts —
+// because lib/exportScene.ts (the drop-in React component zip) is built on
+// boardProject/boardPose/boardCompose. Re-adding an entry here brings the mode
+// back; app/page.tsx still has no branch for it, so that needs restoring too.
 const NAV = [
+  { id: 'projects', label: 'Projects', icon: (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M2.75 6.25A1.5 1.5 0 014.25 4.75h3l1.5 1.75h6a1.5 1.5 0 011.5 1.5v6.25a1.5 1.5 0 01-1.5 1.5h-10.5a1.5 1.5 0 01-1.5-1.5V6.25z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>
+  ) },
   { id: 'library', label: 'Library', icon: (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="3" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="11" y="3" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="3" y="11" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="11" y="11" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/></svg>
   ) },
@@ -12,9 +21,6 @@ const NAV = [
   { id: 'web', label: 'Web', icon: (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M7.5 6.5L4 10l3.5 3.5M12.5 6.5L16 10l-3.5 3.5M11 4.5l-2 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
   ) },
-  { id: 'new', label: 'New', icon: (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M10 4v12M4 10h12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/></svg>
-  ) },
 ];
 
 export default function IconRail() {
@@ -22,6 +28,16 @@ export default function IconRail() {
   const theme = useUIStore((s) => s.theme);
   const setActive = useUIStore((s) => s.setNav);
   const toggleTheme = useUIStore((s) => s.toggleTheme);
+  const createProject = useProjectStore((s) => s.create);
+  const projectCount = useProjectStore((s) => s.projects.length);
+
+  // An ACTION, not a nav section — so it never takes the active state. The +
+  // icon at the top of the rail now creates what it looks like it creates.
+  const newProject = () => {
+    createProject(`Project ${projectCount + 1}`);
+    setActive('projects');
+  };
+
   return (
     <aside className="card rail">
       <div className="rail-top">
@@ -32,6 +48,12 @@ export default function IconRail() {
             <rect x="25" y="6.5" width="6" height="6" rx="1.5" fill="currentColor" opacity="0.3"/>
           </svg>
         </div>
+        <button className="rail-item rail-action" onClick={newProject} title="Create a new project">
+          <span className="rail-ico">
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M10 4v12M4 10h12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/></svg>
+          </span>
+          <span className="rail-label">New</span>
+        </button>
         {NAV.map((n) => (
           <button key={n.id} className={`rail-item ${active === n.id ? 'active' : ''}`} onClick={() => setActive(n.id)}>
             <span className="rail-ico">{n.icon}</span>

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -3,11 +3,6 @@
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
 
-// Board mode (nav id 'board') was removed from this list on request. Its code is
-// still on disk — components/Board*.tsx, store/useBoardStore.ts, lib/board*.ts —
-// because lib/exportScene.ts (the drop-in React component zip) is built on
-// boardProject/boardPose/boardCompose. Re-adding an entry here brings the mode
-// back; app/page.tsx still has no branch for it, so that needs restoring too.
 const NAV = [
   { id: 'projects', label: 'Projects', icon: (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M2.75 6.25A1.5 1.5 0 014.25 4.75h3l1.5 1.75h6a1.5 1.5 0 011.5 1.5v6.25a1.5 1.5 0 01-1.5 1.5h-10.5a1.5 1.5 0 01-1.5-1.5V6.25z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>
@@ -20,6 +15,13 @@ const NAV = [
   ) },
   { id: 'web', label: 'Web', icon: (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M7.5 6.5L4 10l3.5 3.5M12.5 6.5L16 10l-3.5 3.5M11 4.5l-2 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+  ) },
+  // Board mode — a DOM playground of arranged cards with hover interactions,
+  // and the entry point for the drop-in React component export. Its nav id is
+  // 'board' rather than the original 'new': the + button at the top of the rail
+  // now creates a project, so the two ids would collide. Kept last in the list.
+  { id: 'board', label: 'Board', icon: (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="2.5" y="4.5" width="4.5" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5"/><rect x="8" y="4.5" width="4" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5" opacity="0.65"/><rect x="13" y="4.5" width="4.5" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5" opacity="0.4"/></svg>
   ) },
 ];
 

--- a/components/PreviewStage.tsx
+++ b/components/PreviewStage.tsx
@@ -21,7 +21,16 @@ export default function PreviewStage() {
   const height = useSceneStore((s) => s.height);
   // Engine flag drives a full canvas remount — a canvas can never be reused
   // across GL libraries (context attributes and loss behaviour differ).
-  const engine = useSceneStore((s) => getTemplate(s.activeTemplateId).meta.engine ?? 'pixi');
+  //
+  // Layer stacking is a 2D compositing feature: only the Pixi renderer draws a
+  // container per track. So a stack of two or more layers stays on Pixi even if
+  // the selected track's template is webgl — that template falls back to its own
+  // 2D `transform`, which every template provides. Otherwise selecting a webgl
+  // layer would swap in the single-motion 3D renderer and the other layers would
+  // vanish.
+  const engine = useSceneStore((s) =>
+    s.tracks.length > 1 ? 'pixi' : getTemplate(s.activeTemplateId).meta.engine ?? 'pixi',
+  );
 
   useEffect(() => {
     let mounted = true;

--- a/components/ProjectsPanel.tsx
+++ b/components/ProjectsPanel.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState } from 'react';
+import { useProjectStore } from '@/store/useProjectStore';
+import { CollapseButton } from './TplCollapse';
+
+// Relative time, coarse on purpose — an exact timestamp is noise in a list you
+// scan to find "the one I was just working on".
+function ago(ms: number): string {
+  const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
+  if (s < 60) return 'just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} h ago`;
+  const d = Math.floor(h / 24);
+  return d === 1 ? 'yesterday' : `${d} days ago`;
+}
+
+export default function ProjectsPanel() {
+  const projects = useProjectStore((s) => s.projects);
+  const activeId = useProjectStore((s) => s.activeId);
+  const open = useProjectStore((s) => s.open);
+  const create = useProjectStore((s) => s.create);
+  const duplicate = useProjectStore((s) => s.duplicate);
+  const rename = useProjectStore((s) => s.rename);
+  const remove = useProjectStore((s) => s.remove);
+
+  const [naming, setNaming] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  // Deleting a project throws away its scene, so it asks first.
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+
+  const commitNew = () => {
+    create(newName.trim() || `Project ${projects.length + 1}`);
+    setNaming(false);
+    setNewName('');
+  };
+
+  const commitRename = (id: string) => {
+    if (editName.trim()) rename(id, editName.trim());
+    setEditingId(null);
+    setEditName('');
+  };
+
+  return (
+    <section className="card templates">
+      <div className="tpl-head">
+        <div className="tpl-head-row">
+          <span className="eyebrow">Projects</span>
+          <CollapseButton />
+        </div>
+        <div className="prj-sub">
+          {projects.length} {projects.length === 1 ? 'project' : 'projects'} in this browser
+        </div>
+      </div>
+
+      <div className="tpl-list prj-list">
+        {projects.map((p) => {
+          const isActive = p.id === activeId;
+          const isEditing = editingId === p.id;
+          const isConfirming = confirmId === p.id;
+
+          return (
+            <div key={p.id} className={`prj-item ${isActive ? 'active' : ''}`}>
+              {isEditing ? (
+                <input
+                  className="field prj-rename"
+                  autoFocus
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onBlur={() => commitRename(p.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitRename(p.id);
+                    if (e.key === 'Escape') { setEditingId(null); setEditName(''); }
+                  }}
+                />
+              ) : (
+                <button
+                  className="prj-open"
+                  onClick={() => open(p.id)}
+                  title={isActive ? 'Project open' : 'Open project'}
+                >
+                  <span className="prj-name">{p.name}</span>
+                  <span className="prj-meta">
+                    {isActive && <b>open · </b>}
+                    edited {ago(p.updatedAt)}
+                  </span>
+                </button>
+              )}
+
+              {!isEditing && (
+                <div className="prj-actions">
+                  <button
+                    className="icon-btn"
+                    title="Rename"
+                    onClick={() => { setEditingId(p.id); setEditName(p.name); setConfirmId(null); }}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M10.5 2.5l3 3-8 8H2.5v-3l8-8z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/></svg>
+                  </button>
+                  <button className="icon-btn" title="Duplicate" onClick={() => duplicate(p.id)}>
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><rect x="2.5" y="2.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.3"/><path d="M5.5 13.5h6a2 2 0 002-2v-6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
+                  </button>
+                  <button
+                    className={`icon-btn ${isConfirming ? 'danger' : ''}`}
+                    title={isConfirming ? 'Click again to delete' : 'Delete'}
+                    onClick={() => (isConfirming ? (remove(p.id), setConfirmId(null)) : setConfirmId(p.id))}
+                    onBlur={() => setConfirmId((c) => (c === p.id ? null : c))}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M3 5h10M6.5 5V3.5h3V5M5 5l.6 8h4.8L11 5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                  </button>
+                </div>
+              )}
+
+              {isConfirming && (
+                <div className="prj-confirm">Click the bin again to delete — this can&apos;t be undone.</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="tpl-foot">
+        {naming ? (
+          <div className="tpl-save-row">
+            <input
+              className="field"
+              autoFocus
+              placeholder={`Project ${projects.length + 1}`}
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') commitNew();
+                if (e.key === 'Escape') { setNaming(false); setNewName(''); }
+              }}
+            />
+            <button className="btn solid" onClick={commitNew}>Create</button>
+          </div>
+        ) : (
+          <button className="btn full" onClick={() => setNaming(true)}>New project</button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/ProjectsPanel.tsx
+++ b/components/ProjectsPanel.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { useProjectStore } from '@/store/useProjectStore';
-import { CollapseButton } from './TplCollapse';
 
 // Relative time, coarse on purpose — an exact timestamp is noise in a list you
 // scan to find "the one I was just working on".
@@ -50,7 +49,6 @@ export default function ProjectsPanel() {
       <div className="tpl-head">
         <div className="tpl-head-row">
           <span className="eyebrow">Projects</span>
-          <CollapseButton />
         </div>
         <div className="prj-sub">
           {projects.length} {projects.length === 1 ? 'project' : 'projects'} in this browser

--- a/components/ScenePanel.tsx
+++ b/components/ScenePanel.tsx
@@ -4,6 +4,7 @@ import { useSceneStore } from '@/store/useSceneStore';
 import { getTemplate, templateList } from '@/templates';
 import { ControlRow } from './Controls';
 import EasingPanel from './EasingPanel';
+import TrackInspector from './TrackInspector';
 
 // Renders the SCENE + TIMING sections (no card wrapper — the page composes cards).
 export default function ScenePanel() {
@@ -13,6 +14,10 @@ export default function ScenePanel() {
   const setActiveTemplate = useSceneStore((s) => s.setActiveTemplate);
   const duration = useSceneStore((s) => s.duration);
   const setDuration = useSceneStore((s) => s.setDuration);
+  const trackCount = useSceneStore((s) => s.tracks.length);
+  const activeTrackName = useSceneStore(
+    (s) => s.tracks.find((t) => t.id === s.activeTrackId)?.name ?? '',
+  );
 
   const template = getTemplate(activeTemplateId);
 
@@ -30,12 +35,26 @@ export default function ScenePanel() {
         </select>
       </div>
       <div className="section-body">
+        {/* With more than one layer, make it explicit that these controls edit
+            the SELECTED layer's motion, not the whole scene's. */}
+        {trackCount > 1 && (
+          <div className="ctl-hint">Editing the motion of <b>{activeTrackName}</b>.</div>
+        )}
         {template.controls.map((def) => (
           <ControlRow key={def.key} def={def} value={values[def.key]} onChange={(val) => setValue(def.key, val)} />
         ))}
       </div>
 
       <div className="hairline" />
+
+      {/* layer compositing: opacity, blend, retiming, asset split. Only
+          meaningful once a second layer exists. */}
+      {trackCount > 1 && (
+        <>
+          <TrackInspector />
+          <div className="hairline" />
+        </>
+      )}
 
       <div className="section-head"><span className="eyebrow">Timing</span></div>
       <div className="section-body">

--- a/components/TemplatesCard.tsx
+++ b/components/TemplatesCard.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { useSceneStore } from '@/store/useSceneStore';
 import { templateList, templateGroups, getTemplate } from '@/templates';
 import TemplateThumb from './TemplateThumb';
-import { CollapseButton } from './TplCollapse';
 import { ControlRow } from './Controls';
 
 const Chevron = ({ dir = 'right' }: { dir?: 'right' | 'left' }) => (
@@ -68,7 +67,6 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
             <button className={`tab ${tab === 'templates' ? 'active' : ''}`} onClick={() => setTab('templates')}>Templates</button>
             <button className={`tab ${tab === 'custom' ? 'active' : ''}`} onClick={() => setTab('custom')}>Custom</button>
           </div>
-          <CollapseButton />
         </div>
 
         <div className="searchbox">

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSceneStore } from '@/store/useSceneStore';
 import ExportDialog from './ExportDialog';
+import TrackLane from './TrackLane';
 
 function fmt(sec: number) {
   const s = Math.max(0, sec);
@@ -41,7 +42,45 @@ export default function Timeline({
   const setPlaying = useSceneStore((s) => s.setPlaying);
   const setFrame = useSceneStore((s) => s.setFrame);
   const setDuration = useSceneStore((s) => s.setDuration);
+  const tracks = useSceneStore((s) => s.tracks);
+  const addTrack = useSceneStore((s) => s.addTrack);
+  const reorderTracks = useSceneStore((s) => s.reorderTracks);
   const [showExportDialog, setShowExportDialog] = useState(false);
+  const [lanesOpen, setLanesOpen] = useState(false);
+
+  const shellRef = useRef<HTMLDivElement>(null);
+  const scrubberRef = useRef<HTMLDivElement>(null);
+
+  // Publish the scrubber's geometry as CSS vars on the shell, so the lane bars
+  // below sit in the SAME coordinate space as the ruler above. The transport row
+  // is a flex layout whose left offset depends on the time readout and the
+  // buttons in `extra`, so measuring beats hardcoding: the playhead and the bars
+  // stay aligned whatever lands in that row.
+  useEffect(() => {
+    const shell = shellRef.current;
+    const scrubber = scrubberRef.current;
+    if (!shell || !scrubber) return;
+    // Only the SCRUBBER is observed, never the shell: these vars drive the lane
+    // gutter width, so observing the shell we write to would feed its own layout
+    // change back in as a resize — the classic ResizeObserver loop. Writes are
+    // also skipped when the value is unchanged, so a nudge can't oscillate.
+    const sync = () => {
+      const a = shell.getBoundingClientRect();
+      const b = scrubber.getBoundingClientRect();
+      const left = `${Math.round(b.left - a.left)}px`;
+      const width = `${Math.round(b.width)}px`;
+      if (shell.style.getPropertyValue('--tl-axis-left') !== left) {
+        shell.style.setProperty('--tl-axis-left', left);
+      }
+      if (shell.style.getPropertyValue('--tl-axis-w') !== width) {
+        shell.style.setProperty('--tl-axis-w', width);
+      }
+    };
+    sync();
+    const ro = new ResizeObserver(sync);
+    ro.observe(scrubber);
+    return () => ro.disconnect();
+  }, [lanesOpen]);
 
   // Spacebar toggles play/pause anywhere except while typing in a field.
   useEffect(() => {
@@ -63,6 +102,7 @@ export default function Timeline({
   const { labels, dashes } = buildRuler(duration);
 
   return (
+    <div className={`timeline-shell ${lanesOpen ? 'lanes-open' : ''}`} ref={shellRef}>
     <div className="timeline">
       <button className="play-btn" onClick={() => setPlaying(!playing)} title={playing ? 'Pause' : 'Play'}>
         {playing ? (
@@ -74,7 +114,7 @@ export default function Timeline({
 
       <span className="time-readout"><b>{fmt(curTime)}</b> / {fmt(duration)}s</span>
 
-      <div className="scrubber">
+      <div className="scrubber" ref={scrubberRef}>
         <div className="tl-trackbar" />
         <div className="ruler">
           {dashes.map((pct, i) => (
@@ -100,6 +140,18 @@ export default function Timeline({
         <span>s</span>
       </label>
 
+      {/* Motion layers: the stack of tracks sharing this one timeline. */}
+      <button
+        className={`tl-lanes-btn ${lanesOpen ? 'active' : ''}`}
+        onClick={() => setLanesOpen((v) => !v)}
+        aria-expanded={lanesOpen}
+        title="Motion layers"
+      >
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M8 1.8l6 3-6 3-6-3 6-3z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/><path d="M2 8.2l6 3 6-3" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/></svg>
+        Layers
+        <span className="tl-lanes-count">{tracks.length}</span>
+      </button>
+
       {extra}
 
       {showExport && (
@@ -110,6 +162,36 @@ export default function Timeline({
       )}
 
       {showExport && showExportDialog && <ExportDialog onClose={() => setShowExportDialog(false)} />}
+    </div>
+
+    {lanesOpen && (
+      <div className="tl-lanes">
+        {/* Topmost lane = topmost layer, so the list reads like the stack looks:
+            the store's array is bottom-to-top, the UI shows it reversed. */}
+        {tracks.slice().reverse().map((track) => (
+          <TrackLane
+            key={track.id}
+            track={track}
+            index={tracks.findIndex((t) => t.id === track.id)}
+            totalFrames={totalFrames}
+            onReorder={reorderTracks}
+          />
+        ))}
+
+        {/* one playhead across every lane, in the shared axis space */}
+        <div className="tl-lanes-playhead" style={{ left: `calc(var(--tl-axis-left) + var(--tl-axis-w) * ${progress / 100})` }} />
+
+        <div className="tl-lanes-foot">
+          <button className="tl-add-track" onClick={() => addTrack()}>
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M8 3.5v9M3.5 8h9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+            Add layer
+          </button>
+          <span className="tl-lanes-hint">
+            Drag a bar to retime · drag its edges to trim · the arrows change stacking order
+          </span>
+        </div>
+      </div>
+    )}
     </div>
   );
 }

--- a/components/TrackInspector.tsx
+++ b/components/TrackInspector.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useSceneStore } from '@/store/useSceneStore';
+import { BLEND_MODES, trackWindow, type BlendMode } from '@/lib/tracks';
+import { ControlRow } from './Controls';
+
+// The active track's own properties — everything that is about the LAYER rather
+// than about the motion template inside it. The template's own controls stay in
+// the Scene block above; this block is what makes two layers read as a
+// composition instead of two things drawn on top of each other.
+export default function TrackInspector() {
+  const tracks = useSceneStore((s) => s.tracks);
+  const activeTrackId = useSceneStore((s) => s.activeTrackId);
+  const patchTrack = useSceneStore((s) => s.patchTrack);
+  const renameTrack = useSceneStore((s) => s.renameTrack);
+  const toggleTrackAsset = useSceneStore((s) => s.toggleTrackAsset);
+  const assets = useSceneStore((s) => s.assets);
+  const duration = useSceneStore((s) => s.duration);
+  const fps = useSceneStore((s) => s.fps);
+
+  const track = tracks.find((t) => t.id === activeTrackId);
+  // A single layer needs no compositing controls — the block would be noise.
+  if (!track || tracks.length < 2) return null;
+
+  const totalFrames = Math.max(1, Math.round(duration * fps));
+  const { inFrame, outFrame, length } = trackWindow(track, totalFrames);
+  const patch = (p: Parameters<typeof patchTrack>[1]) => patchTrack(track.id, p);
+  // Which assets this layer draws. An empty list means "all of them".
+  const usesAll = track.assetIds.length === 0;
+
+  return (
+    <>
+      <div className="section-head">
+        <span className="eyebrow">Layer</span>
+        <input
+          className="badge trk-name"
+          value={track.name}
+          onChange={(e) => renameTrack(track.id, e.target.value)}
+          aria-label="Layer name"
+        />
+      </div>
+
+      <div className="section-body">
+        <ControlRow
+          def={{ key: '_op', label: 'Opacity', type: 'slider', min: 0, max: 100, step: 1, default: 100 }}
+          value={Math.round(track.opacity * 100)}
+          onChange={(v) => patch({ opacity: Math.max(0, Math.min(100, Number(v))) / 100 })}
+        />
+        <ControlRow
+          def={{ key: '_blend', label: 'Blend', type: 'select', options: [...BLEND_MODES], default: 'normal' }}
+          value={track.blend}
+          onChange={(v) => patch({ blend: v as BlendMode })}
+        />
+        <ControlRow
+          def={{ key: '_ts', label: 'Speed', type: 'slider', min: 0.25, max: 4, step: 0.05, default: 1 }}
+          value={track.timeScale}
+          onChange={(v) => patch({ timeScale: Number(v) })}
+        />
+        {/* Phase slip: the same template twice at different offsets reads as an
+            echo instead of a duplicate. */}
+        <ControlRow
+          def={{ key: '_off', label: 'Offset %', type: 'slider', min: 0, max: 100, step: 1, default: 0 }}
+          value={track.offset}
+          onChange={(v) => patch({ offset: Number(v) })}
+        />
+        {/* Fade in frames, capped at half the window by resolveTrackTime. */}
+        <ControlRow
+          def={{ key: '_fade', label: 'Fade (frames)', type: 'slider', min: 0, max: Math.max(1, Math.floor(length / 2)), step: 1, default: 0 }}
+          value={Math.min(track.fade, Math.floor(length / 2))}
+          onChange={(v) => patch({ fade: Number(v) })}
+        />
+        <div className="ctl-hint">
+          Window {(inFrame / fps).toFixed(1)}s → {(outFrame / fps).toFixed(1)}s ({length} frames)
+        </div>
+      </div>
+
+      <div className="hairline" />
+
+      <div className="section-head"><span className="eyebrow">Layer transform</span></div>
+      <div className="section-body">
+        <ControlRow
+          def={{ key: '_xy', label: 'Position', type: 'xypad', max: 400, default: { x: 0, y: 0 } }}
+          value={{ x: track.transform.x, y: track.transform.y }}
+          onChange={(v) => patch({ transform: { ...track.transform, x: v.x, y: v.y } })}
+        />
+        <ControlRow
+          def={{ key: '_sc', label: 'Scale', type: 'slider', min: 0.1, max: 3, step: 0.05, default: 1 }}
+          value={track.transform.scale}
+          onChange={(v) => patch({ transform: { ...track.transform, scale: Number(v) } })}
+        />
+        <ControlRow
+          def={{ key: '_rot', label: 'Rotation', type: 'slider', min: -180, max: 180, step: 1, default: 0 }}
+          value={track.transform.rotation}
+          onChange={(v) => patch({ transform: { ...track.transform, rotation: Number(v) } })}
+        />
+      </div>
+
+      <div className="hairline" />
+
+      {/* Splitting the asset list across layers is what turns two animations
+          into one scene: layer A drifts the backdrop images, layer B runs the
+          foreground carousel. */}
+      <div className="section-head">
+        <span className="eyebrow">Layer images</span>
+        {!usesAll && (
+          <button className="badge" onClick={() => patch({ assetIds: [] })}>All</button>
+        )}
+      </div>
+      <div className="section-body">
+        {assets.length === 0 ? (
+          <div className="ctl-hint">No images in the scene.</div>
+        ) : (
+          <>
+            <div className="trk-assets">
+              {assets.map((a, i) => {
+                const on = usesAll || track.assetIds.includes(a.id);
+                return (
+                  <button
+                    key={a.id}
+                    className={`trk-asset ${on ? 'on' : ''}`}
+                    onClick={() => toggleTrackAsset(track.id, a.id)}
+                    title={a.name}
+                  >
+                    {i + 1}
+                  </button>
+                );
+              })}
+            </div>
+            <div className="ctl-hint">
+              {usesAll ? 'Using every image in the scene.' : `${track.assetIds.length} of ${assets.length} selected.`}
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/TrackLane.tsx
+++ b/components/TrackLane.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useMemo, useRef } from 'react';
+import { useSceneStore } from '@/store/useSceneStore';
+import { getTemplate, templateList } from '@/templates';
+import { resolveEasing } from '@/lib/easing';
+import { trackWindow, type MotionTrack } from '@/lib/tracks';
+
+// How many poses to sample for a bar's motion sparkline. 48 is enough to read
+// the shape of a curve at bar width without making a drag feel heavy — the
+// sample is memoized on the values that actually change it.
+const SPARK_SAMPLES = 48;
+
+type DragMode = 'move' | 'in' | 'out';
+
+/**
+ * The motion signature drawn inside a track bar: the template's own x and y for
+ * slot 0, sampled across the track's window and normalized to the bar. Templates
+ * are pure functions of (frame, index, count, values, ctx), so this is just a
+ * cheap read of the same code the renderer runs — the bar shows the real motion,
+ * not a generic waveform.
+ */
+function useSparkline(track: MotionTrack, length: number, width: number, height: number) {
+  return useMemo(() => {
+    let template;
+    try { template = getTemplate(track.templateId); } catch { return null; }
+    const count = Math.max(1, Math.round(track.values.count ?? 6));
+    const ease = resolveEasing(track.easing);
+    const ctx = {
+      fps: 30,
+      width: 1080,
+      height: 1350,
+      duration: Math.max(1, length / 30),
+      totalFrames: Math.max(1, length),
+      ease,
+      easedPhase: (p: number) => { const b = Math.floor(p); return b + ease(p - b); },
+    };
+
+    const xs: number[] = [];
+    const ys: number[] = [];
+    try {
+      for (let i = 0; i < SPARK_SAMPLES; i++) {
+        const f = (i / (SPARK_SAMPLES - 1)) * Math.max(1, length);
+        const t = template.transform(f, 0, count, track.values, ctx);
+        xs.push(Number.isFinite(t.x) ? t.x : 0);
+        ys.push(Number.isFinite(t.y) ? t.y : 0);
+      }
+    } catch {
+      return null; // a template that dislikes being sampled just gets no spark
+    }
+
+    // Normalize each axis independently into the bar; a flat signal sits on the
+    // centre line instead of collapsing to an edge.
+    const toPath = (vals: number[]) => {
+      const min = Math.min(...vals);
+      const max = Math.max(...vals);
+      const span = max - min;
+      return vals
+        .map((v, i) => {
+          const px = (i / (SPARK_SAMPLES - 1)) * width;
+          const norm = span < 1e-6 ? 0.5 : (v - min) / span;
+          const py = height - norm * height;
+          return `${i === 0 ? 'M' : 'L'}${px.toFixed(1)} ${py.toFixed(1)}`;
+        })
+        .join(' ');
+    };
+
+    return { x: toPath(xs), y: toPath(ys) };
+  }, [track.templateId, track.values, track.easing, length, width, height]);
+}
+
+export default function TrackLane({
+  track,
+  index,
+  totalFrames,
+  onReorder,
+}: {
+  track: MotionTrack;
+  index: number;             // index in the store's tracks array
+  totalFrames: number;
+  onReorder: (from: number, to: number) => void;
+}) {
+  const activeTrackId = useSceneStore((s) => s.activeTrackId);
+  const setActiveTrack = useSceneStore((s) => s.setActiveTrack);
+  const toggleTrackVisible = useSceneStore((s) => s.toggleTrackVisible);
+  const patchTrack = useSceneStore((s) => s.patchTrack);
+  const duplicateTrack = useSceneStore((s) => s.duplicateTrack);
+  const removeTrack = useSceneStore((s) => s.removeTrack);
+  const trackCount = useSceneStore((s) => s.tracks.length);
+
+  const barsRef = useRef<HTMLDivElement>(null);
+  // Drag state lives in a ref: a pointer drag must not re-render per move, and
+  // the store already re-renders us when the window actually changes.
+  const dragRef = useRef<{ mode: DragMode; startX: number; inF: number; outF: number; moved: boolean } | null>(null);
+
+  const active = track.id === activeTrackId;
+  const { inFrame, outFrame, length } = trackWindow(track, totalFrames);
+  const leftPct = (inFrame / totalFrames) * 100;
+  const widthPct = (length / totalFrames) * 100;
+
+  const templateName = useMemo(
+    () => templateList.find((t) => t.meta.id === track.templateId)?.meta.name ?? track.templateId,
+    [track.templateId],
+  );
+
+  const spark = useSparkline(track, length, 200, 20);
+  const fadePct = length > 0 ? Math.min(45, (Math.min(track.fade, length / 2) / length) * 100) : 0;
+
+  // ---- window drag / trim ----
+  const framesPerPx = () => {
+    const el = barsRef.current;
+    if (!el) return 0;
+    const w = el.getBoundingClientRect().width;
+    return w > 0 ? totalFrames / w : 0;
+  };
+
+  const onPointerDown = (mode: DragMode) => (e: React.PointerEvent) => {
+    e.stopPropagation();
+    setActiveTrack(track.id);
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    dragRef.current = { mode, startX: e.clientX, inF: inFrame, outF: outFrame, moved: false };
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    const d = dragRef.current;
+    if (!d) return;
+    const dFrames = Math.round((e.clientX - d.startX) * framesPerPx());
+    if (dFrames === 0 && !d.moved) return;
+    d.moved = true;
+
+    if (d.mode === 'move') {
+      const span = d.outF - d.inF;
+      // Slide the whole window, stopping at both ends of the clip rather than
+      // squashing it.
+      const nextIn = Math.max(0, Math.min(totalFrames - span, d.inF + dFrames));
+      patchTrack(track.id, { inFrame: nextIn, outFrame: nextIn + span });
+    } else if (d.mode === 'in') {
+      const nextIn = Math.max(0, Math.min(d.outF - 2, d.inF + dFrames));
+      patchTrack(track.id, { inFrame: nextIn, outFrame: d.outF });
+    } else {
+      const nextOut = Math.min(totalFrames, Math.max(d.inF + 2, d.outF + dFrames));
+      patchTrack(track.id, { inFrame: d.inF, outFrame: nextOut });
+    }
+  };
+
+  const onPointerUp = () => { dragRef.current = null; };
+
+  return (
+    <div
+      className={`tl-lane ${active ? 'active' : ''} ${track.visible ? '' : 'hidden'}`}
+      onPointerDown={() => setActiveTrack(track.id)}
+    >
+      <div className="tl-lane-gutter">
+        <button
+          className="tl-lane-eye"
+          title={track.visible ? 'Hide layer' : 'Show layer'}
+          onClick={(e) => { e.stopPropagation(); toggleTrackVisible(track.id); }}
+        >
+          {track.visible ? (
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M1.5 8S4 3.5 8 3.5 14.5 8 14.5 8S12 12.5 8 12.5 1.5 8 1.5 8z" stroke="currentColor" strokeWidth="1.3"/><circle cx="8" cy="8" r="1.8" fill="currentColor"/></svg>
+          ) : (
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M1.5 8S4 3.5 8 3.5 14.5 8 14.5 8S12 12.5 8 12.5 1.5 8 1.5 8z" stroke="currentColor" strokeWidth="1.3"/><path d="M3 13L13 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
+          )}
+        </button>
+
+        {/* stacking order: up = drawn nearer the viewer (later in the array) */}
+        <div className="tl-lane-order">
+          <button
+            className="tl-lane-arrow"
+            title="Bring forward"
+            disabled={index === trackCount - 1}
+            onClick={(e) => { e.stopPropagation(); onReorder(index, index + 1); }}
+          >
+            <svg width="9" height="9" viewBox="0 0 12 12" fill="none"><path d="M2.5 7.5L6 4l3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+          </button>
+          <button
+            className="tl-lane-arrow"
+            title="Send backward"
+            disabled={index === 0}
+            onClick={(e) => { e.stopPropagation(); onReorder(index, index - 1); }}
+          >
+            <svg width="9" height="9" viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+          </button>
+        </div>
+      </div>
+
+      <div className="tl-lane-bars" ref={barsRef}>
+        <div
+          className="tl-bar"
+          style={{ left: `${leftPct}%`, width: `${widthPct}%` }}
+          onPointerDown={onPointerDown('move')}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          title={`${track.name} · ${templateName}`}
+        >
+          {/* the fade ramps, drawn as the alpha envelope the renderer applies */}
+          {fadePct > 0 && (
+            <div
+              className="tl-bar-fade"
+              style={{
+                background: `linear-gradient(90deg, transparent 0%, var(--tl-bar-fill) ${fadePct}%, var(--tl-bar-fill) ${100 - fadePct}%, transparent 100%)`,
+              }}
+            />
+          )}
+
+          {spark && (
+            <svg className="tl-bar-spark" viewBox="0 0 200 20" preserveAspectRatio="none" aria-hidden="true">
+              <path d={spark.x} />
+              <path d={spark.y} className="tl-bar-spark-y" />
+            </svg>
+          )}
+
+          <span className="tl-bar-label">
+            <b>{track.name}</b>
+            <em>{templateName}</em>
+          </span>
+
+          <span className="tl-bar-edge in" onPointerDown={onPointerDown('in')} onPointerMove={onPointerMove} onPointerUp={onPointerUp} onPointerCancel={onPointerUp} title="Trim in" />
+          <span className="tl-bar-edge out" onPointerDown={onPointerDown('out')} onPointerMove={onPointerMove} onPointerUp={onPointerUp} onPointerCancel={onPointerUp} title="Trim out" />
+
+          <span className="tl-bar-actions">
+            <button
+              title="Duplicate layer (offset)"
+              onClick={(e) => { e.stopPropagation(); duplicateTrack(track.id); }}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="none"><rect x="2.5" y="2.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.3"/><path d="M5.5 13.5h6a2 2 0 002-2v-6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
+            </button>
+            {trackCount > 1 && (
+              <button
+                title="Remove layer"
+                onClick={(e) => { e.stopPropagation(); removeTrack(track.id); }}
+                onPointerDown={(e) => e.stopPropagation()}
+              >
+                <svg width="10" height="10" viewBox="0 0 16 16" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+              </button>
+            )}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/TrackLane.tsx
+++ b/components/TrackLane.tsx
@@ -2,72 +2,10 @@
 
 import { useMemo, useRef } from 'react';
 import { useSceneStore } from '@/store/useSceneStore';
-import { getTemplate, templateList } from '@/templates';
-import { resolveEasing } from '@/lib/easing';
+import { templateList } from '@/templates';
 import { trackWindow, type MotionTrack } from '@/lib/tracks';
 
-// How many poses to sample for a bar's motion sparkline. 48 is enough to read
-// the shape of a curve at bar width without making a drag feel heavy — the
-// sample is memoized on the values that actually change it.
-const SPARK_SAMPLES = 48;
-
 type DragMode = 'move' | 'in' | 'out';
-
-/**
- * The motion signature drawn inside a track bar: the template's own x and y for
- * slot 0, sampled across the track's window and normalized to the bar. Templates
- * are pure functions of (frame, index, count, values, ctx), so this is just a
- * cheap read of the same code the renderer runs — the bar shows the real motion,
- * not a generic waveform.
- */
-function useSparkline(track: MotionTrack, length: number, width: number, height: number) {
-  return useMemo(() => {
-    let template;
-    try { template = getTemplate(track.templateId); } catch { return null; }
-    const count = Math.max(1, Math.round(track.values.count ?? 6));
-    const ease = resolveEasing(track.easing);
-    const ctx = {
-      fps: 30,
-      width: 1080,
-      height: 1350,
-      duration: Math.max(1, length / 30),
-      totalFrames: Math.max(1, length),
-      ease,
-      easedPhase: (p: number) => { const b = Math.floor(p); return b + ease(p - b); },
-    };
-
-    const xs: number[] = [];
-    const ys: number[] = [];
-    try {
-      for (let i = 0; i < SPARK_SAMPLES; i++) {
-        const f = (i / (SPARK_SAMPLES - 1)) * Math.max(1, length);
-        const t = template.transform(f, 0, count, track.values, ctx);
-        xs.push(Number.isFinite(t.x) ? t.x : 0);
-        ys.push(Number.isFinite(t.y) ? t.y : 0);
-      }
-    } catch {
-      return null; // a template that dislikes being sampled just gets no spark
-    }
-
-    // Normalize each axis independently into the bar; a flat signal sits on the
-    // centre line instead of collapsing to an edge.
-    const toPath = (vals: number[]) => {
-      const min = Math.min(...vals);
-      const max = Math.max(...vals);
-      const span = max - min;
-      return vals
-        .map((v, i) => {
-          const px = (i / (SPARK_SAMPLES - 1)) * width;
-          const norm = span < 1e-6 ? 0.5 : (v - min) / span;
-          const py = height - norm * height;
-          return `${i === 0 ? 'M' : 'L'}${px.toFixed(1)} ${py.toFixed(1)}`;
-        })
-        .join(' ');
-    };
-
-    return { x: toPath(xs), y: toPath(ys) };
-  }, [track.templateId, track.values, track.easing, length, width, height]);
-}
 
 export default function TrackLane({
   track,
@@ -103,7 +41,6 @@ export default function TrackLane({
     [track.templateId],
   );
 
-  const spark = useSparkline(track, length, 200, 20);
   const fadePct = length > 0 ? Math.min(45, (Math.min(track.fade, length / 2) / length) * 100) : 0;
 
   // ---- window drag / trim ----
@@ -150,9 +87,12 @@ export default function TrackLane({
       className={`tl-lane ${active ? 'active' : ''} ${track.visible ? '' : 'hidden'}`}
       onPointerDown={() => setActiveTrack(track.id)}
     >
+      {/* Every per-layer control lives here, always visible — they used to hide
+          inside the bar on hover, which made them hard to find and put click
+          targets on top of the drag surface. */}
       <div className="tl-lane-gutter">
         <button
-          className="tl-lane-eye"
+          className="tl-lane-btn"
           title={track.visible ? 'Hide layer' : 'Show layer'}
           onClick={(e) => { e.stopPropagation(); toggleTrackVisible(track.id); }}
         >
@@ -182,6 +122,23 @@ export default function TrackLane({
             <svg width="9" height="9" viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
           </button>
         </div>
+
+        <button
+          className="tl-lane-btn"
+          title="Duplicate layer (offset)"
+          onClick={(e) => { e.stopPropagation(); duplicateTrack(track.id); }}
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><rect x="2.5" y="2.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.3"/><path d="M5.5 13.5h6a2 2 0 002-2v-6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
+        </button>
+
+        <button
+          className="tl-lane-btn danger"
+          title={trackCount > 1 ? 'Remove layer' : 'The last layer can’t be removed'}
+          disabled={trackCount <= 1}
+          onClick={(e) => { e.stopPropagation(); removeTrack(track.id); }}
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M3 5h10M6.5 5V3.5h3V5M5 5l.6 8h4.8L11 5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/></svg>
+        </button>
       </div>
 
       <div className="tl-lane-bars" ref={barsRef}>
@@ -194,7 +151,8 @@ export default function TrackLane({
           onPointerCancel={onPointerUp}
           title={`${track.name} · ${templateName}`}
         >
-          {/* the fade ramps, drawn as the alpha envelope the renderer applies */}
+          {/* The alpha envelope the renderer applies at the window edges. Only
+              drawn when a fade is set (default 0), so a plain bar stays plain. */}
           {fadePct > 0 && (
             <div
               className="tl-bar-fade"
@@ -204,13 +162,6 @@ export default function TrackLane({
             />
           )}
 
-          {spark && (
-            <svg className="tl-bar-spark" viewBox="0 0 200 20" preserveAspectRatio="none" aria-hidden="true">
-              <path d={spark.x} />
-              <path d={spark.y} className="tl-bar-spark-y" />
-            </svg>
-          )}
-
           <span className="tl-bar-label">
             <b>{track.name}</b>
             <em>{templateName}</em>
@@ -218,25 +169,6 @@ export default function TrackLane({
 
           <span className="tl-bar-edge in" onPointerDown={onPointerDown('in')} onPointerMove={onPointerMove} onPointerUp={onPointerUp} onPointerCancel={onPointerUp} title="Trim in" />
           <span className="tl-bar-edge out" onPointerDown={onPointerDown('out')} onPointerMove={onPointerMove} onPointerUp={onPointerUp} onPointerCancel={onPointerUp} title="Trim out" />
-
-          <span className="tl-bar-actions">
-            <button
-              title="Duplicate layer (offset)"
-              onClick={(e) => { e.stopPropagation(); duplicateTrack(track.id); }}
-              onPointerDown={(e) => e.stopPropagation()}
-            >
-              <svg width="10" height="10" viewBox="0 0 16 16" fill="none"><rect x="2.5" y="2.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.3"/><path d="M5.5 13.5h6a2 2 0 002-2v-6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
-            </button>
-            {trackCount > 1 && (
-              <button
-                title="Remove layer"
-                onClick={(e) => { e.stopPropagation(); removeTrack(track.id); }}
-                onPointerDown={(e) => e.stopPropagation()}
-              >
-                <svg width="10" height="10" viewBox="0 0 16 16" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
-              </button>
-            )}
-          </span>
         </div>
       </div>
     </div>

--- a/components/WelcomeDialog.tsx
+++ b/components/WelcomeDialog.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useProjectStore } from '@/store/useProjectStore';
+import { useUIStore } from '@/store/useUIStore';
 
 const SEEN_KEY = 'motion-welcome-seen';
 
@@ -13,8 +15,16 @@ export default function WelcomeDialog() {
     try { if (!localStorage.getItem(SEEN_KEY)) setOpen(true); } catch { /* storage blocked */ }
   }, []);
 
+  // Accepting hands the user a real, named project to work in rather than an
+  // unsaved scratch scene. bootstrap() (page mount) has already created the
+  // default project, so this only has to make sure one is open — it never
+  // overwrites an existing project.
   const enter = () => {
     try { localStorage.setItem(SEEN_KEY, '1'); } catch { /* storage blocked */ }
+    const projects = useProjectStore.getState();
+    projects.bootstrap();               // no-op when already booted
+    if (!projects.activeId) projects.create('Default project');
+    useUIStore.getState().setNav('library');
     setOpen(false);
   };
 

--- a/lib/boardProject.ts
+++ b/lib/boardProject.ts
@@ -127,11 +127,15 @@ export function applyBoardProject(p: BoardProject) {
   // exists falls back to whatever getTemplate resolves, and we store that id so
   // the panels don't point at a phantom.
   const tpl = getTemplate(s.activeTemplateId);
-  useSceneStore.setState({
-    activeTemplateId: tpl.meta.id,
+  // Route the motion through patchTrack rather than setState: the top-level
+  // activeTemplateId/values/easing are a projection of the ACTIVE TRACK, so
+  // writing them directly would leave the track (what the renderer reads) stale.
+  // A board project carries one motion, so it lands on the active track.
+  const st = useSceneStore.getState();
+  st.patchTrack(st.activeTrackId, {
+    templateId: tpl.meta.id,
     values: s.values ?? {},
     easing: s.easing,
-    duration: s.duration ?? 8,
-    frame: 0,
   });
+  useSceneStore.setState({ duration: s.duration ?? 8, frame: 0 });
 }

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,0 +1,175 @@
+// ============================================================
+//  PROJECTS — many named scenes instead of one autosaved blob
+//
+//  Storage layout (localStorage):
+//    motion-projects-v1     → { activeId, projects: ProjectMeta[] }   the index
+//    motion-project-<id>    → ScenePartial                            one per project
+//    motion-scene-v1        → ScenePartial   LEGACY, kept as a backup
+//
+//  The scene lives in its OWN key per project rather than inside the index, so
+//  the 500ms autosave rewrites one project's blob instead of serializing every
+//  project on every write (a scene carries the whole asset list).
+//
+//  Migration is non-destructive: the pre-projects scene is COPIED into a project
+//  and `motion-scene-v1` is left untouched, so a user who downgrades (or a bug
+//  here) can't lose their work.
+// ============================================================
+
+import type { ScenePartial } from './scenePersist';
+
+const INDEX_KEY = 'motion-projects-v1';
+export const LEGACY_SCENE_KEY = 'motion-scene-v1';
+
+const sceneKeyFor = (id: string) => `motion-project-${id}`;
+
+export interface ProjectMeta {
+  id: string;
+  name: string;
+  createdAt: number;  // epoch ms
+  updatedAt: number;
+}
+
+interface ProjectsIndex {
+  activeId: string | null;
+  projects: ProjectMeta[];
+}
+
+// A FUNCTION, not a shared constant: callers mutate the index they get back
+// (createProject pushes into `.projects`), so handing out one frozen-in-place
+// object would let an empty read accumulate state and resurrect phantom
+// projects after the index is cleared or corrupted.
+const emptyIndex = (): ProjectsIndex => ({ activeId: null, projects: [] });
+
+// Ids only need to be unique within one browser. A counter alongside the clock
+// keeps two projects created in the same millisecond apart.
+let seq = 0;
+const newId = () => `p${Date.now().toString(36)}${(seq++).toString(36)}`;
+
+function readIndex(): ProjectsIndex {
+  if (typeof window === 'undefined') return emptyIndex();
+  try {
+    const raw = localStorage.getItem(INDEX_KEY);
+    if (!raw) return emptyIndex();
+    const parsed = JSON.parse(raw) as ProjectsIndex;
+    if (!Array.isArray(parsed.projects)) return emptyIndex();
+    // Drop malformed entries rather than letting them crash the panel later.
+    const projects = parsed.projects.filter(
+      (p): p is ProjectMeta => !!p && typeof p.id === 'string' && typeof p.name === 'string',
+    );
+    return { activeId: typeof parsed.activeId === 'string' ? parsed.activeId : null, projects };
+  } catch {
+    return emptyIndex();
+  }
+}
+
+function writeIndex(ix: ProjectsIndex): void {
+  try { localStorage.setItem(INDEX_KEY, JSON.stringify(ix)); } catch { /* quota — non-fatal */ }
+}
+
+export function listProjects(): ProjectMeta[] {
+  // Most recently touched first: the list reads as a "recent projects" list.
+  return readIndex().projects.slice().sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export function activeProjectId(): string | null {
+  const ix = readIndex();
+  // Guard against an activeId whose project was removed out from under it.
+  return ix.projects.some((p) => p.id === ix.activeId) ? ix.activeId : null;
+}
+
+export function readProjectScene(id: string): ScenePartial | null {
+  try {
+    const raw = localStorage.getItem(sceneKeyFor(id));
+    return raw ? (JSON.parse(raw) as ScenePartial) : null;
+  } catch {
+    return null;
+  }
+}
+
+// Persist a project's scene and stamp it as the most recently touched.
+export function writeProjectScene(id: string, partial: ScenePartial): void {
+  try { localStorage.setItem(sceneKeyFor(id), JSON.stringify(partial)); } catch { return; }
+  const ix = readIndex();
+  const i = ix.projects.findIndex((p) => p.id === id);
+  if (i < 0) return;
+  ix.projects[i] = { ...ix.projects[i], updatedAt: Date.now() };
+  writeIndex(ix);
+}
+
+export function createProject(name: string, scene?: ScenePartial | null): ProjectMeta {
+  const now = Date.now();
+  const meta: ProjectMeta = { id: newId(), name: name.trim() || 'Untitled', createdAt: now, updatedAt: now };
+  const ix = readIndex();
+  ix.projects.push(meta);
+  ix.activeId = meta.id;
+  writeIndex(ix);
+  // No scene → the app keeps its current state / built-in defaults. Writing an
+  // empty object here would hydrate a blank scene over the defaults.
+  if (scene) {
+    try { localStorage.setItem(sceneKeyFor(meta.id), JSON.stringify(scene)); } catch { /* quota */ }
+  }
+  return meta;
+}
+
+export function renameProject(id: string, name: string): void {
+  const ix = readIndex();
+  const i = ix.projects.findIndex((p) => p.id === id);
+  if (i < 0) return;
+  ix.projects[i] = { ...ix.projects[i], name: name.trim() || ix.projects[i].name };
+  writeIndex(ix);
+}
+
+export function duplicateProject(id: string): ProjectMeta | null {
+  const ix = readIndex();
+  const src = ix.projects.find((p) => p.id === id);
+  if (!src) return null;
+  return createProject(`${src.name} copy`, readProjectScene(id));
+}
+
+// Removing the active project hands the active slot to the next most recent one,
+// so the app is never left pointing at nothing.
+export function deleteProject(id: string): void {
+  const ix = readIndex();
+  const projects = ix.projects.filter((p) => p.id !== id);
+  let activeId = ix.activeId;
+  if (activeId === id) {
+    const next = projects.slice().sort((a, b) => b.updatedAt - a.updatedAt)[0];
+    activeId = next ? next.id : null;
+  }
+  writeIndex({ activeId, projects });
+  try { localStorage.removeItem(sceneKeyFor(id)); } catch { /* noop */ }
+}
+
+export function setActiveProject(id: string): void {
+  const ix = readIndex();
+  if (!ix.projects.some((p) => p.id === id)) return;
+  writeIndex({ ...ix, activeId: id });
+}
+
+/**
+ * Resolve which project the app should open, creating one if needed. Returns the
+ * active project and the scene to hydrate (null = use the app's own defaults).
+ *
+ * Runs once on mount. Non-destructive by design: a pre-projects scene is COPIED
+ * into a project and the legacy key is left in place as a backup.
+ */
+export function openInitialProject(defaultName: string): { meta: ProjectMeta; scene: ScenePartial | null } {
+  const ix = readIndex();
+
+  if (ix.projects.length === 0) {
+    let legacy: ScenePartial | null = null;
+    try {
+      const raw = localStorage.getItem(LEGACY_SCENE_KEY);
+      if (raw) legacy = JSON.parse(raw) as ScenePartial;
+    } catch { /* corrupt legacy blob — start fresh instead of failing to boot */ }
+    // A migrated scene keeps its own name so the user recognizes their work.
+    const meta = createProject(legacy ? 'My project' : defaultName, legacy);
+    return { meta, scene: legacy };
+  }
+
+  const wanted = activeProjectId();
+  const sorted = ix.projects.slice().sort((a, b) => b.updatedAt - a.updatedAt);
+  const meta = ix.projects.find((p) => p.id === wanted) ?? sorted[0];
+  if (meta.id !== ix.activeId) setActiveProject(meta.id);
+  return { meta, scene: readProjectScene(meta.id) };
+}

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -4,7 +4,8 @@ import { getTemplate } from '@/templates';
 import { getEffect } from '@/effects';
 import { useSceneStore, type SceneState } from '@/store/useSceneStore';
 import { resolveEasing } from '@/lib/easing';
-import { assetIndexForSlot } from '@/lib/motion';
+import { assetIndexForSlot, clamp } from '@/lib/motion';
+import { resolveTrackTime, trackAssetIndices, type MotionTrack } from '@/lib/tracks';
 import { cardAspectFor, coverCrop, cropKey } from '@/lib/crop';
 import { advanceVideoForExport, createCardVideo, isVideoSource, prepareVideoForSequentialExport, whenVideoReady } from '@/lib/videoTexture';
 
@@ -24,6 +25,16 @@ interface Slot {
   texW: number;
   texH: number;
   cornerR: number; // last-applied corner radius fraction, for mask caching
+}
+
+// The GPU-side realization of one motion track. Each track owns its own sprite
+// pool and its own container, so tracks composite over each other (container
+// order = stacking order) and can carry independent alpha / blend modes.
+interface TrackRT {
+  container: PIXI.Container;
+  slots: Slot[];
+  assetSig: string;
+  countSig: number;
 }
 
 // A single white rounded texture, tinted per placeholder card.
@@ -50,11 +61,11 @@ export class SceneRenderer {
   private videoEls = new Map<string, HTMLVideoElement>();  // live <video> per url, for playback + cleanup
   private exportVideoFrames = new Map<string, { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D; texture: PIXI.Texture }>();
   private liveVideoTextures = new Map<string, PIXI.Texture>();
-  private slots: Slot[] = [];
+  // One runtime per motion track, keyed by track id. `motion` holds their
+  // containers; zIndex mirrors the store's track order.
+  private trackRTs = new Map<string, TrackRT>();
   private ready = false;
 
-  private lastAssetSig = '';
-  private lastCountSig = -1;
   private lastFxSig = '';
   private bgImageUrl = '';                        // last-loaded uploaded bg url
   private bgImageTex: PIXI.Texture | null = null;
@@ -143,26 +154,58 @@ export class SceneRenderer {
     return tex;
   }
 
-  // Rebuild the sprite pool to match count; slot i binds to asset i (positional,
-  // 1:1 with the Assets panel), or to asset i % assets.length when the template
-  // opts into repeatAssets (high-count fields). Slots past the asset list cycle
-  // the available images; numbered placeholders appear only with zero assets.
+  // Reconcile the GPU track list against the store, then rebuild each track's
+  // sprite pool. Container order inside `motion` is the stacking order, so a
+  // track later in the array draws over the ones before it.
   syncAssets() {
     if (!this.ready) return;
     const s = useSceneStore.getState();
-    const count = Math.max(1, Math.round(s.values.count ?? 6));
-    const meta = getTemplate(s.activeTemplateId).meta;
+
+    // drop runtimes for tracks that no longer exist
+    for (const [id, rt] of this.trackRTs) {
+      if (!s.tracks.some((t) => t.id === id)) {
+        rt.container.destroy({ children: true });
+        this.trackRTs.delete(id);
+      }
+    }
+
+    s.tracks.forEach((track, order) => {
+      let rt = this.trackRTs.get(track.id);
+      if (!rt) {
+        const container = new PIXI.Container();
+        container.sortableChildren = true; // per-track depth sorting
+        this.motion.addChild(container);
+        rt = { container, slots: [], assetSig: '', countSig: -1 };
+        this.trackRTs.set(track.id, rt);
+      }
+      rt.container.zIndex = order;
+      this.syncTrackSlots(track, rt, s);
+    });
+  }
+
+  // Rebuild one track's sprite pool to match its count; slot i binds to the
+  // i-th asset OF THIS TRACK'S SLICE (positional, 1:1 with the Assets panel
+  // when the track takes everything), or to i % length when the template opts
+  // into repeatAssets (high-count fields). Slots past the list cycle the
+  // available images; numbered placeholders appear only with zero assets.
+  private syncTrackSlots(track: MotionTrack, rt: TrackRT, s: SceneState) {
+    const count = Math.max(1, Math.round(track.values.count ?? 6));
+    const meta = getTemplate(track.templateId).meta;
     const repeat = meta.repeatAssets === true;
     const aspect = cardAspectFor(meta, s.width, s.height, s.cardShape);
-    const assetSig = (repeat ? 'R|' : '') + 'A' + aspect.toFixed(4) + '|' +
-      s.assets.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + (a.crop ? a.crop.x + ',' + a.crop.y : 'c')).join('|');
+    // Which scene assets feed this track, in track order.
+    const indices = trackAssetIndices(track, s.assets);
+    const pool = indices.map((i) => s.assets[i]).filter(Boolean);
 
-    if (count === this.lastCountSig && assetSig === this.lastAssetSig) return;
-    this.lastCountSig = count;
-    this.lastAssetSig = assetSig;
+    const assetSig = (repeat ? 'R|' : '') + 'A' + aspect.toFixed(4) + '|' +
+      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + (a.crop ? a.crop.x + ',' + a.crop.y : 'c')).join('|');
+
+    if (count === rt.countSig && assetSig === rt.assetSig) return;
+    rt.countSig = count;
+    rt.assetSig = assetSig;
 
     // grow / shrink pool
-    while (this.slots.length < count) {
+    while (rt.slots.length < count) {
       const sprite = new PIXI.Sprite(this.placeholder);
       sprite.anchor.set(0.5);
       const mask = new PIXI.Graphics();
@@ -174,19 +217,19 @@ export class SceneRenderer {
       });
       label.anchor.set(0.5);
       sprite.addChild(label);
-      this.motion.addChild(sprite);
-      this.slots.push({ sprite, mask, label, texW: 480, texH: 600, cornerR: -1 });
+      rt.container.addChild(sprite);
+      rt.slots.push({ sprite, mask, label, texW: 480, texH: 600, cornerR: -1 });
     }
-    while (this.slots.length > count) {
-      const slot = this.slots.pop()!;
+    while (rt.slots.length > count) {
+      const slot = rt.slots.pop()!;
       slot.sprite.destroy({ children: true });
     }
 
-    // assign textures — slot i ↔ asset i (or i % assets.length when repeating);
-    // slots past the list cycle the set; hidden → placeholder
-    this.slots.forEach((slot, i) => {
-      let asset = s.assets[assetIndexForSlot(i, s.assets.length, repeat)];
-      if (!asset && s.assets.length > 0) asset = s.assets[i % s.assets.length];
+    // assign textures — slot i ↔ pool asset i (or i % pool.length when
+    // repeating); slots past the list cycle the set; hidden → placeholder
+    rt.slots.forEach((slot, i) => {
+      let asset = pool[assetIndexForSlot(i, pool.length, repeat)];
+      if (!asset && pool.length > 0) asset = pool[i % pool.length];
       if (!asset || !asset.visible) {
         slot.sprite.texture = this.placeholder;
         slot.sprite.tint = PLACEHOLDER_FILL;
@@ -206,6 +249,12 @@ export class SceneRenderer {
         });
       }
     });
+  }
+
+  // Force every track to rebuild its pool on the next syncAssets — used when the
+  // texture cache is swapped wholesale (video export begin/end).
+  private invalidateTracks() {
+    this.trackRTs.forEach((rt) => { rt.assetSig = ''; rt.countSig = -1; });
   }
 
   private applyMask(slot: Slot, cornerRadiusPct: number) {
@@ -347,45 +396,71 @@ export class SceneRenderer {
     this.syncEffects();
     this.drawOverlays(s);
 
-    const template = getTemplate(s.activeTemplateId);
-    const count = this.slots.length;
+    const totalFrames = Math.max(1, Math.round(s.duration * s.fps));
 
-    // Resolve the scene easing once per frame; shape cyclic phases so each
-    // unit step follows the curve while the loop stays seamless (ease(0)=0,
-    // ease(1)=1 ⇒ continuous at every integer boundary).
-    const ease = resolveEasing(s.easing);
-    const easedPhase = (phase: number) => {
-      const base = Math.floor(phase);
-      return base + ease(phase - base);
-    };
-    const ctx = {
-      fps: s.fps, width: s.width, height: s.height,
-      duration: s.duration,
-      totalFrames: Math.max(1, Math.round(s.duration * s.fps)),
-      ease, easedPhase,
-    };
-
-    // Track the featured (front-most) card so a 'card' background can reflect it.
+    // Track the featured (front-most) card so a 'card' background can reflect
+    // it. Later tracks draw on top, so their cards win ties — the background
+    // reflects what the viewer actually sees in front.
     let featured: { tex: PIXI.Texture; x: number; y: number } | null = null;
-    let featuredDepth = -Infinity;
+    let featuredScore = -Infinity;
 
-    for (let i = 0; i < count; i++) {
-      const slot = this.slots[i];
-      const t = template.transform(frame, i, count, s.values, ctx);
-      const norm = SPRITE_BASE / Math.max(slot.texW, slot.texH);
-      slot.sprite.position.set(t.x, t.y);
-      slot.sprite.scale.set(norm * t.scale * (t.scaleX ?? 1), norm * t.scale * (t.scaleY ?? 1));
-      slot.sprite.rotation = t.rotation;
-      slot.sprite.alpha = t.alpha;
-      slot.sprite.skew.set(t.skewX ?? 0, t.skewY ?? 0);
-      slot.sprite.zIndex = t.depth * 1000 + i; // stable tiebreak
-      this.applyMask(slot, s.values.cornerRadius ?? 0);
+    s.tracks.forEach((track, order) => {
+      const rt = this.trackRTs.get(track.id);
+      if (!rt) return;
 
-      if (t.depth > featuredDepth && t.alpha > 0.15) {
-        featuredDepth = t.depth;
-        featured = { tex: slot.sprite.texture, x: t.x, y: t.y };
+      // Map the scene frame onto this track's own window. Outside it, the whole
+      // container is hidden — no per-slot work at all.
+      const time = resolveTrackTime(track, frame, totalFrames);
+      if (!time.active) { rt.container.visible = false; return; }
+
+      rt.container.visible = true;
+      rt.container.alpha = clamp(track.opacity, 0, 1) * time.envelope;
+      rt.container.blendMode = track.blend;
+      // Track-level transform, on top of whatever the template poses.
+      rt.container.position.set(track.transform.x, track.transform.y);
+      rt.container.scale.set(track.transform.scale);
+      rt.container.rotation = (track.transform.rotation * Math.PI) / 180;
+
+      const template = getTemplate(track.templateId);
+      const count = rt.slots.length;
+
+      // Resolve this track's easing once per frame; shape cyclic phases so each
+      // unit step follows the curve while the loop stays seamless (ease(0)=0,
+      // ease(1)=1 ⇒ continuous at every integer boundary).
+      const ease = resolveEasing(track.easing);
+      const easedPhase = (phase: number) => {
+        const base = Math.floor(phase);
+        return base + ease(phase - base);
+      };
+      // The track's WINDOW is its clip: templates quantize against
+      // ctx.totalFrames, so each track loops seamlessly inside its own window.
+      const ctx = {
+        fps: s.fps, width: s.width, height: s.height,
+        duration: time.localTotal / Math.max(1, s.fps),
+        totalFrames: time.localTotal,
+        ease, easedPhase,
+      };
+
+      for (let i = 0; i < count; i++) {
+        const slot = rt.slots[i];
+        const t = template.transform(time.localFrame, i, count, track.values, ctx);
+        const norm = SPRITE_BASE / Math.max(slot.texW, slot.texH);
+        slot.sprite.position.set(t.x, t.y);
+        slot.sprite.scale.set(norm * t.scale * (t.scaleX ?? 1), norm * t.scale * (t.scaleY ?? 1));
+        slot.sprite.rotation = t.rotation;
+        slot.sprite.alpha = t.alpha;
+        slot.sprite.skew.set(t.skewX ?? 0, t.skewY ?? 0);
+        slot.sprite.zIndex = t.depth * 1000 + i; // stable tiebreak
+        this.applyMask(slot, track.values.cornerRadius ?? 0);
+
+        // Rank across tracks: stacking order dominates, card depth breaks ties.
+        const score = order * 1e6 + t.depth;
+        if (score > featuredScore && t.alpha > 0.15) {
+          featuredScore = score;
+          featured = { tex: slot.sprite.texture, x: t.x, y: t.y };
+        }
       }
-    }
+    });
 
     this.updateBackground(s, featured);
   }
@@ -414,7 +489,7 @@ export class SceneRenderer {
     });
     this.croppedCache.forEach((tex) => tex.destroy(false));
     this.croppedCache.clear();
-    this.lastAssetSig = '';
+    this.invalidateTracks();
     this.syncAssets();
     await Promise.resolve();
   }
@@ -426,7 +501,7 @@ export class SceneRenderer {
     this.croppedCache.clear();
     this.exportVideoFrames.forEach(({ texture }) => texture.destroy(true));
     this.exportVideoFrames.clear();
-    this.lastAssetSig = '';
+    this.invalidateTracks();
     this.syncAssets();
   }
 

--- a/lib/scenePersist.ts
+++ b/lib/scenePersist.ts
@@ -1,4 +1,5 @@
 import { useSceneStore, type SceneState } from '@/store/useSceneStore';
+import { writeProjectScene } from './projects';
 
 // Client-side scene persistence. Settings live in localStorage; uploaded media
 // bytes live in IndexedDB (see lib/assetDb). A refresh restores the full working
@@ -17,6 +18,12 @@ export const SCENE_KEY = 'motion-scene-v1';
 // url is rebuilt from IndexedDB on load, so a dead blob: string is never saved.
 export function buildScenePartial(s: SceneState) {
   return {
+    // Motion tracks are the source of truth for what animates; the flat
+    // activeTemplateId/values/easing triple below is the active track's
+    // projection, kept for scenes saved before tracks existed (hydrate folds a
+    // trackless save back into a single track).
+    tracks: s.tracks,
+    activeTrackId: s.activeTrackId,
     activeTemplateId: s.activeTemplateId,
     values: s.values,
     easing: s.easing,
@@ -43,7 +50,8 @@ export function buildScenePartial(s: SceneState) {
 
 export type ScenePartial = ReturnType<typeof buildScenePartial>;
 
-// Read the saved scene, or null when absent/corrupt.
+// Read the legacy single-scene blob. Projects superseded it (see lib/projects),
+// which migrates this into a project on first run; the key is kept as a backup.
 export function loadScene(): ScenePartial | null {
   try {
     const raw = localStorage.getItem(SCENE_KEY);
@@ -53,23 +61,44 @@ export function loadScene(): ScenePartial | null {
   }
 }
 
-// Start throttled auto-save. Returns an unsubscribe. At most one write every
-// ~500ms, and only when the serialized slice actually changed — so play/scrub
-// (frame churn) produces zero writes.
+// Which project the autosave writes into. Set when a project is opened; while
+// null, autosave holds its writes rather than guessing a destination and
+// stamping a scene onto the wrong project.
+let autosaveTarget: string | null = null;
+let lastSig = '';
+
+export function setAutosaveTarget(projectId: string | null, seedSig?: ScenePartial | null): void {
+  autosaveTarget = projectId;
+  // Seed the change signature with what was just loaded, so merely opening a
+  // project doesn't immediately rewrite it (and bump its updatedAt).
+  lastSig = seedSig ? JSON.stringify(seedSig) : '';
+}
+
+/**
+ * Write the live scene into the active project now, bypassing the throttle.
+ * Call before switching projects, or the last edits land in the wrong one.
+ */
+export function flushScene(): void {
+  if (!autosaveTarget) return;
+  try {
+    const partial = buildScenePartial(useSceneStore.getState());
+    const sig = JSON.stringify(partial);
+    if (sig === lastSig) return;
+    lastSig = sig;
+    writeProjectScene(autosaveTarget, partial);
+  } catch {
+    /* quota exceeded or serialize error — skip this write, non-fatal */
+  }
+}
+
+// Start throttled auto-save into the active project. Returns an unsubscribe. At
+// most one write every ~500ms, and only when the serialized slice actually
+// changed — so play/scrub (frame churn) produces zero writes.
 export function startSceneAutosave(): () => void {
-  let lastSig = '';
   let scheduled = false;
   const flush = () => {
     scheduled = false;
-    try {
-      const sig = JSON.stringify(buildScenePartial(useSceneStore.getState()));
-      if (sig !== lastSig) {
-        lastSig = sig;
-        localStorage.setItem(SCENE_KEY, sig);
-      }
-    } catch {
-      /* quota exceeded or serialize error — skip this write, non-fatal */
-    }
+    flushScene();
   };
   return useSceneStore.subscribe(() => {
     if (scheduled) return;

--- a/lib/tracks.ts
+++ b/lib/tracks.ts
@@ -1,0 +1,147 @@
+// ============================================================
+//  MOTION TRACKS — stacked motion layers on one shared timeline
+//
+//  A track is a self-contained mini-clip: its own template, its own control
+//  values, its own easing curve, its own slice of the asset list, and its own
+//  window on the scene timeline. The renderer draws one Pixi container per
+//  track, in array order, so tracks composite over each other.
+//
+//  The scene clock stays single (principle 1: ONE clock for preview AND
+//  export). Tracks never keep their own time — `resolveTrackTime` maps the
+//  scene frame to a track-local frame, purely, every frame.
+//
+//  LOOP GUARANTEE. Templates quantize their speed with `loopCycles()` against
+//  `ctx.totalFrames`, which is what makes frame 0 ≡ frame totalFrames. A track
+//  therefore receives its WINDOW length as `totalFrames`, not the clip length:
+//  each track loops seamlessly inside its own window. A track spanning the full
+//  clip at timeScale 1 / offset 0 gets localFrame === frame and
+//  localTotal === totalFrames, so it is bit-identical to the single-template
+//  behaviour that predates tracks.
+// ============================================================
+
+import type { EasingSpec } from './easing';
+import { clamp } from './motion';
+
+// Only the blend modes PixiJS v8 supports natively. The advanced set (overlay,
+// hard-light, hue…) needs the separate 'pixi.js/advanced-blend-modes' import
+// and a render-group per layer, which isn't worth the cost here.
+export const BLEND_MODES = ['normal', 'add', 'screen', 'multiply'] as const;
+export type BlendMode = (typeof BLEND_MODES)[number];
+
+export interface TrackTransform {
+  x: number;         // px offset applied on top of the template's pose
+  y: number;
+  scale: number;     // multiplies the template scale (1 = untouched)
+  rotation: number;  // degrees, added to the template rotation
+}
+
+export interface MotionTrack {
+  id: string;
+  name: string;
+  templateId: string;
+  values: Record<string, any>;
+  easing: EasingSpec;
+
+  // Which assets feed this track's slots. Empty = the whole asset list (the
+  // pre-track behaviour). Ids rather than indices so reordering assets in the
+  // panel doesn't silently repoint a track at different images.
+  assetIds: string[];
+
+  visible: boolean;
+  opacity: number;      // 0..1, multiplies every layer's alpha
+  blend: BlendMode;
+
+  // Window on the scene timeline, in scene frames. outFrame is exclusive.
+  inFrame: number;
+  outFrame: number;
+  // Phase slip as a percentage of the window (0..100). Two tracks on the same
+  // template at different offsets read as an echo/trail rather than a copy.
+  offset: number;
+  timeScale: number;    // 0.25..4 — how fast the track runs inside its window
+  fade: number;         // frames of auto in/out fade at the window edges
+
+  transform: TrackTransform;
+}
+
+export const DEFAULT_TRACK_TRANSFORM: TrackTransform = { x: 0, y: 0, scale: 1, rotation: 0 };
+
+// `outFrame: TRACK_END` means "to the end of the clip", whatever the clip length
+// becomes. A real frame number lands there the moment the user trims the bar.
+// Storing the sentinel (rather than the resolved length) keeps an untrimmed
+// track spanning the full clip after the duration changes — and unlike
+// Infinity it survives JSON.stringify for persistence.
+export const TRACK_END = 1e9;
+
+// What the renderer needs to draw one track at one scene frame.
+export interface TrackTime {
+  active: boolean;      // the window contains this frame
+  localFrame: number;   // the frame to hand the template
+  localTotal: number;   // the window length — becomes ctx.totalFrames
+  envelope: number;     // 0..1 fade envelope from the window edges
+}
+
+const INACTIVE: TrackTime = { active: false, localFrame: 0, localTotal: 1, envelope: 0 };
+
+// Positive modulo — `%` keeps the sign of the dividend, which would send a
+// negative offset outside the window.
+const mod = (a: number, n: number) => ((a % n) + n) % n;
+
+/**
+ * Clamp a track's window to the clip and return it in whole frames. Exported
+ * because the timeline UI has to draw exactly the window the renderer uses —
+ * one source of truth for the geometry, or bars drift from behaviour.
+ */
+export function trackWindow(track: MotionTrack, totalFrames: number): { inFrame: number; outFrame: number; length: number } {
+  const total = Math.max(1, Math.round(totalFrames));
+  const inFrame = clamp(Math.round(track.inFrame), 0, total - 1);
+  const outFrame = clamp(Math.round(track.outFrame), inFrame + 1, total);
+  return { inFrame, outFrame, length: outFrame - inFrame };
+}
+
+/**
+ * Map a scene frame to this track's local time. PURE — same inputs, same
+ * output, every call. Both the live preview and the export capture go through
+ * it, so a track's retiming is WYSIWYG.
+ */
+export function resolveTrackTime(track: MotionTrack, frame: number, totalFrames: number): TrackTime {
+  if (!track.visible || track.opacity <= 0) return INACTIVE;
+
+  const { inFrame, outFrame, length } = trackWindow(track, totalFrames);
+  if (frame < inFrame || frame >= outFrame) return INACTIVE;
+
+  const rel = frame - inFrame;
+
+  // Slip the phase, then wrap into the window. The wrap is seam-free because
+  // the template's own pose at local frame 0 equals its pose at `length`.
+  const slip = (clamp(track.offset, 0, 100) / 100) * length;
+  const scale = clamp(track.timeScale, 0.05, 8);
+  const localFrame = mod(rel * scale + slip, length);
+
+  // Symmetric edge fade, capped at half the window so in and out can't cross.
+  const fadeFrames = clamp(Math.round(track.fade), 0, Math.floor(length / 2));
+  let envelope = 1;
+  if (fadeFrames > 0) {
+    const rise = rel / fadeFrames;
+    const fall = (length - rel) / fadeFrames;
+    envelope = clamp(Math.min(rise, fall), 0, 1);
+  }
+
+  return { active: true, localFrame, localTotal: length, envelope };
+}
+
+/**
+ * The assets a track draws, as indices into the scene asset list. An empty
+ * `assetIds` means "all of them" — that keeps a freshly added track showing
+ * real images instead of placeholders.
+ */
+export function trackAssetIndices(track: MotionTrack, assets: { id: string }[]): number[] {
+  if (track.assetIds.length === 0) return assets.map((_, i) => i);
+  const picked: number[] = [];
+  for (const id of track.assetIds) {
+    const idx = assets.findIndex((a) => a.id === id);
+    if (idx >= 0) picked.push(idx);
+  }
+  // Every id is stale (assets deleted) → fall back to the full list rather
+  // than rendering an empty track the user can't explain.
+  return picked.length > 0 ? picked : assets.map((_, i) => i);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "mp4-muxer": "^5.2.2",
         "@tailwindcss/browser": "^4.3.3",
         "jszip": "^3.10.1",
+        "mp4-muxer": "^5.2.2",
         "next": "^16.2.10",
         "pixi-filters": "^6.1.5",
         "pixi.js": "^8.19.0",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "playwright-core": "^1.61.1",
     "puppeteer-core": "^25.3.0",
     "typescript": "^5.9.3"
+  },
+  "allowScripts": {
+    "sharp@0.34.5": true
   }
 }

--- a/store/useHistoryStore.ts
+++ b/store/useHistoryStore.ts
@@ -1,0 +1,176 @@
+import { create } from 'zustand';
+import { useSceneStore, type SceneState } from './useSceneStore';
+
+// ============================================================
+//  UNDO / REDO
+//
+//  Every control in this app writes to the store on every pointer move, so a
+//  naive "one entry per store change" history would put hundreds of entries in
+//  a single slider drag and make undo useless. Entries are therefore COALESCED:
+//  changes are collected and committed as one entry once the user stops for
+//  COALESCE_MS. One gesture — a drag, a typed number, a template pick — becomes
+//  one undo step.
+//
+//  Snapshots hold REFERENCES, not deep clones. Every action in useSceneStore
+//  builds new objects rather than mutating (verified: no push/splice on state),
+//  so a shallow capture is both safe and cheap — and a shallow reference
+//  comparison detects any change exactly.
+//
+//  This deliberately does NOT reuse buildScenePartial from lib/scenePersist:
+//  that blanks the url of uploaded assets (correct for disk, where a blob: URL
+//  would be dead on reload) and reusing it here would make undo wipe uploaded
+//  images. History lives in memory for one session, so it keeps live urls.
+// ============================================================
+
+const COALESCE_MS = 450;
+// Bounded so a long session can't grow memory without limit. Snapshots are
+// shallow, so each one is a handful of references.
+const MAX_ENTRIES = 60;
+
+// The undoable slice: everything describing the scene, minus the transient clock
+// (frame / playing) and minus customPresets, which is a user-wide library rather
+// than part of any one scene.
+const KEYS = [
+  'tracks', 'activeTrackId',
+  'fps', 'duration',
+  'aspect', 'width', 'height', 'customW', 'customH',
+  'safeArea', 'background', 'logo', 'audioUrl',
+  'assets', 'cardShape', 'videoEnd', 'effects',
+] as const;
+
+type Snapshot = Pick<SceneState, (typeof KEYS)[number]>;
+
+function snapshot(s: SceneState): Snapshot {
+  const out = {} as Record<string, unknown>;
+  for (const k of KEYS) out[k] = s[k];
+  return out as Snapshot;
+}
+
+// Shallow reference comparison — exact for an immutably-updated store.
+function same(a: Snapshot, b: Snapshot): boolean {
+  for (const k of KEYS) if (a[k] !== b[k]) return false;
+  return true;
+}
+
+/**
+ * Apply a snapshot. Routes through `hydrate` rather than setState so the
+ * active-track projection and the per-track value merge stay in one place —
+ * writing the motion fields directly would leave the track stale.
+ *
+ * `hydrate` forces frame 0 ("always start at the clip head"), which is right on
+ * load but jarring on undo, so the playhead is put back afterwards.
+ */
+function apply(snap: Snapshot) {
+  const scene = useSceneStore.getState();
+  const frame = scene.frame;
+  scene.hydrate(snap);
+  useSceneStore.setState({ frame });
+}
+
+interface HistoryState {
+  past: Snapshot[];
+  future: Snapshot[];
+  canUndo: boolean;
+  canRedo: boolean;
+
+  undo: () => void;
+  redo: () => void;
+  /** Drop all history — called when the open project changes. */
+  reset: () => void;
+  /** Subscribe to the scene store. Returns an unsubscribe. */
+  start: () => () => void;
+}
+
+export const useHistoryStore = create<HistoryState>((set, get) => {
+  // `baseline` is the snapshot the scene currently sits on. Undo walks backwards
+  // from it; redo walks forwards. It is not React state — nothing renders from
+  // it, and it changes on every commit.
+  let baseline: Snapshot | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  // Set while apply() runs, so restoring a snapshot can't be recorded as a new
+  // edit and trap the user in a loop.
+  let applying = false;
+
+  const commit = () => {
+    timer = null;
+    if (applying) return;
+    const current = snapshot(useSceneStore.getState());
+    if (!baseline) { baseline = current; return; }
+    if (same(baseline, current)) return;
+
+    const past = [...get().past, baseline];
+    if (past.length > MAX_ENTRIES) past.shift();
+    baseline = current;
+    // A fresh edit invalidates the redo branch.
+    set({ past, future: [], canUndo: past.length > 0, canRedo: false });
+  };
+
+  return {
+    past: [],
+    future: [],
+    canUndo: false,
+    canRedo: false,
+
+    undo: () => {
+      // Flush any in-flight gesture first, or the edit being undone would still
+      // be pending and would land on top afterwards.
+      if (timer) { clearTimeout(timer); commit(); }
+      const { past, future } = get();
+      if (past.length === 0 || !baseline) return;
+      const prev = past[past.length - 1];
+      const restored = baseline;
+      applying = true;
+      apply(prev);
+      applying = false;
+      baseline = prev;
+      const nextPast = past.slice(0, -1);
+      const nextFuture = [restored, ...future];
+      set({
+        past: nextPast,
+        future: nextFuture,
+        canUndo: nextPast.length > 0,
+        canRedo: true,
+      });
+    },
+
+    redo: () => {
+      if (timer) { clearTimeout(timer); commit(); }
+      const { past, future } = get();
+      if (future.length === 0 || !baseline) return;
+      const next = future[0];
+      const left = baseline;
+      applying = true;
+      apply(next);
+      applying = false;
+      baseline = next;
+      const nextPast = [...past, left];
+      const nextFuture = future.slice(1);
+      set({
+        past: nextPast,
+        future: nextFuture,
+        canUndo: true,
+        canRedo: nextFuture.length > 0,
+      });
+    },
+
+    // Switching projects must clear history: undoing across the switch would
+    // write one project's scene into another.
+    reset: () => {
+      if (timer) { clearTimeout(timer); timer = null; }
+      baseline = snapshot(useSceneStore.getState());
+      set({ past: [], future: [], canUndo: false, canRedo: false });
+    },
+
+    start: () => {
+      baseline = snapshot(useSceneStore.getState());
+      return useSceneStore.subscribe(() => {
+        if (applying) return;
+        // Playback moves `frame` every animation frame; it is not in the
+        // snapshot, so restart the debounce only when something undoable moved.
+        if (baseline && same(baseline, snapshot(useSceneStore.getState()))) return;
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(commit, COALESCE_MS);
+      });
+    },
+  };
+});

--- a/store/useProjectStore.ts
+++ b/store/useProjectStore.ts
@@ -1,0 +1,131 @@
+import { create } from 'zustand';
+import {
+  activeProjectId,
+  createProject,
+  deleteProject,
+  duplicateProject,
+  listProjects,
+  openInitialProject,
+  readProjectScene,
+  renameProject,
+  setActiveProject,
+  type ProjectMeta,
+} from '@/lib/projects';
+import { flushScene, setAutosaveTarget } from '@/lib/scenePersist';
+import { useSceneStore } from './useSceneStore';
+
+// The project list, and the switching that keeps the scene store and the
+// autosave target in step. Kept out of useSceneStore: a project is ABOUT a
+// scene, it isn't part of one — and the scene store is what gets serialized.
+export interface ProjectState {
+  projects: ProjectMeta[];
+  activeId: string | null;
+  booted: boolean;
+
+  // Mount-time: resolve/create the project to open and hydrate its scene.
+  bootstrap: () => void;
+  refresh: () => void;
+
+  open: (id: string) => void;
+  create: (name: string) => void;
+  duplicate: (id: string) => void;
+  rename: (id: string, name: string) => void;
+  remove: (id: string) => void;
+}
+
+const DEFAULT_NAME = 'Default project';
+
+export const useProjectStore = create<ProjectState>((set, get) => ({
+  projects: [],
+  activeId: null,
+  booted: false,
+
+  refresh: () => set(() => ({ projects: listProjects(), activeId: activeProjectId() })),
+
+  bootstrap: () => {
+    if (get().booted || typeof window === 'undefined') return;
+    const { meta, scene } = openInitialProject(DEFAULT_NAME);
+    // A migrated/saved scene hydrates; a brand-new project keeps the store's
+    // own defaults (openInitialProject returns null for it).
+    if (scene) {
+      useSceneStore.getState().hydrate(scene);
+      void useSceneStore.getState().rehydrateUploads();
+    }
+    // Seed the autosave signature with what we just loaded, so simply opening a
+    // project doesn't rewrite it and bump its updatedAt.
+    setAutosaveTarget(meta.id, scene);
+    set(() => ({ projects: listProjects(), activeId: meta.id, booted: true }));
+  },
+
+  open: (id) => {
+    if (id === get().activeId) return;
+    flushScene();                       // the edits so far belong to the OLD project
+    setAutosaveTarget(null);            // ...and nothing may be written mid-swap
+    setActiveProject(id);
+    const scene = readProjectScene(id);
+    if (scene) {
+      useSceneStore.getState().hydrate(scene);
+      void useSceneStore.getState().rehydrateUploads();
+    } else {
+      useSceneStore.getState().resetScene();
+    }
+    setAutosaveTarget(id, scene);
+    set(() => ({ projects: listProjects(), activeId: id }));
+  },
+
+  create: (name) => {
+    flushScene();
+    setAutosaveTarget(null);
+    const meta = createProject(name);
+    // A new project starts from the app defaults, not from whatever the previous
+    // project happened to be showing.
+    useSceneStore.getState().resetScene();
+    // Empty signature → the flush below actually writes, persisting the starting
+    // scene now so the project isn't an empty shell if the user switches away
+    // before the first autosave tick.
+    setAutosaveTarget(meta.id, null);
+    flushScene();
+    set(() => ({ projects: listProjects(), activeId: meta.id }));
+  },
+
+  duplicate: (id) => {
+    // Duplicating the ACTIVE project must capture its unsaved edits first.
+    if (id === get().activeId) flushScene();
+    const meta = duplicateProject(id);
+    if (!meta) return;
+    setAutosaveTarget(meta.id, readProjectScene(meta.id));
+    set(() => ({ projects: listProjects(), activeId: meta.id }));
+  },
+
+  rename: (id, name) => {
+    renameProject(id, name);
+    set(() => ({ projects: listProjects() }));
+  },
+
+  remove: (id) => {
+    const wasActive = id === get().activeId;
+    if (wasActive) setAutosaveTarget(null); // don't let a pending tick resurrect it
+    deleteProject(id);
+    const nextActive = activeProjectId();
+    if (wasActive) {
+      if (nextActive) {
+        const scene = readProjectScene(nextActive);
+        if (scene) {
+          useSceneStore.getState().hydrate(scene);
+          void useSceneStore.getState().rehydrateUploads();
+        } else {
+          useSceneStore.getState().resetScene();
+        }
+        setAutosaveTarget(nextActive, scene);
+      } else {
+        // Deleted the last project — start a fresh default one rather than
+        // leaving the app with nowhere to save.
+        useSceneStore.getState().resetScene();
+        const meta = createProject(DEFAULT_NAME);
+        setAutosaveTarget(meta.id, null);
+        flushScene();
+      }
+    }
+    set(() => ({ projects: listProjects(), activeId: activeProjectId() }));
+  },
+}));

--- a/store/useProjectStore.ts
+++ b/store/useProjectStore.ts
@@ -13,6 +13,11 @@ import {
 } from '@/lib/projects';
 import { flushScene, setAutosaveTarget } from '@/lib/scenePersist';
 import { useSceneStore } from './useSceneStore';
+import { useHistoryStore } from './useHistoryStore';
+
+// Any switch of the open project drops undo history: undoing across a switch
+// would write one project's scene into another.
+const resetHistory = () => useHistoryStore.getState().reset();
 
 // The project list, and the switching that keeps the scene store and the
 // autosave target in step. Kept out of useSceneStore: a project is ABOUT a
@@ -70,6 +75,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       useSceneStore.getState().resetScene();
     }
     setAutosaveTarget(id, scene);
+    resetHistory();
     set(() => ({ projects: listProjects(), activeId: id }));
   },
 
@@ -85,6 +91,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     // before the first autosave tick.
     setAutosaveTarget(meta.id, null);
     flushScene();
+    resetHistory();
     set(() => ({ projects: listProjects(), activeId: meta.id }));
   },
 
@@ -94,6 +101,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     const meta = duplicateProject(id);
     if (!meta) return;
     setAutosaveTarget(meta.id, readProjectScene(meta.id));
+    resetHistory();
     set(() => ({ projects: listProjects(), activeId: meta.id }));
   },
 
@@ -126,6 +134,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         flushScene();
       }
     }
+    resetHistory();
     set(() => ({ projects: listProjects(), activeId: activeProjectId() }));
   },
 }));

--- a/store/useSceneStore.ts
+++ b/store/useSceneStore.ts
@@ -1,9 +1,10 @@
 import { create } from 'zustand';
-import { defaultsFor, easingFor } from '@/templates';
+import { defaultsFor, easingFor, templates } from '@/templates';
 import type { EasingSpec } from '@/lib/easing';
 import type { CropFocus } from '@/lib/crop';
 import { DEMO_ASSETS } from '@/lib/demoAssets';
 import { idbPut, idbGet, idbDelete } from '@/lib/assetDb';
+import { DEFAULT_TRACK_TRANSFORM, TRACK_END, type BlendMode, type MotionTrack } from '@/lib/tracks';
 
 // ---------- canvas dimension helpers ----------
 export const ASPECTS: Record<string, [number, number]> = {
@@ -73,7 +74,16 @@ function persistPresets(list: CustomPreset[]) {
 }
 
 export interface SceneState {
-  // motion template
+  // ---- motion tracks: stacked motion layers, drawn in array order ----
+  // The source of truth for what animates. See lib/tracks.ts.
+  tracks: MotionTrack[];
+  activeTrackId: string;
+
+  // The active track's template / values / easing, mirrored to the top level.
+  // These predate tracks and are still what 3D (renderer3d), web (WebStage),
+  // board (BoardStage) and the zip export read, so they stay a first-class
+  // projection of `tracks[active]` rather than being removed. Every mutator
+  // goes through `projectActive` so the two can never drift.
   activeTemplateId: string;
   values: Record<string, any>;
   easing: EasingSpec;   // scene easing curve (seeded from the template default)
@@ -109,10 +119,25 @@ export interface SceneState {
   customPresets: CustomPreset[];
 
   // ---- actions ----
+  // These four act on the ACTIVE track (and mirror to the legacy fields), so
+  // every existing control panel keeps working untouched.
   setValue: (key: string, val: any) => void;
   setActiveTemplate: (id: string) => void;
   setEasing: (easing: EasingSpec) => void;
   resetValues: () => void;
+
+  // ---- track actions ----
+  setActiveTrack: (id: string) => void;
+  addTrack: (templateId?: string) => void;
+  duplicateTrack: (id: string) => void;
+  removeTrack: (id: string) => void;
+  reorderTracks: (from: number, to: number) => void;
+  renameTrack: (id: string, name: string) => void;
+  toggleTrackVisible: (id: string) => void;
+  // Patch any non-motion field of a track (window, blend, opacity, transform…).
+  patchTrack: (id: string, patch: Partial<MotionTrack>) => void;
+  setTrackBlend: (id: string, blend: BlendMode) => void;
+  toggleTrackAsset: (id: string, assetId: string) => void;
   setFrame: (frame: number) => void;
   setPlaying: (p: boolean) => void;
   setFps: (fps: number) => void;
@@ -137,6 +162,7 @@ export interface SceneState {
 
   // persistence (see lib/scenePersist)
   hydrate: (partial: Partial<SceneState>) => void;   // apply a loaded scene
+  resetScene: () => void;                            // back to defaults (new project)
   rehydrateUploads: () => Promise<void>;             // rebuild upload urls from IndexedDB
 
   loadCustomPresets: () => void;
@@ -166,49 +192,203 @@ function seedIdCounter(assets: { id: string }[]) {
   }
 }
 
+// ---------- track helpers ----------
+
+// A fresh track spans the whole clip, inherits the template's own defaults and
+// easing curve, and draws every asset — so adding one immediately shows real
+// motion over the existing stack.
+export function makeTrack(templateId: string, name: string, patch: Partial<MotionTrack> = {}): MotionTrack {
+  return {
+    id: nid('track'),
+    name,
+    templateId,
+    values: defaultsFor(templateId),
+    easing: easingFor(templateId),
+    assetIds: [],
+    visible: true,
+    opacity: 1,
+    blend: 'normal',
+    inFrame: 0,
+    outFrame: TRACK_END,
+    offset: 0,
+    timeScale: 1,
+    fade: 0,
+    transform: { ...DEFAULT_TRACK_TRANSFORM },
+    ...patch,
+  };
+}
+
+// The ONE place the legacy top-level motion fields are derived. Every action
+// that touches `tracks` or `activeTrackId` returns through here, which is what
+// guarantees `values`/`easing`/`activeTemplateId` always describe the active
+// track — the invariant 3D/web/board/persist depend on.
+function projectActive(tracks: MotionTrack[], activeTrackId: string) {
+  const active = tracks.find((t) => t.id === activeTrackId) ?? tracks[0];
+  return {
+    tracks,
+    activeTrackId: active.id,
+    activeTemplateId: active.templateId,
+    values: active.values,
+    easing: active.easing,
+  };
+}
+
+// Apply a patch to one track and re-project. `patch` may replace values/easing/
+// templateId, which is how setValue & friends reach the active track.
+function withTrack(
+  s: Pick<SceneState, 'tracks' | 'activeTrackId'>,
+  id: string,
+  patch: Partial<MotionTrack>,
+) {
+  const tracks = s.tracks.map((t) => (t.id === id ? { ...t, ...patch } : t));
+  return projectActive(tracks, s.activeTrackId);
+}
+
 const INITIAL_TEMPLATE = 'carousel';
 const initDims = dimsFor('3:4');
 
+/**
+ * The scene a fresh project starts from. Factored out (rather than inlined into
+ * create()) because "new project" has to restore exactly this — one definition,
+ * so the app's defaults and a new project's defaults can never disagree.
+ *
+ * Deliberately excludes `customPresets`: saved presets are a user-wide library,
+ * not per-project, so creating a project must not wipe them.
+ */
+function initialSceneState() {
+  const tracks = [makeTrack(INITIAL_TEMPLATE, 'Layer 1')];
+  return {
+    ...projectActive(tracks, tracks[0].id),
+
+    frame: 0,
+    fps: 30,
+    duration: 8,
+    playing: true, // autoplay loop by default
+
+    aspect: '3:4',
+    width: initDims.width,
+    height: initDims.height,
+    customW: initDims.width,
+    customH: initDims.height,
+    safeArea: false,
+    background: { source: 'color' as const, color: '#0d0d0d', gradient: false, color2: '#1f1f1f', imageUrl: null, blur: 28 },
+    logo: { url: null, position: 'br' as const, size: 96 },
+    audioUrl: null,
+
+    // start populated with the bundled demo set so every template shows real motion
+    assets: DEMO_ASSETS.map((a) => ({ ...a, id: nid('asset'), visible: true, origin: 'remote' as const })),
+    cardShape: 'auto',
+    videoEnd: 'loop' as const,
+    effects: [],
+  };
+}
+
 export const useSceneStore = create<SceneState>((set, get) => ({
-  activeTemplateId: INITIAL_TEMPLATE,
-  values: defaultsFor(INITIAL_TEMPLATE),
-  easing: easingFor(INITIAL_TEMPLATE),
-
-  frame: 0,
-  fps: 30,
-  duration: 8,
-  playing: true, // autoplay loop by default
-
-  aspect: '3:4',
-  width: initDims.width,
-  height: initDims.height,
-  customW: initDims.width,
-  customH: initDims.height,
-  safeArea: false,
-  background: { source: 'color', color: '#0d0d0d', gradient: false, color2: '#1f1f1f', imageUrl: null, blur: 28 },
-  logo: { url: null, position: 'br', size: 96 },
-  audioUrl: null,
-
-  // start populated with the bundled demo set so every template shows real motion
-  assets: DEMO_ASSETS.map((a) => ({ ...a, id: nid('asset'), visible: true, origin: 'remote' as const })),
-  cardShape: 'auto',
-  videoEnd: 'loop',
-  effects: [],
+  ...initialSceneState(),
   customPresets: [],
 
   setValue: (key, val) =>
-    set((s) => ({ values: { ...s.values, [key]: val } })),
+    set((s) => withTrack(s, s.activeTrackId, { values: { ...s.values, [key]: val } })),
 
   // full reset on template switch: wipe bag, refill from declared defaults,
-  // and seed the scene easing from the template's default curve.
+  // and seed the track easing from the template's default curve. Only the
+  // ACTIVE track switches — the other layers keep their own motion.
   setActiveTemplate: (id) =>
-    set(() => ({ activeTemplateId: id, values: defaultsFor(id), easing: easingFor(id), frame: 0 })),
+    set((s) => ({
+      ...withTrack(s, s.activeTrackId, { templateId: id, values: defaultsFor(id), easing: easingFor(id) }),
+      frame: 0,
+    })),
 
-  setEasing: (easing) => set(() => ({ easing })),
+  setEasing: (easing) => set((s) => withTrack(s, s.activeTrackId, { easing })),
 
-  // "Reset all values": restore the active template's declared defaults + easing.
+  // "Reset all values": restore the active track template's declared defaults + easing.
   resetValues: () =>
-    set((s) => ({ values: defaultsFor(s.activeTemplateId), easing: easingFor(s.activeTemplateId) })),
+    set((s) => withTrack(s, s.activeTrackId, {
+      values: defaultsFor(s.activeTemplateId),
+      easing: easingFor(s.activeTemplateId),
+    })),
+
+  // ---- track actions ----
+  setActiveTrack: (id) => set((s) => projectActive(s.tracks, id)),
+
+  // New layers start on a template that contrasts with what's already stacked,
+  // so the very first "add layer" reads as two distinct animations rather than
+  // one doubled up. Both ids must be REAL registry ids — getTemplate falls back
+  // to carousel silently, so a typo here would look like a duplicated layer.
+  addTrack: (templateId) =>
+    set((s) => {
+      const id = templateId ?? (s.activeTemplateId === 'parallax-01' ? 'carousel' : 'parallax-01');
+      const track = makeTrack(id, `Layer ${s.tracks.length + 1}`);
+      return projectActive([...s.tracks, track], track.id);
+    }),
+
+  // Duplicate + slip half a window: the copy reads as an echo of the original
+  // instead of hiding exactly behind it.
+  duplicateTrack: (id) =>
+    set((s) => {
+      const i = s.tracks.findIndex((t) => t.id === id);
+      if (i < 0) return {};
+      const src = s.tracks[i];
+      const copy: MotionTrack = {
+        ...src,
+        id: nid('track'),
+        name: `${src.name} copy`,
+        values: { ...src.values },
+        assetIds: [...src.assetIds],
+        transform: { ...src.transform },
+        offset: (src.offset + 50) % 100,
+      };
+      const tracks = s.tracks.slice();
+      tracks.splice(i + 1, 0, copy);
+      return projectActive(tracks, copy.id);
+    }),
+
+  // The last track is never removed — the scene would have nothing to animate
+  // and every panel reads through the active track.
+  removeTrack: (id) =>
+    set((s) => {
+      if (s.tracks.length <= 1) return {};
+      const tracks = s.tracks.filter((t) => t.id !== id);
+      const nextActive = s.activeTrackId === id ? tracks[tracks.length - 1].id : s.activeTrackId;
+      return projectActive(tracks, nextActive);
+    }),
+
+  // Array order IS stacking order: later = drawn on top.
+  reorderTracks: (from, to) =>
+    set((s) => {
+      if (from === to || from < 0 || from >= s.tracks.length) return {};
+      const tracks = s.tracks.slice();
+      const [moved] = tracks.splice(from, 1);
+      tracks.splice(Math.max(0, Math.min(tracks.length, to)), 0, moved);
+      return projectActive(tracks, s.activeTrackId);
+    }),
+
+  renameTrack: (id, name) => set((s) => withTrack(s, id, { name })),
+
+  toggleTrackVisible: (id) =>
+    set((s) => {
+      const t = s.tracks.find((x) => x.id === id);
+      return t ? withTrack(s, id, { visible: !t.visible }) : {};
+    }),
+
+  patchTrack: (id, patch) => set((s) => withTrack(s, id, patch)),
+
+  setTrackBlend: (id, blend) => set((s) => withTrack(s, id, { blend })),
+
+  // Toggle one asset in/out of a track's slice. Turning the last one off means
+  // "all assets" again (assetIds: []), which is what the empty list encodes.
+  toggleTrackAsset: (id, assetId) =>
+    set((s) => {
+      const t = s.tracks.find((x) => x.id === id);
+      if (!t) return {};
+      // An empty list means "all" — materialize it before removing one, or the
+      // first click would read as adding to nothing.
+      const current = t.assetIds.length > 0 ? t.assetIds : s.assets.map((a) => a.id);
+      const next = current.includes(assetId)
+        ? current.filter((x) => x !== assetId)
+        : [...current, assetId];
+      return withTrack(s, id, { assetIds: next.length === 0 ? [] : next });
+    }),
 
   setFrame: (frame) => set(() => ({ frame })),
   setPlaying: (p) => set(() => ({ playing: p })),
@@ -293,23 +473,61 @@ export const useSceneStore = create<SceneState>((set, get) => ({
   setCardShape: (shape) => set(() => ({ cardShape: shape })),
   setVideoEnd: (mode) => set(() => ({ videoEnd: mode })),
 
-  // Apply a persisted scene (from lib/scenePersist). `values` is merged over the
-  // template's current defaults so a saved scene survives added/removed controls.
+  // Apply a persisted scene (from lib/scenePersist). Each track's `values` is
+  // merged over its template's current defaults so a saved scene survives
+  // added/removed controls.
   hydrate: (partial) =>
     set((s) => {
-      const tid = partial.activeTemplateId ?? s.activeTemplateId;
-      let templateOk = true;
-      try { defaultsFor(tid); } catch { templateOk = false; } // stale/removed template → keep current
       const assets = partial.assets ?? s.assets;
       seedIdCounter(assets);
+
+      // Scenes saved before motion tracks existed carry only the flat
+      // activeTemplateId/values/easing triple — fold it into a single track so
+      // an old autosave still opens.
+      const rawTracks: MotionTrack[] = partial.tracks?.length
+        ? partial.tracks
+        : [makeTrack(partial.activeTemplateId ?? s.activeTemplateId, 'Layer 1', {
+            values: partial.values,
+            easing: partial.easing,
+          })];
+
+      // Drop tracks whose template no longer exists, and re-merge the rest over
+      // live defaults. A scene that references only removed templates keeps the
+      // current tracks rather than leaving nothing to animate.
+      //
+      // The check is registry membership, NOT a try/catch around defaultsFor:
+      // getTemplate falls back to carousel for an unknown id, so defaultsFor
+      // never throws and a catch would validate nothing. A stale id would then
+      // silently animate as Runway under the wrong name.
+      const tracks = rawTracks
+        .filter((t) => typeof t.templateId === 'string' && t.templateId in templates)
+        .map((t) => ({
+          ...makeTrack(t.templateId, t.name),
+          ...t,
+          id: t.id || nid('track'),
+          values: { ...defaultsFor(t.templateId), ...(t.values ?? {}) },
+          easing: t.easing ?? easingFor(t.templateId),
+          transform: { ...DEFAULT_TRACK_TRANSFORM, ...(t.transform ?? {}) },
+        }));
+      seedIdCounter(tracks);
+
+      const safeTracks = tracks.length > 0 ? tracks : s.tracks;
+      const activeId = safeTracks.some((t) => t.id === partial.activeTrackId)
+        ? partial.activeTrackId!
+        : safeTracks[0].id;
+
       return {
         ...s,
         ...partial,
-        activeTemplateId: templateOk ? tid : s.activeTemplateId,
-        values: templateOk ? { ...defaultsFor(tid), ...(partial.values ?? {}) } : s.values,
+        ...projectActive(safeTracks, activeId),
         frame: 0, // always start at the clip head
       };
     }),
+
+  // Back to the built-in defaults, for "new project". Uploaded bytes in
+  // IndexedDB are deliberately NOT deleted: they still belong to the scenes of
+  // other projects, which reference them by asset id.
+  resetScene: () => set(() => initialSceneState()),
 
   // Rebuild object URLs for uploaded assets from their IndexedDB bytes. Runs after
   // hydrate; assets whose bytes are gone (evicted/quota) keep an empty url and
@@ -354,15 +572,19 @@ export const useSceneStore = create<SceneState>((set, get) => ({
       persistPresets(next);
       return { customPresets: next };
     }),
+  // A preset lands on the ACTIVE track, like picking a template does — the
+  // other layers keep their own motion.
   applyCustomPreset: (id) =>
     set((s) => {
       const p = s.customPresets.find((c) => c.id === id);
       if (!p) return {};
       // merge over current defaults so presets survive template control changes
       return {
-        activeTemplateId: p.templateId,
-        values: { ...defaultsFor(p.templateId), ...p.values },
-        easing: p.easing,
+        ...withTrack(s, s.activeTrackId, {
+          templateId: p.templateId,
+          values: { ...defaultsFor(p.templateId), ...p.values },
+          easing: p.easing,
+        }),
         frame: 0,
       };
     }),

--- a/store/useSceneStore.ts
+++ b/store/useSceneStore.ts
@@ -9,6 +9,7 @@ import { DEFAULT_TRACK_TRANSFORM, TRACK_END, type BlendMode, type MotionTrack } 
 // ---------- canvas dimension helpers ----------
 export const ASPECTS: Record<string, [number, number]> = {
   '3:4': [3, 4],
+  '4:5': [4, 5],   // Instagram portrait
   '9:16': [9, 16],
   '1:1': [1, 1],
   '4:3': [4, 3],

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -39,6 +39,16 @@
   --beta-bg:      #ffffff;
   --beta-fg:      #111827;
 
+  /* ---- Motion track lanes (timeline layer stack) ---- */
+  --tl-lane-h:    30px;    /* one lane row */
+  --tl-gutter-w:  52px;    /* eye + stacking arrows, right-aligned to the axis */
+  --tl-bar-idle:  #e5e7eb; /* a track bar at rest */
+  --tl-bar-idle-fg: #374151;
+  --tl-bar-on:    #111827; /* the selected track bar */
+  --tl-bar-on-fg: #ffffff;
+  --tl-spark:     rgba(17,24,39,0.34);  /* motion sparkline inside a bar */
+  --tl-spark-on:  rgba(255,255,255,0.5);
+
   /* ---- View gizmo axes (Blender convention: X red, Y green, Z blue).
          Not theme-varying: the 3D stage background is user-set, not themed. ---- */
   --gz-x:         #e05252;
@@ -108,4 +118,10 @@
   --chip-fg:    #171717;
   --beta-bg:    #ffffff;
   --beta-fg:    #111111;
+  --tl-bar-idle:    #2d2d2d;
+  --tl-bar-idle-fg: #cccccc;
+  --tl-bar-on:      #ffffff;
+  --tl-bar-on-fg:   #111111;
+  --tl-spark:       rgba(255,255,255,0.34);
+  --tl-spark-on:    rgba(17,17,17,0.45);
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -41,13 +41,11 @@
 
   /* ---- Motion track lanes (timeline layer stack) ---- */
   --tl-lane-h:    30px;    /* one lane row */
-  --tl-gutter-w:  52px;    /* eye + stacking arrows, right-aligned to the axis */
+  --tl-gutter-w:  86px;    /* visibility + stacking + duplicate + remove */
   --tl-bar-idle:  #e5e7eb; /* a track bar at rest */
   --tl-bar-idle-fg: #374151;
   --tl-bar-on:    #111827; /* the selected track bar */
   --tl-bar-on-fg: #ffffff;
-  --tl-spark:     rgba(17,24,39,0.34);  /* motion sparkline inside a bar */
-  --tl-spark-on:  rgba(255,255,255,0.5);
 
   /* ---- View gizmo axes (Blender convention: X red, Y green, Z blue).
          Not theme-varying: the 3D stage background is user-set, not themed. ---- */
@@ -122,6 +120,4 @@
   --tl-bar-idle-fg: #cccccc;
   --tl-bar-on:      #ffffff;
   --tl-bar-on-fg:   #111111;
-  --tl-spark:       rgba(255,255,255,0.34);
-  --tl-spark-on:    rgba(17,17,17,0.45);
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -8,10 +8,10 @@
 :root {
   /* ---- Surfaces ---- */
   --stage:      #e5e7eb;   /* canvas area behind the preview */
-  /* Dot grid on the stage backdrop. Without it the canvas edge vanishes
+  /* Grid on the stage backdrop. Without it the canvas edge vanishes
      whenever the scene background matches --stage — which the defaults do
      exactly, in dark mode (#0d0d0d on #0d0d0d). */
-  --stage-dot:  rgba(0,0,0,0.055);
+  --stage-dot:  rgba(0,0,0,0.05);
   /* 1px ring around the canvas, so the frame edge is stated outright rather
      than inferred from where the dot grid stops. */
   --stage-edge: rgba(0,0,0,0.16);
@@ -104,7 +104,7 @@
 
 :root[data-theme="dark"] {
   --stage:      #0d0d0d;
-  --stage-dot:  rgba(255,255,255,0.055);
+  --stage-dot:  rgba(255,255,255,0.05);
   --stage-edge: rgba(255,255,255,0.18);
   /* Heavier than light mode: a black shadow on a near-black stage (#0d0d0d)
      has very little room to darken before it stops reading at all. */

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -8,6 +8,16 @@
 :root {
   /* ---- Surfaces ---- */
   --stage:      #e5e7eb;   /* canvas area behind the preview */
+  /* Dot grid on the stage backdrop. Without it the canvas edge vanishes
+     whenever the scene background matches --stage — which the defaults do
+     exactly, in dark mode (#0d0d0d on #0d0d0d). */
+  --stage-dot:  rgba(0,0,0,0.055);
+  /* 1px ring around the canvas, so the frame edge is stated outright rather
+     than inferred from where the dot grid stops. */
+  --stage-edge: rgba(0,0,0,0.16);
+  /* Soft lift under the canvas, so it reads as sitting above the dotted
+     backdrop rather than being cut into it. */
+  --stage-shadow: rgba(0,0,0,0.12);
   --card:       #ffffff;   /* panels */
   --card-inset: #f3f4f6;   /* input tracks / wells / segmented bg */
   --card-thumb: #e5e7eb;   /* hover chips, kbd chip */
@@ -94,6 +104,11 @@
 
 :root[data-theme="dark"] {
   --stage:      #0d0d0d;
+  --stage-dot:  rgba(255,255,255,0.055);
+  --stage-edge: rgba(255,255,255,0.18);
+  /* Heavier than light mode: a black shadow on a near-black stage (#0d0d0d)
+     has very little room to darken before it stops reading at all. */
+  --stage-shadow: rgba(0,0,0,0.55);
   --card:       #171717;
   --card-inset: #232323;
   --card-thumb: #2d2d2d;

--- a/templates/gravity.ts
+++ b/templates/gravity.ts
@@ -50,11 +50,24 @@ const gravity: Template = {
     { key: 'stagger',      label: 'Stagger',       type: 'slider', min: 0, max: 0.6, step: 0.02, default: 0.18 },
     { key: 'spread',       label: 'Spread',        type: 'slider', min: 100, max: 800, step: 1,  default: 500 },
     { key: 'spin',         label: 'Spin',          type: 'slider', min: 0, max: 3, step: 0.1,    default: 1 },
+    // A drop settles in a couple of seconds, so on a default 8s clip the pile
+    // sat frozen for most of it and then teleported back to the top. `drops`
+    // fits whole drops into the clip instead, and `recycleFade` dissolves each
+    // pile before the next one falls so the recycle isn't a hard cut.
+    { key: 'drops',        label: 'Drops',         type: 'slider', min: 1, max: 6, step: 1,      default: 2 },
+    { key: 'recycleFade',  label: 'Recycle Fade',  type: 'slider', min: 0, max: 90, step: 1,     default: 30 }, // % of each drop spent fading out
     { key: 'offset',       label: 'Offset',        type: 'xypad',                                default: { x: 0, y: 0 } },
   ],
 
   transform: (frame, index, count, v, ctx) => {
-    const T = frame / ctx.fps; // non-looping by design — physics drop settles and rests
+    // Physics runs on real seconds, not a normalized phase. Splitting the clip
+    // into whole drops makes frame totalFrames land exactly on frame 0, so this
+    // family now honours the same seamless-loop guarantee as the others — it
+    // used to be the one exception. drops = 1 restores the original single drop.
+    const cycles = Math.max(1, Math.round(v.drops));
+    const cycleFrames = ctx.totalFrames / cycles;
+    const fLocal = ((frame % cycleFrames) + cycleFrames) % cycleFrames;
+    const T = fLocal / ctx.fps;
     const sizeFactor = v.cardSize / BASE;
     const cardPx = v.cardSize * sizeFactor;     // scaled footprint used for spacing
 
@@ -111,12 +124,26 @@ const gravity: Template = {
     const restTilt = (h(index + 13) - 0.5) * 0.25;       // small ±0.125 rad
     const rotation = lerp(airRot, restTilt, settle2);
 
+    // Dissolve the settled pile over the tail of the drop, so the recycle reads
+    // as a fade rather than the pile snapping back to the top. Cards re-enter
+    // from above the frame, which is already off-canvas, so there is no matching
+    // pop on the way in.
+    let alpha = 1;
+    const fadeSpan = (v.recycleFade / 100) * cycleFrames;
+    if (fadeSpan > 0.5) {
+      const left = cycleFrames - fLocal;
+      if (left < fadeSpan) {
+        const u = clamp(left / fadeSpan, 0, 1);
+        alpha = u * u * (3 - 2 * u);                      // smooth falloff
+      }
+    }
+
     return {
       x: x + v.offset.x,
       y: y + v.offset.y,
       scale: sizeFactor,
       rotation,
-      alpha: 1,
+      alpha,
       depth: index,                                      // later cards land on top
     };
     // cornerRadius is applied where the sprite mask is built, not here.

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -24,6 +24,7 @@ import { scatterVariants } from './scatter';
 import { revealVariants } from './reveal';
 import { blankVariants } from './blank';
 import { galleryVariants } from './gallery';
+import { tickerVariants } from './ticker';
 
 const carouselVariants: Template[] = [
   { ...carousel, meta: { ...carousel.meta, name: 'Runway 01' } },
@@ -66,6 +67,7 @@ export const templateList: Template[] = [
   ...revealVariants,
   ...blankVariants,
   ...galleryVariants,
+  ...tickerVariants,
 ];
 
 export const templates: Record<string, Template> = Object.fromEntries(

--- a/templates/ticker.ts
+++ b/templates/ticker.ts
@@ -1,0 +1,123 @@
+import type { Template } from '@/lib/types';
+import { loopCycles, stepHold } from '@/lib/motion';
+import { cardPath } from '@/lib/cardPath';
+import { variant } from './variant';
+
+// Reference size (px) shared with the renderer's sprite normalization, so that
+// `cardSize` reads directly in on-screen pixels.
+const BASE = 340;
+
+// ============================================================
+//  TICKER — a marquee band that runs edge to edge
+//
+//  Where Runway grows a featured card at the centre, a ticker is deliberately
+//  flat: every card keeps the same size, so the strip reads as one continuous
+//  band of content rather than a carousel with a hero. That is the whole point
+//  of the family, and it is why the featuredness term from cardPath is used
+//  only for draw order here, never for scale.
+//
+//  Two things make it more than a constant-speed Runway:
+//
+//  · Hold — the strip can advance in discrete steps instead of gliding, the
+//    stop-and-go of a departure board. This routes through `stepHold`, which
+//    was already in lib/motion.ts (documented for exactly this) with no
+//    consumer until now.
+//
+//  · Rows — cards deal across N rows, and alternate rows can run opposite
+//    directions, which is what gives a marquee its woven look.
+// ============================================================
+
+const ticker: Template = {
+  meta: { id: 'ticker-01', name: 'Ticker 01', group: 'Ticker', defaultEasing: { id: 'linear' }, repeatAssets: true },
+
+  controls: [
+    { key: 'direction',    label: 'Direction',     type: 'pills',  options: ['left','right','up','down'], default: 'left' },
+    { key: 'count',        label: 'Count',         type: 'slider', min: 2, max: 60, step: 1,    default: 12 },
+    { key: 'rows',         label: 'Rows',          type: 'slider', min: 1, max: 5, step: 1,     default: 1 },
+    { key: 'weave',        label: 'Weave Rows',    type: 'toggle', options: ['off','on'],       default: 'off' }, // alternate rows run the other way
+    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 40, max: 600, step: 1,  default: 220 },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,   default: 8 },
+    { key: 'gap',          label: 'Gap',           type: 'slider', min: 0, max: 600, step: 1,   default: 250 }, // px between card centres (at base size)
+    { key: 'rowGap',       label: 'Row Gap',       type: 'slider', min: 0, max: 600, step: 1,   default: 260 },
+    { key: 'hold',         label: 'Step Hold',     type: 'slider', min: 0, max: 90, step: 1,    default: 0 },  // % of each step spent stopped
+    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -30, max: 30, step: 1,  default: 0 },  // degrees, uniform
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                               default: { x: 0, y: 0 } },
+    { key: 'outerFade',    label: 'Outer Fade',    type: 'slider', min: 0, max: 100, step: 1,   default: 100 }, // fade while leaving the frame %
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 4, step: 0.1,   default: 0.8 }, // cards/sec
+  ],
+
+  transform: (frame, index, count, v, ctx) => {
+    const horiz = v.direction === 'left' || v.direction === 'right';
+    const baseDir = (v.direction === 'left' || v.direction === 'up') ? 1 : -1;
+
+    // Deal the cards across rows: row = index % rows keeps consecutive images on
+    // different rows, so a small asset set spreads instead of clustering.
+    const rows = Math.max(1, Math.round(v.rows));
+    const row = index % rows;
+    const slot = Math.floor(index / rows);
+    const perRow = Math.max(1, Math.ceil(count / rows));
+
+    // Weave: odd rows travel the other way.
+    const dir = v.weave === 'on' && row % 2 === 1 ? -baseDir : baseDir;
+
+    // Period is the row length, so every card lands back on its own slot at the
+    // loop point — the same guarantee the other conveyors make.
+    const cycles = loopCycles(v.speed, ctx.duration, perRow);
+    const raw = (frame / ctx.totalFrames) * cycles * dir;
+
+    // Hold > 0 turns the glide into discrete steps. `stepHold` is loop-safe
+    // (f(n) = n at integers), and handing it ctx.ease means the scene's easing
+    // curve shapes each step — so stepping and easing compose instead of
+    // fighting, which is what running easedPhase on top would do.
+    const hold = v.hold / 100;
+    const phase = hold > 0 ? stepHold(raw, hold, ctx.ease) : ctx.easedPhase(raw);
+
+    // gap:1 → x carries the raw signed offset in card units
+    const p = cardPath({ kind: 'line', index: slot, count: perRow, phase, gap: 1, wrap: true });
+    const offset = p.x;
+    const sizeFactor = v.cardSize / BASE;
+
+    // Along-track position, and the row's cross-track position centred on 0.
+    const along = offset * v.gap * sizeFactor;
+    const across = (row - (rows - 1) / 2) * v.rowGap * sizeFactor;
+
+    const x = (horiz ? along : across) + v.offset.x;
+    const y = (horiz ? across : along) + v.offset.y;
+
+    // Constant scale — a ticker has no hero card.
+    const scale = sizeFactor;
+
+    // Outer fade: cards dissolve as they leave the frame instead of popping at
+    // the edge, which is what makes the band read as endless.
+    let alpha = 1;
+    const half = (horiz ? ctx.width : ctx.height) / 2;
+    const cardHalf = v.cardSize / 2;
+    const axisPos = horiz ? x : y;
+    const leaving = Math.abs(axisPos) - (half - cardHalf);
+    if (leaving > 0) {
+      const t = Math.min(1, leaving / Math.max(1, cardHalf * 2));
+      alpha *= 1 - (v.outerFade / 100) * (t * t * (3 - 2 * t));
+    }
+
+    return {
+      x,
+      y,
+      scale,
+      rotation: (v.tilt * Math.PI) / 180,
+      alpha,
+      // Rows nearer the bottom of the stack draw on top, and within a row the
+      // card closest to centre wins — stable, and never flickers mid-travel.
+      depth: row + p.depthNorm * 0.5,
+    };
+  },
+};
+
+export const tickerVariants: Template[] = [
+  ticker,
+  variant(ticker, 'ticker-02', 'Ticker Tilt', {
+    rows: 3, weave: 'on', tilt: -12, cardSize: 180, gap: 200, rowGap: 210, speed: 0.6, count: 24,
+  }),
+  variant(ticker, 'ticker-03', 'Ticker Step', {
+    hold: 62, speed: 1.2, cardSize: 260, gap: 290, count: 10,
+  }),
+];


### PR DESCRIPTION
## Overview

Two features on top of `main`: **stacked motion layers** on one shared timeline, and a **multi-project workspace**.

| | |
|---|---|
| **Motion layers** | Several animations composite on one timeline, each with its own template, timing and slice of the assets. |
| **Projects** | Many named projects replace the single autosaved scene, so opening one no longer overwrites the last. |

A layer is a self-contained mini-clip carrying its own template, control values, easing curve, slice of the asset list, and window on the timeline. The renderer draws one container per layer, in array order, so layers stack.

---

## Changes

### Motion layers

* **Stacking** — layers composite in array order on one shared timeline.
* **Own motion** — each layer holds its own template, control values and easing curve.
* **Time window** — drag a bar to retime it, drag its edges to trim.
* **Edge fades** — overlapping layers crossfade instead of popping.
* **Blend modes** — `normal`, `add`, `screen`, `multiply`.
* **Offset and speed** — the same template twice reads as an echo rather than a copy. Duplicating a layer applies a 50% offset for that reason.
* **Per-layer assets and transform** — applied on top of whatever the template poses.
* **Lanes** — the timeline expands into one lane per layer; visibility, stacking, duplicate and remove sit in the gutter.

### Projects

* Named projects with create, open, rename, duplicate and delete.
* Each scene stored under its own key, so the autosave rewrites one blob rather than every project.
* An existing scene is migrated by copying it into a project — `motion-scene-v1` stays as a backup.
* The rail's `+` button now creates a project. It previously opened board mode, which showed an inert board.

### Other

* Board mode moved to the end of the rail under its own `Board` label.
* Removed the collapse chevron from the Templates, Projects and 3D headers; it duplicated the stage-edge toggle.
* Removed the motion sparkline inside track bars; it read as visual noise.
* `lib/boardProject.ts` no longer writes the motion fields through `setState`, which left the track stale.

---

## Loop integrity

Each layer receives its own window length as `ctx.totalFrames`, so `loopCycles()` quantizes against the window and every layer loops seamlessly inside it.

A default layer spans the whole clip at speed 1 and offset 0, yielding `localFrame === frame`. **Existing scenes render identically** — that path is unchanged.

<details>
<summary><b>Note for reviewers — how the store is wired</b></summary>

`tracks` is the source of truth, but `activeTemplateId`, `values` and `easing` remain a projection of the active layer, because `renderer3d`, `WebStage`, `BoardStage`, `scenePersist` and the zip export all read them. Keeping the projection meant those subsystems needed no changes; only the Pixi renderer became multi-layer.

**Never write those three through `setState` directly** — it leaves the track, which is what the renderer reads, stale. Use `patchTrack`, `setValue` or `setActiveTemplate`. `projectActive()` is the single place that derives them.

</details>

---

## Validation

* TypeScript type checking and the Next.js production build both pass.
* 63 assertions run in Node over layer retiming and project persistence.

<details>
<summary><b>What the assertions cover, and the three defects they caught</b></summary>

**Layer retiming** — backward compatibility across every frame, speed wrapping inside the window, offset slip without negative frames, fade envelope clamping, degenerate windows, stale asset ids.

**Project persistence** — migration preserves the legacy backup byte-for-byte, a second boot does not duplicate the project, a corrupt index and a corrupt legacy scene both still boot, malformed entries are dropped, a dangling active id falls back and self-repairs, deletion hands over the active slot.

Three defects surfaced and were fixed:

1. `getTemplate` silently falls back to `carousel` for an unknown id, so a wrong template id animated as Runway under another name. The guard meant to catch this was dead code — it wrapped `defaultsFor`, which never throws for exactly that reason.
2. `readIndex()` returned a shared empty singleton that `createProject` pushed into, permanently polluting the module object and producing phantom projects after the index was cleared.
3. A `ResizeObserver` loop, where the timeline observed the element whose layout it was writing.



## Design

@appariciojunior — the new surfaces here were built against `styles/tokens.css`, with every new colour and metric added to the token sheet rather than hardcoded, so restyling stays a one-file edit.

The design calls themselves are guesses: lane height, gutter width, how heavy a bar should look, how a selected lane stands out. **If you can share the Figma file*