### PR TITLE
Feature/template families iso coverflow flip box

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "motion-studio",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,14 @@ public/exports/*
 # demo source originals (compressed copies live in public/demo)
 demo-images/
 out/
+
+# reference imagery pulled from the reference tool for local visual comparison
+# only. Third-party licensed stock — never commit, never deploy.
+public/demo-arqe/
+
+# local env (holds the demo-set override; never commit)
+.env*.local
+
+# contact sheets from scripts/shoot.cjs — generated, and rendered with whatever
+# demo set is active (may be third-party reference imagery)
+.shots/

--- a/app/globals.css
+++ b/app/globals.css
@@ -267,6 +267,19 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
   background: var(--card-soft); border: 1px solid var(--line);
   transition: border-color var(--t-fast), background var(--t-fast);
 }
+/* NEW next to a family name in the collapsed accordion list, so the marker is
+   visible without opening a group. .tpl-name is flex:1, which would shove the
+   badge over to the chevron, so on rows that carry a badge the name shrinks to
+   its text and the badge's own margin-right:auto holds the chevron at the far
+   edge. Scoped with :has() so every other row keeps its layout. */
+.tpl-item:has(.tpl-new-inline) .tpl-name { flex: 0 1 auto; }
+.tpl-new-inline {
+  margin-left: 6px; margin-right: auto; flex: 0 0 auto;
+  font-size: var(--fs-micro); line-height: 1; letter-spacing: 0.6px; font-weight: 500;
+  padding: 2px 4px; border-radius: var(--r-seg);
+  background: var(--inverse-bg); color: var(--inverse-fg);
+}
+
 /* NEW badge, pinned over the thumbnail's top-right corner. Reuses the beta-tag
    type treatment so the two markers read as the same family of label. */
 .tpl-new {

--- a/app/globals.css
+++ b/app/globals.css
@@ -262,9 +262,19 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
   display: grid; grid-template-columns: 1fr 1fr; gap: 14px 10px; padding: 8px 0 16px;
 }
 .tpl-card {
+  position: relative;
   display: flex; flex-direction: column; gap: 8px; padding: 8px;
   background: var(--card-soft); border: 1px solid var(--line);
   transition: border-color var(--t-fast), background var(--t-fast);
+}
+/* NEW badge, pinned over the thumbnail's top-right corner. Reuses the beta-tag
+   type treatment so the two markers read as the same family of label. */
+.tpl-new {
+  position: absolute; top: 12px; right: 12px; z-index: 2;
+  font-size: var(--fs-micro); line-height: 1; letter-spacing: 0.6px; font-weight: 500;
+  padding: 3px 5px; border-radius: var(--r-seg);
+  background: var(--inverse-bg); color: var(--inverse-fg);
+  pointer-events: none;
 }
 .tpl-card:hover { border-color: var(--handle); }
 .tpl-card.active { border-color: var(--fg); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -295,6 +295,13 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
 .tpl-thumb {
   position: relative; width: 100%; aspect-ratio: 3 / 4;
   background: var(--frame); overflow: hidden;
+  /* The preview cards carry the renderer's own stacking numbers
+     (TemplateThumb: depth * 1000 + i), so they run into the thousands. Without
+     a stacking context here those compete directly with .tpl-new's z-index in
+     .tpl-card's context and bury the badge under the cards. `overflow: hidden`
+     clips but does not isolate — this does, and it keeps the badge's z-index
+     honest at 2 instead of chasing whatever depth a template happens to use. */
+  isolation: isolate;
 }
 .tpl-thumb-el { position: absolute; background: #c9c9c9; }
 .tpl-thumb.is-previewing .tpl-thumb-el { will-change: transform, opacity; }
@@ -438,6 +445,8 @@ select.field { padding-right: 26px; }
 }
 .icon-btn:hover { color: var(--fg-body); }
 .icon-btn.off { opacity: 0.4; }
+.icon-btn:disabled { opacity: 0.28; cursor: default; }
+.asset-mobile-order { display: none; }
 
 /* collapsible — Details: summary pt14 pb6 px0(section pads), chevron 10px */
 .collapsible { border-top: 1px solid var(--line); }
@@ -484,6 +493,9 @@ select.field { padding-right: 26px; }
   border-style: dashed; object-fit: unset;
 }
 .asset-name-empty { color: var(--fg-faint); font-style: italic; }
+.mobile-slot-copy { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; text-align: left; }
+.mobile-slot-copy strong { color: var(--fg-label); font-size: var(--fs-ui); font-weight: 500; }
+.mobile-slot-copy small { color: var(--fg-faint); font-size: var(--fs-meta); }
 
 /* card-shape pills (scene-level crop aspect) */
 .shape-pills .pill { padding: 0 2px; font-size: 11px; }
@@ -517,6 +529,11 @@ select.field { padding-right: 26px; }
 .effect-title { flex: 1; font-size: var(--fs-ui); color: var(--fg-label); }
 .drag-grip { cursor: grab; color: var(--fg-faint); font-size: 11px; }
 .effect-card-body { padding: 12px 10px; display: flex; flex-direction: column; gap: var(--gap-row); border-top: 1px solid var(--line); }
+
+.export-demo-warning { padding: 14px; border: 1px solid color-mix(in srgb, #d39a36 38%, var(--line)); border-radius: var(--r-ctrl); background: color-mix(in srgb, #d39a36 9%, var(--card)); }
+.export-demo-warning strong { display: block; margin-bottom: 5px; color: var(--fg); font-size: 12px; }
+.export-demo-warning p { margin: 0 0 12px; color: var(--fg-muted); font-size: 11px; line-height: 1.45; }
+.export-demo-actions { display: grid; grid-template-columns: 1fr 1.4fr; gap: 8px; }
 
 /* ============================================================
    CANVAS STAGE
@@ -1093,6 +1110,280 @@ select.field { padding-right: 26px; }
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
+/* ============================================================
+   MOBILE EDITOR — one preview, one compact transport and one inspector.
+   The desktop grid is not mounted below 768px, so there are no duplicate
+   renderers or hidden sidebars doing work behind this layout.
+   ============================================================ */
+@media (max-width: 767px) {
+  html, body { width: 100%; overflow: hidden; overscroll-behavior: none; }
+
+  .mobile-editor {
+    width: 100%; height: 100vh; height: 100dvh;
+    display: grid;
+    grid-template-rows:
+      calc(48px + env(safe-area-inset-top))
+      minmax(180px, 42dvh)
+      52px
+      minmax(0, 1fr)
+      calc(60px + env(safe-area-inset-bottom));
+    background: var(--card); overflow: hidden;
+  }
+  .mobile-editor.mobile-panel-is-closed {
+    grid-template-rows:
+      calc(48px + env(safe-area-inset-top))
+      minmax(0, 1fr)
+      52px
+      0
+      calc(60px + env(safe-area-inset-bottom));
+  }
+
+  .mobile-topbar {
+    display: flex; align-items: flex-end; justify-content: space-between; gap: 8px;
+    padding: env(safe-area-inset-top) 8px 0;
+    background: var(--card); border-bottom: 1px solid var(--line); z-index: 20;
+  }
+  .mobile-project-button {
+    min-width: 0; height: 47px; padding: 0 8px;
+    display: flex; align-items: center; gap: 8px; color: var(--fg-body);
+  }
+  .mobile-project-button span {
+    max-width: min(44vw, 190px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    font-size: 13px; font-weight: 600;
+  }
+  .mobile-top-actions { height: 47px; display: flex; align-items: center; gap: 4px; }
+  .mobile-icon-button {
+    width: 44px; height: 44px; display: grid; place-items: center;
+    color: var(--fg-muted); flex: 0 0 auto;
+  }
+  .mobile-top-actions .stage-history {
+    position: static; border: 0; background: transparent; backdrop-filter: none;
+  }
+  .mobile-top-actions .stage-hist-btn { width: 44px; height: 44px; }
+  .mobile-top-actions .stage-hist-sep { display: none; }
+
+  .mobile-stage { grid-area: auto; min-height: 0; border: 0; }
+  .mobile-stage .stage-wrap { padding: 18px; }
+  .mobile-stage .stage-canvas { border-radius: 0; }
+
+  .mobile-transport {
+    display: flex; align-items: center; gap: 8px; min-width: 0;
+    height: 52px; padding: 0 12px; background: var(--card); border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line); z-index: 15;
+  }
+  .mobile-play {
+    width: 40px; height: 40px; display: grid; place-items: center; flex: 0 0 auto;
+    color: var(--inverse-fg); background: var(--inverse-bg);
+  }
+  .mobile-time {
+    width: 36px; flex: 0 0 auto; font-size: 11px; color: var(--fg-label);
+    font-variant-numeric: tabular-nums; text-align: right;
+  }
+  .mobile-time-total { text-align: left; color: var(--fg-faint); }
+  .mobile-scrubber {
+    min-width: 0; flex: 1; height: 44px; margin: 0; touch-action: pan-x;
+  }
+  .mobile-scrubber::-webkit-slider-runnable-track { height: 4px; background: var(--line); }
+  .mobile-scrubber::-webkit-slider-thumb {
+    -webkit-appearance: none; width: 20px; height: 20px; margin-top: -8px;
+    border-radius: 50%; background: var(--fg); border: 5px solid var(--card);
+    box-shadow: 0 0 0 1px var(--handle);
+  }
+  .mobile-scrubber::-moz-range-track { height: 4px; background: var(--line); }
+  .mobile-scrubber::-moz-range-thumb {
+    width: 12px; height: 12px; border-radius: 50%; background: var(--fg); border: 4px solid var(--card);
+  }
+
+  .mobile-panel {
+    min-height: 0; position: relative; background: var(--card); overflow: hidden;
+    border-top: 1px solid var(--line); transition: opacity 140ms ease;
+  }
+  .mobile-panel-is-closed .mobile-panel { opacity: 0; pointer-events: none; }
+  .mobile-panel-handle {
+    position: absolute; top: 6px; left: 50%; z-index: 3; transform: translateX(-50%);
+    width: 36px; height: 3px; background: var(--handle); opacity: .65;
+  }
+  .mobile-panel-scroll { height: 100%; overflow-y: auto; overscroll-behavior: contain; padding-top: 8px; }
+  .mobile-panel .templates {
+    width: 100%; height: 100%; grid-area: auto; border: 0; border-radius: 0;
+  }
+  .mobile-panel .tpl-head { padding-top: 10px; }
+  .mobile-panel .searchbox { height: 44px; }
+  .mobile-panel .tpl-foot { padding-bottom: 18px; }
+  .mobile-composed-panel { min-height: 100%; --pad-sect: 16px; }
+  .mobile-desktop-hint {
+    margin: 12px 16px; padding: 10px 12px; background: var(--card-soft); border: 1px solid var(--line);
+    color: var(--fg-muted); font-size: 11px; line-height: 1.45;
+  }
+
+  .mobile-bottom-nav {
+    display: grid; grid-template-columns: repeat(5, minmax(0, 1fr));
+    padding: 0 4px env(safe-area-inset-bottom); background: var(--card);
+    border-top: 1px solid var(--line); z-index: 30;
+  }
+  .mobile-nav-item {
+    min-width: 0; height: 59px; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 3px;
+    color: var(--fg-faint); position: relative;
+  }
+  .mobile-nav-item span { font-size: 9px; line-height: 12px; font-weight: 600; }
+  .mobile-nav-item.active { color: var(--fg); }
+  .mobile-nav-item.active::before {
+    content: ''; position: absolute; left: 22%; right: 22%; top: -1px; height: 2px; background: var(--fg);
+  }
+  .mobile-nav-export { color: var(--fg-label); }
+
+  /* Touch controls: large hit areas, without changing desktop density. */
+  .mobile-editor input:not([type='range']),
+  .mobile-editor select,
+  .mobile-editor textarea { font-size: 16px; }
+  .mobile-editor .field,
+  .mobile-editor .btn,
+  .mobile-editor .upload,
+  .mobile-editor .dropzone,
+  .mobile-editor .seg,
+  .mobile-editor .pill,
+  .mobile-editor .tab { min-height: 48px; }
+  .mobile-editor .btn,
+  .mobile-editor .field,
+  .mobile-editor .upload,
+  .mobile-editor .dropzone { min-height: 52px; }
+  .mobile-editor .strack { height: 52px; touch-action: none; overflow: visible; }
+  .mobile-editor .strack .shandle { width: 24px; height: 24px; border: 6px solid var(--card); border-radius: 50%; background: var(--fg); box-shadow: 0 0 0 1px var(--handle); }
+  .mobile-editor .sval { min-width: 52px; min-height: 52px; display: grid; place-items: center; padding: 0 10px; }
+  .mobile-editor .slider-bubble {
+    position: absolute; z-index: 4; bottom: calc(100% + 8px); transform: translateX(-50%);
+    min-width: 48px; padding: 6px 8px; border-radius: 7px; background: var(--inverse-bg);
+    color: var(--inverse-fg); font-size: 12px; text-align: center; pointer-events: none;
+  }
+  .mobile-editor .collapsible-head { min-height: 52px; padding: 0; }
+  .mobile-composed-panel .icon-btn { width: 44px; height: 44px; }
+  .mobile-editor .xypad-wrap { width: 100%; align-items: stretch; flex-direction: column; gap: 8px; }
+  .mobile-editor .xypad { width: 100%; min-height: 180px; }
+  .mobile-editor .xypad-dot { width: 28px; height: 28px; border: 7px solid var(--card); box-shadow: 0 0 0 1px var(--handle); }
+  .mobile-editor .xypad-vals { text-align: center; font-size: 13px; }
+  .mobile-editor .xypad-reset { min-height: 44px; border-radius: var(--r-ctrl); background: var(--card-inset); color: var(--fg-muted); }
+  .mobile-editor .pills { overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; scroll-snap-type: x proximity; }
+  .mobile-editor .pills::-webkit-scrollbar { display: none; }
+  .mobile-editor .pills .pill { flex: 0 0 auto; min-width: 64px; scroll-snap-align: start; }
+  .mobile-editor .segmented .seg { min-width: 64px; }
+  .mobile-editor .color input[type=color] { width: 52px; height: 52px; flex: 0 0 52px; }
+  .mobile-editor button:active { transform: scale(.97); }
+  .mobile-editor button:disabled { transform: none; }
+  .mobile-editor .section-head { padding-left: 16px; padding-right: 16px; }
+  .mobile-editor .section-body { padding-left: 16px; padding-right: 16px; }
+  .mobile-editor .hairline { margin-left: 16px; margin-right: 16px; }
+
+  .mobile-asset-list { list-style: none; margin: 0; padding: 4px 0; display: flex; flex-direction: column; gap: 6px; }
+  .mobile-asset-row { position: relative; min-height: 64px; overflow: hidden; border-radius: 10px; background: var(--card-inset); }
+  .mobile-asset-row.is-dragging { opacity: .28; }
+  .mobile-asset-actions { position: absolute; inset: 0 0 0 auto; display: grid; grid-template-columns: repeat(3, 56px); }
+  .mobile-asset-actions button { width: 56px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; color: var(--fg-muted); font-size: 9px; }
+  .mobile-asset-actions button.danger { color: #e75d5d; }
+  .mobile-asset-face {
+    position: relative; z-index: 1; min-height: 64px; display: flex; align-items: center; gap: 10px;
+    padding: 8px 6px; background: var(--card); touch-action: pan-y; transition: transform 180ms ease;
+  }
+  .mobile-asset-row:has(.mobile-asset-face:active) .mobile-asset-face { transition: none; }
+  .mobile-editor .asset-thumb { width: 48px; height: 48px; flex: 0 0 48px; }
+  .mobile-editor .asset-name { min-width: 0; font-size: 13px; color: var(--fg-body); }
+  .mobile-drag-handle, .mobile-effect-grip {
+    width: 44px; height: 44px; flex: 0 0 44px; display: grid; place-items: center;
+    border-radius: 8px; color: var(--fg-muted); background: var(--card-inset); touch-action: none; cursor: grab;
+  }
+  .mobile-drag-handle:active, .mobile-effect-grip:active { cursor: grabbing; }
+  .mobile-asset-empty { min-height: 64px; display: flex; align-items: center; gap: 10px; padding: 8px 6px; border: 1px dashed var(--line); border-radius: 10px; }
+  .mobile-asset-overlay { min-width: 260px; min-height: 64px; display: flex; align-items: center; gap: 10px; padding: 8px 12px; border-radius: 10px; background: var(--card); color: var(--fg); box-shadow: 0 14px 38px rgba(0,0,0,.28); }
+  .mobile-asset-overlay span:nth-child(2) { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  .mobile-effects-list { display: flex; flex-direction: column; gap: 10px; margin-top: 10px; }
+  .mobile-effect-card { overflow: visible; }
+  .mobile-effect-card.is-dragging { opacity: .3; }
+  .mobile-effect-card .effect-card-head { min-height: 60px; padding: 8px; }
+  .mobile-effect-card .icon-btn { width: 44px; height: 44px; }
+  .mobile-remove-confirm { font-size: 10px; color: #e75d5d; }
+
+  .mobile-sheet-backdrop {
+    position: fixed; inset: 0; z-index: 220; display: flex; align-items: flex-end;
+    background: rgba(0,0,0,.48); backdrop-filter: blur(3px);
+  }
+  .mobile-sheet {
+    width: 100%; max-height: min(82dvh, 680px); overflow: hidden; padding-bottom: env(safe-area-inset-bottom);
+    border-radius: 18px 18px 0 0; background: var(--card); box-shadow: 0 -16px 48px rgba(0,0,0,.24);
+  }
+  .mobile-sheet-grip { width: 38px; height: 4px; margin: 8px auto 2px; border-radius: 3px; background: var(--handle); }
+  .mobile-sheet-head { min-height: 52px; padding: 0 12px 0 18px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); }
+  .mobile-sheet-head strong { font-size: 14px; color: var(--fg); }
+  .mobile-sheet-close { width: 44px; height: 44px; color: var(--fg-muted); font-size: 24px; }
+  .mobile-sheet-body { max-height: calc(82dvh - 66px); overflow-y: auto; padding: 18px; }
+  .mobile-sheet-actions { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-top: 18px; }
+  .mobile-sheet-actions .btn { min-height: 48px; }
+  .mobile-number-editor { display: grid; grid-template-columns: 52px 1fr 52px; gap: 8px; }
+  .mobile-number-editor button, .mobile-number-editor input { min-height: 56px; border-radius: 10px; background: var(--card-inset); text-align: center; font-size: 20px; color: var(--fg); }
+  .mobile-number-editor input { min-width: 0; width: 100%; font-size: 18px; }
+  .mobile-crop-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 16px; }
+  .mobile-crop-grid button { aspect-ratio: 1.45; min-height: 58px; border: 1px solid var(--line); border-radius: 10px; background: var(--card-inset); }
+  .mobile-crop-grid button.active { background: var(--seg-active-bg); border-color: var(--fg-muted); box-shadow: inset 0 0 0 2px var(--card); }
+
+  .mobile-projects-screen {
+    position: fixed; inset: 0; z-index: 120; display: grid;
+    grid-template-rows: calc(48px + env(safe-area-inset-top)) minmax(0, 1fr);
+    background: var(--card);
+  }
+  .mobile-subpage-head {
+    padding: env(safe-area-inset-top) 8px 0; display: grid; grid-template-columns: 44px 1fr 44px;
+    align-items: end; border-bottom: 1px solid var(--line);
+  }
+  .mobile-subpage-head strong { height: 47px; display: grid; place-items: center; font-size: 14px; }
+  .mobile-projects-screen .templates { grid-area: auto; width: 100%; height: 100%; border: 0; }
+  .mobile-projects-screen .prj-item { min-height: 64px; padding-right: 8px; }
+  .mobile-projects-screen .prj-actions { display: flex; }
+  .mobile-projects-screen .prj-actions .icon-btn { width: 44px; height: 44px; }
+  .mobile-projects-screen .tpl-foot { padding-bottom: calc(16px + env(safe-area-inset-bottom)); }
+
+  .mobile-notice-backdrop {
+    position: fixed; inset: 0; z-index: 140; display: flex; align-items: flex-end;
+    padding: 16px 16px calc(16px + env(safe-area-inset-bottom));
+    background: rgba(17,24,39,.42); backdrop-filter: blur(3px);
+  }
+  .mobile-notice {
+    width: 100%; padding: 20px; background: var(--card); border: 1px solid var(--line);
+    box-shadow: 0 16px 50px rgba(0,0,0,.24);
+  }
+  .mobile-notice strong { display: block; margin-bottom: 8px; font-size: 15px; color: var(--fg); }
+  .mobile-notice p { margin: 0 0 18px; font-size: 13px; line-height: 1.5; color: var(--fg-label); }
+
+  .mobile-editor .modal-backdrop,
+  body:has(.mobile-editor) .modal-backdrop { align-items: stretch; justify-content: stretch; padding: 0; }
+  .mobile-editor .modal,
+  body:has(.mobile-editor) .modal {
+    width: 100%; height: 100dvh; max-height: none; border: 0; box-shadow: none;
+    display: flex; flex-direction: column;
+  }
+  .mobile-editor .modal-head,
+  body:has(.mobile-editor) .modal-head {
+    min-height: calc(52px + env(safe-area-inset-top)); padding-top: env(safe-area-inset-top);
+  }
+  .mobile-editor .modal-head .icon-btn,
+  body:has(.mobile-editor) .modal-head .icon-btn { width: 44px; height: 44px; }
+  .mobile-editor .modal-body,
+  body:has(.mobile-editor) .modal-body { overflow-y: auto; padding-bottom: calc(24px + env(safe-area-inset-bottom)); }
+  body:has(.mobile-editor) .modal.welcome { width: 100%; height: 100dvh; max-height: none; }
+
+  @media (orientation: landscape) and (max-height: 560px) {
+    .mobile-editor {
+      grid-template-rows: calc(44px + env(safe-area-inset-top)) minmax(0, 1fr) 48px 0 calc(54px + env(safe-area-inset-bottom));
+    }
+    .mobile-topbar, .mobile-project-button, .mobile-top-actions { min-height: 43px; height: auto; }
+    .mobile-panel-is-open .mobile-panel {
+      position: fixed; inset: calc(44px + env(safe-area-inset-top)) 0 calc(54px + env(safe-area-inset-bottom));
+      z-index: 25; opacity: 1; border-top: 0;
+    }
+    .mobile-transport { height: 48px; }
+    .mobile-nav-item { height: 53px; }
+  }
+}
+
 /* fullscreen source editor — code is entered rarely, tweaked constantly, so
    it gets the whole window on demand instead of a permanent column */
 .modal.web-modal {
@@ -1307,3 +1598,61 @@ select.field { padding-right: 26px; }
   flex: 0 0 auto; height: 22px; border-radius: 5px; border: 1px solid var(--line);
   background: var(--card-inset); color: var(--fg-body); font-size: 11px; padding: 0 4px; cursor: pointer;
 }
+/* Neutral SSR/hydration gate. The desktop editor is never rendered until the
+   browser has resolved the responsive breakpoint. */
+.editor-loading {
+  width: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+  box-sizing: border-box;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-size: 12px;
+  letter-spacing: 0.01em;
+}
+
+.editor-loading-mark {
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: editor-loading-spin 0.8s linear infinite;
+}
+
+@keyframes editor-loading-spin { to { transform: rotate(360deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .editor-loading-mark { animation: none; border-right-color: currentColor; }
+}
+.ctl-section + .ctl-section { margin-top: 14px; }
+.ctl-section-title {
+  margin: 0 0 7px;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+.strack:focus-visible { outline: 1px solid var(--ink); outline-offset: 2px; }
+.szero {
+  position: absolute;
+  top: 7px;
+  width: 1px;
+  height: 20px;
+  background: color-mix(in srgb, var(--ink) 22%, transparent);
+  pointer-events: none;
+}
+.ctl-advanced { margin-top: 12px; border-top: 1px solid var(--line); padding-top: 8px; }
+.ctl-advanced-toggle {
+  width: 100%; display: flex; align-items: center; justify-content: space-between;
+  padding: 7px 0; border: 0; background: transparent; color: var(--muted);
+  font: inherit; font-size: 11px; cursor: pointer;
+}
+.ctl-advanced-toggle:hover { color: var(--text); }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,190 +1,85 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
-import IconRail from '@/components/IconRail';
-import TemplatesCard from '@/components/TemplatesCard';
-import ScenePanel from '@/components/ScenePanel';
-import CanvasPanel from '@/components/CanvasPanel';
-import EffectsPanel from '@/components/EffectsPanel';
-import AssetsPanel from '@/components/AssetsPanel';
-import Timeline from '@/components/Timeline';
-import BoardPanel from '@/components/BoardPanel';
-import BoardExportBar from '@/components/BoardExportBar';
 import WelcomeDialog from '@/components/WelcomeDialog';
-import Effects3DPanel from '@/components/Effects3DPanel';
-import Effect3DControls from '@/components/Effect3DControls';
-import ModelControl from '@/components/ModelControl';
-import ModelColors from '@/components/ModelColors';
-import BackgroundFill from '@/components/BackgroundFill';
-import WebScenePanel from '@/components/WebScenePanel';
-import WebSelectionPanel from '@/components/WebSelectionPanel';
-import WebCodeModal from '@/components/WebCodeModal';
-import WebSourceBar from '@/components/WebSourceBar';
-import { CollapsedStrip } from '@/components/TplCollapse';
-import { useUIStore } from '@/store/useUIStore';
-import { useProjectStore } from '@/store/useProjectStore';
-import { useHistoryStore } from '@/store/useHistoryStore';
 import { startSceneAutosave } from '@/lib/scenePersist';
-import { useWebStore } from '@/store/useWebStore';
-import ProjectsPanel from '@/components/ProjectsPanel';
-import HistoryControls from '@/components/HistoryControls';
+import { useHistoryStore } from '@/store/useHistoryStore';
+import { useProjectStore } from '@/store/useProjectStore';
+import { useUIStore } from '@/store/useUIStore';
 
-// Pixi must run client-side only.
-const PreviewStage = dynamic(() => import('@/components/PreviewStage'), { ssr: false });
-// Three.js 3D stage — also client-only.
-const ThreeStage3D = dynamic(() => import('@/components/ThreeStage3D'), { ssr: false });
-// Web mode compiles user source in the browser — client-only too.
-const WebStage = dynamic(() => import('@/components/WebStage'), { ssr: false });
-// Board mode poses DOM cards from a rAF loop — client-only too.
-const BoardStage = dynamic(() => import('@/components/BoardStage'), { ssr: false });
+const MobileEditor = dynamic(() => import('@/components/MobileEditor'), {
+  ssr: false,
+  loading: () => <EditorLoading />,
+});
+
+const DesktopEditor = dynamic(() => import('@/components/DesktopEditor'), {
+  ssr: false,
+  loading: () => <EditorLoading />,
+});
+
+const MOBILE_QUERY = '(max-width: 767px)';
+type ViewportMode = 'pending' | 'mobile' | 'desktop';
+
+function useViewportMode(): ViewportMode {
+  const [mode, setMode] = useState<ViewportMode>('pending');
+
+  useEffect(() => {
+    const query = window.matchMedia(MOBILE_QUERY);
+    const sync = () => setMode(query.matches ? 'mobile' : 'desktop');
+    sync();
+    query.addEventListener('change', sync);
+    return () => query.removeEventListener('change', sync);
+  }, []);
+
+  return mode;
+}
+
+function EditorLoading() {
+  return (
+    <main className="editor-loading" aria-label="Loading editor" aria-busy="true">
+      <span className="editor-loading-mark" aria-hidden="true" />
+      <span>Loading editor...</span>
+    </main>
+  );
+}
 
 export default function Home() {
-  const nav = useUIStore((s) => s.nav);
-  const leftCollapsed = useUIStore((s) => s.leftCollapsed);
-  const rightCollapsed = useUIStore((s) => s.rightCollapsed);
-  const toggleLeftPanel = useUIStore((s) => s.toggleLeftPanel);
-  const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
-  const is3D = nav === '3d';
-  const isWeb = nav === 'web';
-  const isBoard = nav === 'board';
-  // Projects swaps the left column for the project list; the stage, scene column
-  // and timeline keep showing the open project, so switching is a live preview.
-  const isProjects = nav === 'projects';
-  const codeOpen = useWebStore((s) => s.codeOpen);
-  const tplCollapsed = useUIStore((s) => s.tplCollapsed);
+  const mode = useViewportMode();
 
-  // Open the active project on mount (after hydration, so no SSR mismatch), then
-  // start throttled auto-save into it. bootstrap() also migrates a pre-projects
-  // scene into a project and rebuilds uploaded media urls from IndexedDB.
   useEffect(() => {
     useUIStore.getState().hydratePreferences();
     useProjectStore.getState().bootstrap();
-    // History starts AFTER bootstrap, so the loaded scene is the baseline and
-    // the first undo can't rewind into the pre-load default state.
     const stopHistory = useHistoryStore.getState().start();
     const stopAutosave = startSceneAutosave();
-    return () => { stopHistory(); stopAutosave(); };
+    return () => {
+      stopHistory();
+      stopAutosave();
+    };
   }, []);
 
-  // Undo/redo shortcuts. Skipped while typing so ⌘Z keeps its normal meaning
-  // inside a text field (project names, layer names, exact slider values).
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
-      const k = e.key.toLowerCase();
-      if (k !== 'z' && k !== 'y') return;
-      const t = e.target as HTMLElement | null;
-      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT' || t.isContentEditable)) return;
+      const key = e.key.toLowerCase();
+      if (key !== 'z' && key !== 'y') return;
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT' || target.isContentEditable)) return;
       e.preventDefault();
-      const h = useHistoryStore.getState();
-      // ⌘⇧Z and ⌘Y both redo — the Mac and Windows idioms respectively.
-      if (k === 'y' || e.shiftKey) h.redo();
-      else h.undo();
+      const history = useHistoryStore.getState();
+      if (key === 'y' || e.shiftKey) history.redo();
+      else history.undo();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
+  if (mode === 'pending') return <EditorLoading />;
+
   return (
-    <div className={`app ${is3D ? 'app-3d' : ''} ${isWeb || isBoard ? 'app-web' : ''} ${tplCollapsed ? 'app-tpl-collapsed' : ''} ${leftCollapsed ? 'left-collapsed' : ''} ${rightCollapsed ? 'right-collapsed' : ''}`}>
-
-      <IconRail />
-
-      {/* left column — motion templates (2D, web, board) or the 3D effect
-          picker, foldable to a strip when the stage needs the width.
-          Web and board reuse the template list wholesale: the templates are
-          pure frame→pose functions, so the picker doesn't care what renders
-          them. */}
-      {tplCollapsed ? <CollapsedStrip /> : isProjects ? <ProjectsPanel /> : is3D ? <Effects3DPanel /> : <TemplatesCard controlsInline={isBoard} />}
-
-      {/* middle SCENE column — 2D only. 3D, web and board fold everything into
-          the single right sidebar rather than run two 280px panels side by
-          side. */}
-      {!is3D && !isWeb && !isBoard && (
-        <section className="card controls card-scroll">
-          <ScenePanel />
-          <div className="hairline" />
-          <EffectsPanel />
-        </section>
-      )}
-
-      <main className="stage-col">
-        {isBoard ? (
-          <BoardStage />
-        ) : isWeb ? (
-          <WebStage />
-        ) : is3D ? (
-          <ThreeStage3D />
-        ) : (
-          <>
-            <PreviewStage />
-            <button className="stage-fs" title="Fullscreen">
-              <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><path d="M2 6V2h4M14 6V2h-4M2 10v4h4M14 10v4h-4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
-            </button>
-          </>
-        )}
-        {/* scene-level undo/redo, floating top-left of the stage */}
-        <HistoryControls />
-        <button
-          className="panel-toggle panel-toggle-left"
-          onClick={toggleLeftPanel}
-          aria-expanded={!leftCollapsed}
-          aria-label={leftCollapsed ? 'Expand left sidebar' : 'Collapse left sidebar'}
-          title={leftCollapsed ? 'Expand left sidebar' : 'Collapse left sidebar'}
-        >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 3.5L10.5 8 6 12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
-        </button>
-        <button
-          className="panel-toggle panel-toggle-right"
-          onClick={toggleRightPanel}
-          aria-expanded={!rightCollapsed}
-          aria-label={rightCollapsed ? 'Expand right sidebar' : 'Collapse right sidebar'}
-          title={rightCollapsed ? 'Expand right sidebar' : 'Collapse right sidebar'}
-        >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 3.5L10.5 8 6 12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
-        </button>
-      </main>
-
-      {/* right column — canvas/assets (2D) or current 3D effect controls */}
-      <section className="card right card-scroll">
-        {isBoard ? (
-          <BoardPanel />
-        ) : isWeb ? (
-          <>
-            {/* what animates, then how it moves */}
-            <WebSelectionPanel />
-            <div className="hairline" />
-            <WebScenePanel />
-          </>
-        ) : is3D ? (
-          <>
-            <ModelControl />
-            <div className="hairline" />
-            <ModelColors />
-            <div className="hairline" />
-            <BackgroundFill />
-            <div className="hairline" />
-            <Effect3DControls />
-          </>
-        ) : (
-          <>
-            <CanvasPanel />
-            <div className="hairline" />
-            <AssetsPanel />
-          </>
-        )}
-      </section>
-
-      <footer className="card bottom">
-        {/* Video export is a 2D/3D product; web mode's deliverable is a zip
-            of the user's component, which doesn't exist yet. Its source
-            controls take that slot. */}
-        <Timeline showExport={!isWeb && !isBoard} extra={isWeb ? <WebSourceBar /> : isBoard ? <BoardExportBar /> : undefined} />
-      </footer>
-
+    <>
+      {mode === 'mobile' ? <MobileEditor /> : <DesktopEditor />}
       <WelcomeDialog />
-      {isWeb && codeOpen && <WebCodeModal />}
-    </div>
+    </>
   );
 }

--- a/components/AssetsPanel.tsx
+++ b/components/AssetsPanel.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import { useRef, useState } from 'react';
+import { DndContext, DragOverlay, PointerSensor, closestCenter, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useSceneStore, type AssetItem } from '@/store/useSceneStore';
 import { getTemplate } from '@/templates';
 import { CARD_SHAPES, DEFAULT_FOCUS, type CropFocus } from '@/lib/crop';
 import { isVideoSource } from '@/lib/videoTexture';
+import MobileSheet from './MobileSheet';
+import { useMobileInteractions } from './MobileInteractions';
 
 const SHAPE_OPTIONS = ['auto', ...Object.keys(CARD_SHAPES)];
 
@@ -55,7 +60,125 @@ function CropPopover({ asset, onClose }: { asset: AssetItem; onClose: () => void
   );
 }
 
+function MobileCropSheet({ asset, onClose }: { asset: AssetItem; onClose: () => void }) {
+  const setAssetCrop = useSceneStore((s) => s.setAssetCrop);
+  const setAllAssetCrops = useSceneStore((s) => s.setAllAssetCrops);
+  const focus = asset.crop ?? DEFAULT_FOCUS;
+  return (
+    <MobileSheet title="Crop focus" onClose={onClose}>
+      <div className="mobile-crop-grid">
+        {FOCUS_CELLS.map((cell) => (
+          <button
+            key={`${cell.x}-${cell.y}`}
+            className={focus.x === cell.x && focus.y === cell.y ? 'active' : ''}
+            onClick={() => setAssetCrop(asset.id, cell)}
+            aria-label={`${['Left', 'Centre', 'Right'][cell.x * 2]} / ${['Top', 'Middle', 'Bottom'][cell.y * 2]}`}
+          />
+        ))}
+      </div>
+      <button className="btn full" onClick={() => { setAllAssetCrops(focus); onClose(); }}>Apply to all images</button>
+    </MobileSheet>
+  );
+}
+
+const GripIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
+    {[5, 9, 13].flatMap((y) => [7, 11].map((x) => <circle key={`${x}-${y}`} cx={x} cy={y} r="1" />))}
+  </svg>
+);
+
+function MobileAssetRow({
+  asset,
+  index,
+  open,
+  onOpen,
+  onReplace,
+  onCrop,
+  onToggle,
+  onRemove,
+}: {
+  asset: AssetItem;
+  index: number;
+  open: boolean;
+  onOpen: (open: boolean) => void;
+  onReplace: () => void;
+  onCrop: () => void;
+  onToggle: () => void;
+  onRemove: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: asset.id });
+  const [offset, setOffset] = useState(open ? -168 : 0);
+  const swipe = useRef<{ x: number; y: number; start: number; horizontal: boolean } | null>(null);
+  const shownOffset = swipe.current ? offset : (open ? -168 : 0);
+
+  const pointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if ((event.target as HTMLElement).closest('button,[data-drag-handle]')) return;
+    swipe.current = { x: event.clientX, y: event.clientY, start: open ? -168 : 0, horizontal: false };
+    setOffset(open ? -168 : 0);
+  };
+  const pointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const state = swipe.current;
+    if (!state) return;
+    const dx = event.clientX - state.x;
+    const dy = event.clientY - state.y;
+    if (!state.horizontal && Math.abs(dx) > 8 && Math.abs(dx) > Math.abs(dy)) {
+      state.horizontal = true;
+      event.currentTarget.setPointerCapture(event.pointerId);
+    }
+    if (state.horizontal) setOffset(Math.max(-168, Math.min(0, state.start + dx)));
+  };
+  const pointerUp = () => {
+    const shouldOpen = offset < -64;
+    swipe.current = null;
+    onOpen(shouldOpen);
+    setOffset(shouldOpen ? -168 : 0);
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      className={`mobile-asset-row ${isDragging ? 'is-dragging' : ''}`}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+    >
+      <div className="mobile-asset-actions" aria-hidden={!open}>
+        <button onClick={() => { onCrop(); onOpen(false); }}><CropIcon /><span>Crop</span></button>
+        <button onClick={() => { onToggle(); onOpen(false); }}><EyeIcon off={!asset.visible} /><span>{asset.visible ? 'Hide' : 'Show'}</span></button>
+        <button className="danger" onClick={() => { onRemove(); onOpen(false); }}><XIcon /><span>Remove</span></button>
+      </div>
+      <div
+        className="mobile-asset-face"
+        style={{ transform: `translateX(${shownOffset}px)` }}
+        onPointerDown={pointerDown}
+        onPointerMove={pointerMove}
+        onPointerUp={pointerUp}
+        onPointerCancel={() => { swipe.current = null; setOffset(open ? -168 : 0); }}
+      >
+        <span className="asset-idx">{index + 1}</span>
+        {!asset.url ? (
+          <span className="asset-thumb asset-thumb-empty" onClick={onReplace}>+</span>
+        ) : isVideoSource(asset.url, asset.kind) ? (
+          <video className="asset-thumb" src={asset.url} muted playsInline preload="metadata" onClick={onReplace} />
+        ) : (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img className="asset-thumb" src={asset.url} alt={asset.name} onClick={onReplace} />
+        )}
+        <span className="asset-name" title={asset.name}>{asset.name}</span>
+        <button
+          className="mobile-drag-handle"
+          data-drag-handle
+          aria-label={`Reorder ${asset.name}`}
+          {...attributes}
+          {...listeners}
+        >
+          <GripIcon />
+        </button>
+      </div>
+    </li>
+  );
+}
+
 export default function AssetsPanel() {
+  const mobile = useMobileInteractions();
   const assets = useSceneStore((s) => s.assets);
   const count = useSceneStore((s) => Math.max(1, Math.round(s.values.count ?? 1)));
   const repeat = useSceneStore((s) => getTemplate(s.activeTemplateId).meta.repeatAssets === true);
@@ -69,7 +192,7 @@ export default function AssetsPanel() {
   const setCardShape = useSceneStore((s) => s.setCardShape);
   const videoEnd = useSceneStore((s) => s.videoEnd);
   const setVideoEnd = useSceneStore((s) => s.setVideoEnd);
-  const hasVideo = useSceneStore((s) => s.assets.some((a) => isVideoSource(a.url, a.kind)));
+  const hasVideo = useSceneStore((s) => s.assets.some((a) => a.origin !== 'demo' && isVideoSource(a.url, a.kind)));
   const fullBleed = useSceneStore((s) => getTemplate(s.activeTemplateId).meta.cardAspect === 'canvas');
   const inputRef = useRef<HTMLInputElement>(null);
   const slotInputRef = useRef<HTMLInputElement>(null);
@@ -78,6 +201,9 @@ export default function AssetsPanel() {
   const [overIdx, setOverIdx] = useState<number | null>(null);
   const [dropActive, setDropActive] = useState(false);
   const [cropOpenId, setCropOpenId] = useState<string | null>(null);
+  const [swipeOpenId, setSwipeOpenId] = useState<string | null>(null);
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
   // Pointer-based row drag (HTML5 DnD is unreliable: img elements hijack the
   // drag and re-renders can cancel it). Drag arms after a 4px move so plain
   // clicks (replace / hide / remove) keep working.
@@ -115,7 +241,7 @@ export default function AssetsPanel() {
     const over = rowIndexAt(e.clientX, e.clientY);
     if (over !== null && over !== d.idx) {
       // dropping past the filled range (an empty slot) moves the card to the end
-      reorderAssets(d.idx, Math.min(over, filled - 1));
+      reorderAssets(d.idx, Math.min(over, assets.length - 1));
     }
     setDragIdx(null);
     setOverIdx(null);
@@ -147,9 +273,21 @@ export default function AssetsPanel() {
   // The list is sized by the template's `count` — one row per layer slot.
   // Repeat-mode templates cycle a small image set across many layers, so the
   // panel shows just the images plus one add-row instead of `count` slots.
-  const filled = Math.min(assets.length, count);
-  const rows = repeat ? Math.min(count, assets.length + 1) : count;
+  const realAssetCount = assets.filter((asset) => asset.origin !== 'demo').length;
+  const rows = repeat ? Math.min(count, realAssetCount + 1) : count;
   const slots = Array.from({ length: rows }, (_, i) => assets[i] ?? null);
+  const filled = slots.filter((asset) => asset && asset.origin !== 'demo').length;
+  const sortableEntries = slots
+    .map((asset, index) => asset && asset.origin !== 'demo' ? { asset, index } : null)
+    .filter((entry): entry is { asset: AssetItem; index: number } => entry !== null);
+
+  const finishMobileDrag = ({ active, over }: DragEndEvent) => {
+    setActiveDragId(null);
+    if (!over || active.id === over.id) return;
+    const from = sortableEntries.find((entry) => entry.asset.id === active.id)?.index;
+    const to = sortableEntries.find((entry) => entry.asset.id === over.id)?.index;
+    if (from !== undefined && to !== undefined) reorderAssets(from, to);
+  };
 
   return (
     <>
@@ -172,11 +310,11 @@ export default function AssetsPanel() {
         <div className="asset-meta">
           <span>
             {repeat
-              ? `${assets.length || 'your'} image${assets.length === 1 ? '' : 's'} repeat across ${count} layers`
+              ? `${realAssetCount || 'your'} image${realAssetCount === 1 ? '' : 's'} repeat across ${count} layers`
               : `${count} ${count === 1 ? 'slot' : 'slots'} · linked to Count`}
           </span>
           <span className="spacer" />
-          {assets.length > 0 && <button className="link-btn" onClick={clearAssets}>Clear all</button>}
+          {realAssetCount > 0 && <button className="link-btn" onClick={clearAssets}>Clear all</button>}
         </div>
 
         {/* card shape — the cover-crop aspect every card adapts to */}
@@ -234,9 +372,54 @@ export default function AssetsPanel() {
           }}
         />
 
+        {mobile ? (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={({ active }) => { setSwipeOpenId(null); setActiveDragId(String(active.id)); }}
+            onDragCancel={() => setActiveDragId(null)}
+            onDragEnd={finishMobileDrag}
+          >
+            <SortableContext items={sortableEntries.map((entry) => entry.asset.id)} strategy={verticalListSortingStrategy}>
+              <ul className="mobile-asset-list" onPointerDown={(event) => {
+                if (!(event.target as HTMLElement).closest('.mobile-asset-row')) setSwipeOpenId(null);
+              }}>
+                {slots.map((asset, index) => asset && asset.origin !== 'demo' ? (
+                  <MobileAssetRow
+                    key={asset.id}
+                    asset={asset}
+                    index={index}
+                    open={swipeOpenId === asset.id}
+                    onOpen={(open) => setSwipeOpenId(open ? asset.id : null)}
+                    onReplace={() => openSlotPicker(index)}
+                    onCrop={() => setCropOpenId(asset.id)}
+                    onToggle={() => toggleAsset(asset.id)}
+                    onRemove={() => removeAsset(asset.id)}
+                  />
+                ) : (
+                  <li key={`mobile-empty-${index}`} className="mobile-asset-empty" onClick={() => openSlotPicker(index)}>
+                    <span className="asset-idx">{index + 1}</span>
+                    <span className="asset-thumb asset-thumb-empty">+</span>
+                    <span className="mobile-slot-copy"><strong>Slot {index + 1}</strong><small>Drop or click to add</small></span>
+                  </li>
+                ))}
+              </ul>
+            </SortableContext>
+            <DragOverlay>
+              {activeDragId && (() => {
+                const asset = sortableEntries.find((entry) => entry.asset.id === activeDragId)?.asset;
+                return asset ? <div className="mobile-asset-overlay"><span className="asset-thumb asset-thumb-empty" /><span>{asset.name}</span><GripIcon /></div> : null;
+              })()}
+            </DragOverlay>
+            {cropOpenId && (() => {
+              const asset = assets.find((item) => item.id === cropOpenId);
+              return asset ? <MobileCropSheet asset={asset} onClose={() => setCropOpenId(null)} /> : null;
+            })()}
+          </DndContext>
+        ) : (
         <ul className="asset-list">
           {slots.map((a, i) =>
-            a ? (
+            a && a.origin !== 'demo' ? (
               <li
                 key={a.id}
                 data-slot-idx={i}
@@ -274,6 +457,26 @@ export default function AssetsPanel() {
                   <img className="asset-thumb" src={a.url} alt={a.name} onClick={() => openSlotPicker(i)} title="Replace" />
                 )}
                 <span className="asset-name" title={a.name}>{a.name}</span>
+                <span className="asset-mobile-order" aria-label={`Reorder ${a.name}`}>
+                  <button
+                    className="icon-btn"
+                    title="Move up"
+                    aria-label={`Move ${a.name} up`}
+                    disabled={i === 0}
+                    onClick={() => i > 0 && reorderAssets(i, i - 1)}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M4 10l4-4 4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                  </button>
+                  <button
+                    className="icon-btn"
+                    title="Move down"
+                    aria-label={`Move ${a.name} down`}
+                    disabled={i >= filled - 1}
+                    onClick={() => i < filled - 1 && reorderAssets(i, i + 1)}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                  </button>
+                </span>
                 <button
                   className={`icon-btn ${a.crop && (a.crop.x !== 0.5 || a.crop.y !== 0.5) ? 'crop-set' : ''}`}
                   title="Crop focus"
@@ -300,13 +503,12 @@ export default function AssetsPanel() {
                 <span className="asset-thumb asset-thumb-empty">
                   <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/></svg>
                 </span>
-                <span className="asset-name asset-name-empty">
-                  {assets.length > 0 ? `Repeats image ${(i % assets.length) + 1} — click to override` : 'Empty slot — add image'}
-                </span>
+                <span className="mobile-slot-copy"><strong>Slot {i + 1}</strong><small>Drop or click to add</small></span>
               </li>
             )
           )}
         </ul>
+        )}
       </div>
     </>
   );

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -2,6 +2,8 @@
 
 import { useRef, useState } from 'react';
 import type { ControlDef } from '@/lib/types';
+import MobileSheet from './MobileSheet';
+import { useMobileInteractions } from './MobileInteractions';
 
 interface RowProps {
   def: ControlDef;
@@ -11,7 +13,7 @@ interface RowProps {
 
 export function ControlRow({ def, value, onChange }: RowProps) {
   return (
-    <div className="ctl-row">
+    <div className="ctl-row" title={def.description}>
       <label className="ctl-label">{def.label}</label>
       <div className="ctl-input">{renderControl(def, value, onChange)}</div>
     </div>
@@ -36,32 +38,59 @@ function renderControl(def: ControlDef, value: any, onChange: (v: any) => void) 
 // a 2×16px #424242 bar as handle, value inside the track right-aligned
 // (12px #aaa), click the value to type an exact number.
 function SliderControl({ def, value, onChange }: RowProps) {
+  const mobile = useMobileInteractions();
   const min = def.min ?? 0, max = def.max ?? 100, step = def.step ?? 1;
   const trackRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [draft, setDraft] = useState(String(value));
+  const [dragging, setDragging] = useState(false);
   const num = Number(value);
   const pct = Math.max(0, Math.min(100, ((num - min) / (max - min)) * 100));
-  const decimals = step < 1 ? 1 : 0;
+  const decimals = def.precision ?? (step < 1 ? Math.min(3, Math.ceil(-Math.log10(step))) : 0);
 
-  const setFromX = (clientX: number) => {
+  const setFromX = (clientX: number, fine = false) => {
     const el = trackRef.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
     const t = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
-    const snapped = Math.round((min + t * (max - min)) / step) * step;
+    const effectiveStep = fine ? step * 0.1 : step;
+    const snapped = Math.round((min + t * (max - min)) / effectiveStep) * effectiveStep;
     onChange(Number(Math.max(min, Math.min(max, snapped)).toFixed(4)));
+  };
+
+  const clampValue = (next: number) => Number(Math.max(min, Math.min(max, next)).toFixed(4));
+  const openExact = () => {
+    setDraft(String(num));
+    setSheetOpen(true);
+  };
+  const applyExact = () => {
+    const next = Number(draft);
+    if (Number.isFinite(next)) onChange(clampValue(next));
+    setSheetOpen(false);
   };
 
   return (
     <div
       ref={trackRef}
-      className="strack"
+      className={`strack ${mobile ? 'strack-mobile' : ''} ${dragging ? 'is-dragging' : ''}`}
+      tabIndex={0}
       onPointerDown={(e) => {
         if (editing) return;
         (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
-        setFromX(e.clientX);
+        setDragging(true);
+        setFromX(e.clientX, e.shiftKey);
       }}
-      onPointerMove={(e) => { if (!editing && e.buttons === 1) setFromX(e.clientX); }}
+      onPointerMove={(e) => { if (!editing && e.buttons === 1) setFromX(e.clientX, e.shiftKey); }}
+      onPointerUp={() => setDragging(false)}
+      onPointerCancel={() => setDragging(false)}
+      onKeyDown={(e) => {
+        if (editing || !['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp'].includes(e.key)) return;
+        e.preventDefault();
+        const sign = e.key === 'ArrowRight' || e.key === 'ArrowUp' ? 1 : -1;
+        const delta = step * (e.shiftKey ? 0.1 : 1) * sign;
+        onChange(Number(Math.max(min, Math.min(max, num + delta)).toFixed(4)));
+      }}
       onDoubleClick={(e) => {
         // double-click resets to the control's declared default
         if (editing) return;
@@ -72,7 +101,9 @@ function SliderControl({ def, value, onChange }: RowProps) {
       title="Double-click to reset"
     >
       <div className="sfill" style={{ width: `${pct}%` }} />
+      {min < 0 && max > 0 && <div className="szero" style={{ left: `${((-min) / (max - min)) * 100}%` }} />}
       <div className="shandle" style={{ left: `${pct}%` }} />
+      {mobile && dragging && <output className="slider-bubble" style={{ left: `${pct}%` }}>{num.toFixed(decimals)}{def.unit ?? ''}</output>}
       {editing ? (
         <input
           className="sval-input"
@@ -90,13 +121,44 @@ function SliderControl({ def, value, onChange }: RowProps) {
       ) : (
         <span
           className="sval"
-          onPointerDown={(e) => { e.stopPropagation(); setEditing(true); }}
+          onPointerDown={(e) => { e.stopPropagation(); mobile ? openExact() : setEditing(true); }}
         >
-          {num.toFixed(decimals)}
+          {num.toFixed(decimals)}{def.unit ?? ''}
         </span>
+      )}
+      {mobile && sheetOpen && (
+        <MobileSheet title={def.label} onClose={() => setSheetOpen(false)}>
+          <div className="mobile-number-editor">
+            <button onClick={() => setDraft(String(clampValue((Number(draft) || 0) - step)))} aria-label={`Decrease ${def.label}`}>−</button>
+            <input
+              type="number"
+              min={min}
+              max={max}
+              step={step}
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              autoFocus
+            />
+            <button onClick={() => setDraft(String(clampValue((Number(draft) || 0) + step)))} aria-label={`Increase ${def.label}`}>+</button>
+          </div>
+          <div className="mobile-sheet-actions">
+            <button className="btn" onClick={() => setDraft(String(def.default))}>Reset</button>
+            <button className="btn" onClick={() => setSheetOpen(false)}>Cancel</button>
+            <button className="btn solid" onClick={applyExact}>Apply</button>
+          </div>
+        </MobileSheet>
       )}
     </div>
   );
+}
+
+export function controlVisible(def: ControlDef, values: Record<string, any>): boolean {
+  const rule = def.visibleWhen;
+  if (!rule) return true;
+  const current = values[rule.key];
+  if (rule.equals !== undefined && current !== rule.equals) return false;
+  if (rule.not !== undefined && current === rule.not) return false;
+  return true;
 }
 
 function ToggleControl({ def, value, onChange }: RowProps) {
@@ -138,6 +200,7 @@ function ColorControl({ value, onChange }: { value: any; onChange: (v: any) => v
 }
 
 function XYPadControl({ def, value, onChange }: RowProps) {
+  const mobile = useMobileInteractions();
   const ref = useRef<HTMLDivElement>(null);
   const range = def.max ?? 400;
   const v = value ?? { x: 0, y: 0 };
@@ -167,6 +230,7 @@ function XYPadControl({ def, value, onChange }: RowProps) {
         <div className="xypad-dot" style={{ left: `${dotX}%`, top: `${dotY}%` }} />
       </div>
       <div className="xypad-vals">{v.x}, {v.y}</div>
+      {mobile && <button className="xypad-reset" onClick={() => onChange({ x: 0, y: 0 })}>Reset to center</button>}
     </div>
   );
 }

--- a/components/DesktopEditor.tsx
+++ b/components/DesktopEditor.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import AssetsPanel from '@/components/AssetsPanel';
+import BackgroundFill from '@/components/BackgroundFill';
+import BoardExportBar from '@/components/BoardExportBar';
+import BoardPanel from '@/components/BoardPanel';
+import CanvasPanel from '@/components/CanvasPanel';
+import Effect3DControls from '@/components/Effect3DControls';
+import Effects3DPanel from '@/components/Effects3DPanel';
+import EffectsPanel from '@/components/EffectsPanel';
+import HistoryControls from '@/components/HistoryControls';
+import IconRail from '@/components/IconRail';
+import ModelColors from '@/components/ModelColors';
+import ModelControl from '@/components/ModelControl';
+import ProjectsPanel from '@/components/ProjectsPanel';
+import ScenePanel from '@/components/ScenePanel';
+import TemplatesCard from '@/components/TemplatesCard';
+import Timeline from '@/components/Timeline';
+import { CollapsedStrip } from '@/components/TplCollapse';
+import WebCodeModal from '@/components/WebCodeModal';
+import WebScenePanel from '@/components/WebScenePanel';
+import WebSelectionPanel from '@/components/WebSelectionPanel';
+import WebSourceBar from '@/components/WebSourceBar';
+import { useUIStore } from '@/store/useUIStore';
+import { useWebStore } from '@/store/useWebStore';
+
+const PreviewStage = dynamic(() => import('@/components/PreviewStage'), { ssr: false });
+const ThreeStage3D = dynamic(() => import('@/components/ThreeStage3D'), { ssr: false });
+const WebStage = dynamic(() => import('@/components/WebStage'), { ssr: false });
+const BoardStage = dynamic(() => import('@/components/BoardStage'), { ssr: false });
+
+export default function DesktopEditor() {
+  const nav = useUIStore((s) => s.nav);
+  const leftCollapsed = useUIStore((s) => s.leftCollapsed);
+  const rightCollapsed = useUIStore((s) => s.rightCollapsed);
+  const toggleLeftPanel = useUIStore((s) => s.toggleLeftPanel);
+  const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
+  const tplCollapsed = useUIStore((s) => s.tplCollapsed);
+  const codeOpen = useWebStore((s) => s.codeOpen);
+  const is3D = nav === '3d';
+  const isWeb = nav === 'web';
+  const isBoard = nav === 'board';
+  const isProjects = nav === 'projects';
+
+  return (
+    <div className={`app ${is3D ? 'app-3d' : ''} ${isWeb || isBoard ? 'app-web' : ''} ${tplCollapsed ? 'app-tpl-collapsed' : ''} ${leftCollapsed ? 'left-collapsed' : ''} ${rightCollapsed ? 'right-collapsed' : ''}`}>
+      <IconRail />
+
+      {tplCollapsed ? <CollapsedStrip /> : isProjects ? <ProjectsPanel /> : is3D ? <Effects3DPanel /> : <TemplatesCard controlsInline={isBoard} />}
+
+      {!is3D && !isWeb && !isBoard && (
+        <section className="card controls card-scroll">
+          <ScenePanel />
+          <div className="hairline" />
+          <EffectsPanel />
+        </section>
+      )}
+
+      <main className="stage-col">
+        {isBoard ? <BoardStage /> : isWeb ? <WebStage /> : is3D ? <ThreeStage3D /> : (
+          <>
+            <PreviewStage />
+            <button className="stage-fs" title="Fullscreen">
+              <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><path d="M2 6V2h4M14 6V2h-4M2 10v4h4M14 10v4h-4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" /></svg>
+            </button>
+          </>
+        )}
+        <HistoryControls />
+        <button className="panel-toggle panel-toggle-left" onClick={toggleLeftPanel} aria-expanded={!leftCollapsed} aria-label={leftCollapsed ? 'Expand left sidebar' : 'Collapse left sidebar'} title={leftCollapsed ? 'Expand left sidebar' : 'Collapse left sidebar'}>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 3.5L10.5 8 6 12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
+        </button>
+        <button className="panel-toggle panel-toggle-right" onClick={toggleRightPanel} aria-expanded={!rightCollapsed} aria-label={rightCollapsed ? 'Expand right sidebar' : 'Collapse right sidebar'} title={rightCollapsed ? 'Expand right sidebar' : 'Collapse right sidebar'}>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 3.5L10.5 8 6 12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
+        </button>
+      </main>
+
+      <section className="card right card-scroll">
+        {isBoard ? <BoardPanel /> : isWeb ? (
+          <><WebSelectionPanel /><div className="hairline" /><WebScenePanel /></>
+        ) : is3D ? (
+          <><ModelControl /><div className="hairline" /><ModelColors /><div className="hairline" /><BackgroundFill /><div className="hairline" /><Effect3DControls /></>
+        ) : (
+          <><CanvasPanel /><div className="hairline" /><AssetsPanel /></>
+        )}
+      </section>
+
+      <footer className="card bottom">
+        <Timeline showExport={!isWeb && !isBoard} extra={isWeb ? <WebSourceBar /> : isBoard ? <BoardExportBar /> : undefined} />
+      </footer>
+
+      {isWeb && codeOpen && <WebCodeModal />}
+    </div>
+  );
+}

--- a/components/EditorIcons.tsx
+++ b/components/EditorIcons.tsx
@@ -1,0 +1,98 @@
+import type { SVGProps } from 'react';
+
+export type EditorIconProps = Omit<SVGProps<SVGSVGElement>, 'width' | 'height'> & {
+  size?: number;
+};
+
+function iconProps({ size = 20, ...props }: EditorIconProps) {
+  return {
+    width: size,
+    height: size,
+    viewBox: '0 0 20 20',
+    fill: 'none',
+    'aria-hidden': true,
+    focusable: false,
+    ...props,
+  } as const;
+}
+
+export function ProjectsIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M2.75 6.25A1.5 1.5 0 014.25 4.75h3l1.5 1.75h6a1.5 1.5 0 011.5 1.5v6.25a1.5 1.5 0 01-1.5 1.5h-10.5a1.5 1.5 0 01-1.5-1.5V6.25z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>;
+}
+
+export function LibraryIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><rect x="3" y="3" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="11" y="3" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="3" y="11" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="11" y="11" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/></svg>;
+}
+
+export function ThreeDIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M10 2.5l6.5 3.75v7.5L10 17.5l-6.5-3.75v-7.5L10 2.5z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/><path d="M3.7 6.4L10 10l6.3-3.6M10 10v7.4" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>;
+}
+
+export function WebIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M7.5 6.5L4 10l3.5 3.5M12.5 6.5L16 10l-3.5 3.5M11 4.5l-2 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+}
+
+export function BoardIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><rect x="2.5" y="4.5" width="4.5" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5"/><rect x="8" y="4.5" width="4" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5" opacity="0.65"/><rect x="13" y="4.5" width="4.5" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5" opacity="0.4"/></svg>;
+}
+
+export function AddIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M10 4v12M4 10h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>;
+}
+
+export function SunIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><circle cx="10" cy="10" r="3.25" stroke="currentColor" strokeWidth="1.5"/><path d="M10 2.5v2M10 15.5v2M2.5 10h2M15.5 10h2M4.7 4.7l1.4 1.4M13.9 13.9l1.4 1.4M15.3 4.7l-1.4 1.4M6.1 13.9l-1.4 1.4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>;
+}
+
+export function MoonIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M15.7 12.6A6 6 0 017.4 4.3 6.1 6.1 0 1015.7 12.6z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>;
+}
+
+export function MediaIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><rect x="2.75" y="3.5" width="14.5" height="13" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><circle cx="7" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.5"/><path d="M4.5 14l3.2-3 2.4 2 2.1-2.1 3.3 3.1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+}
+
+export function AdjustIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M3 5h4M11 5h6M3 10h8M15 10h2M3 15h3M10 15h7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/><circle cx="9" cy="5" r="2" stroke="currentColor" strokeWidth="1.5"/><circle cx="13" cy="10" r="2" stroke="currentColor" strokeWidth="1.5"/><circle cx="8" cy="15" r="2" stroke="currentColor" strokeWidth="1.5"/></svg>;
+}
+
+export function CanvasIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><rect x="3" y="3" width="14" height="14" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><path d="M7 3v14M13 3v14M3 7h14M3 13h14" stroke="currentColor" strokeWidth="1.5" opacity="0.45"/></svg>;
+}
+
+export function ExportIcon(props: EditorIconProps) {
+  const { size = 14, ...rest } = props;
+  return <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden focusable="false" {...rest}><path d="M8 2v8m0 0L5 7m3 3l3-3M3 13h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+}
+
+export function UndoIcon(props: EditorIconProps) {
+  const { size = 15, ...rest } = props;
+  return <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden focusable="false" {...rest}><path d="M3 7h6.5a3.5 3.5 0 010 7H6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/><path d="M5.5 4.5L3 7l2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+}
+
+export function RedoIcon(props: EditorIconProps) {
+  const { size = 15, ...rest } = props;
+  return <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden focusable="false" {...rest}><path d="M13 7H6.5a3.5 3.5 0 000 7H10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/><path d="M10.5 4.5L13 7l-2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+}
+
+export function PlayIcon(props: EditorIconProps) {
+  const { size = 14, ...rest } = props;
+  return <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden focusable="false" {...rest}><path d="M4 2.8v8.4c0 .8.9 1.3 1.6.9l6.6-4.2c.6-.4.6-1.4 0-1.8L5.6 1.9c-.7-.4-1.6.1-1.6.9z" fill="currentColor"/></svg>;
+}
+
+export function PauseIcon(props: EditorIconProps) {
+  const { size = 14, ...rest } = props;
+  return <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden focusable="false" {...rest}><rect x="3" y="2.5" width="3" height="9" rx="1" fill="currentColor"/><rect x="8" y="2.5" width="3" height="9" rx="1" fill="currentColor"/></svg>;
+}
+
+export function ChevronDownIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M5 7.5l5 5 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+}
+
+export function BackIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M13 4l-6 6 6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+}
+
+export function InfoIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><circle cx="10" cy="10" r="7" stroke="currentColor" strokeWidth="1.5"/><path d="M10 9v4M10 6.5v.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>;
+}

--- a/components/EffectsPanel.tsx
+++ b/components/EffectsPanel.tsx
@@ -1,11 +1,50 @@
 'use client';
 
 import { useState } from 'react';
-import { useSceneStore } from '@/store/useSceneStore';
+import { DndContext, PointerSensor, closestCenter, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useSceneStore, type ActiveEffect } from '@/store/useSceneStore';
 import { effectList, getEffect, effectDefaults } from '@/effects';
 import { ControlRow } from './Controls';
+import { useMobileInteractions } from './MobileInteractions';
+
+function MobileEffectCard({
+  effect,
+  onToggle,
+  onRemove,
+  onValue,
+}: {
+  effect: ActiveEffect;
+  onToggle: () => void;
+  onRemove: () => void;
+  onValue: (key: string, value: unknown) => void;
+}) {
+  const def = getEffect(effect.effectId);
+  const [confirming, setConfirming] = useState(false);
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: effect.instanceId });
+  if (!def) return null;
+  return (
+    <div ref={setNodeRef} className={`effect-card mobile-effect-card ${effect.enabled ? '' : 'disabled'} ${isDragging ? 'is-dragging' : ''}`} style={{ transform: CSS.Transform.toString(transform), transition }}>
+      <div className="effect-card-head">
+        <button className="mobile-effect-grip" aria-label={`Reorder ${def.meta.name}`} {...attributes} {...listeners}>⠿</button>
+        <span className="effect-title">{def.meta.name}</span>
+        <button className="icon-btn" aria-label={effect.enabled ? `Disable ${def.meta.name}` : `Enable ${def.meta.name}`} onClick={onToggle}>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M1.5 8s2.5-4.5 6.5-4.5S14.5 8 14.5 8 12 12.5 8 12.5 1.5 8 1.5 8z" stroke="currentColor" strokeWidth="1.3"/><circle cx="8" cy="8" r="2" stroke="currentColor" strokeWidth="1.3"/></svg>
+        </button>
+        <button className={`icon-btn ${confirming ? 'danger' : ''}`} aria-label={confirming ? `Confirm remove ${def.meta.name}` : `Remove ${def.meta.name}`} onClick={() => confirming ? onRemove() : setConfirming(true)} onBlur={() => setConfirming(false)}>
+          {confirming ? <span className="mobile-remove-confirm">Remove?</span> : <span aria-hidden="true">×</span>}
+        </button>
+      </div>
+      <div className="effect-card-body">
+        {def.controls.map((control) => <ControlRow key={control.key} def={control} value={effect.values[control.key]} onChange={(value) => onValue(control.key, value)} />)}
+      </div>
+    </div>
+  );
+}
 
 export default function EffectsPanel() {
+  const mobile = useMobileInteractions();
   const effects = useSceneStore((s) => s.effects);
   const addEffect = useSceneStore((s) => s.addEffect);
   const removeEffect = useSceneStore((s) => s.removeEffect);
@@ -14,6 +53,14 @@ export default function EffectsPanel() {
   const setEffectValue = useSceneStore((s) => s.setEffectValue);
   const [pick, setPick] = useState(effectList[0]?.meta.id ?? '');
   const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+
+  const finishMobileDrag = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    const from = effects.findIndex((effect) => effect.instanceId === active.id);
+    const to = effects.findIndex((effect) => effect.instanceId === over.id);
+    if (from >= 0 && to >= 0) reorderEffects(from, to);
+  };
 
   return (
     <>
@@ -26,7 +73,23 @@ export default function EffectsPanel() {
           <button className="btn" onClick={() => pick && addEffect(pick, effectDefaults(pick))}>Add</button>
         </div>
 
-        {effects.map((e, i) => {
+        {mobile ? (
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={finishMobileDrag}>
+            <SortableContext items={effects.map((effect) => effect.instanceId)} strategy={verticalListSortingStrategy}>
+              <div className="mobile-effects-list">
+                {effects.map((effect) => (
+                  <MobileEffectCard
+                    key={effect.instanceId}
+                    effect={effect}
+                    onToggle={() => toggleEffect(effect.instanceId)}
+                    onRemove={() => removeEffect(effect.instanceId)}
+                    onValue={(key, value) => setEffectValue(effect.instanceId, key, value)}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        ) : effects.map((e, i) => {
           const def = getEffect(e.effectId);
           if (!def) return null;
           return (

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -5,6 +5,7 @@ import { useSceneStore } from '@/store/useSceneStore';
 import { getRendererInstance } from '@/lib/rendererInstance';
 import { BASE_PATH, IS_STATIC_EXPORT } from '@/lib/paths';
 import { supportsWebCodecs, encodeMp4WebCodecs } from '@/lib/webcodecsExport';
+import { countDemoSlotsInUse } from '@/lib/demoUsage';
 
 // An export artifact: server files carry a /exports url; WebCodecs results are
 // local Blobs (url is an object URL for the download link).
@@ -51,6 +52,7 @@ export default function ExportDialog({ onClose }: { onClose: () => void }) {
   const height = useSceneStore((s) => s.height);
   const customW = useSceneStore((s) => s.customW);
   const customH = useSceneStore((s) => s.customH);
+  const demoSlots = useSceneStore(countDemoSlotsInUse);
   const [format, setFormat] = useState<Fmt>('mp4');
   const [res, setRes] = useState<Res>('1080p');
   const [phase, setPhase] = useState<Phase>('idle');
@@ -62,6 +64,7 @@ export default function ExportDialog({ onClose }: { onClose: () => void }) {
   const [saving, setSaving] = useState(false);
   const [savedTo, setSavedTo] = useState<string | null>(null);
   const [saveErr, setSaveErr] = useState('');
+  const [confirmDemo, setConfirmDemo] = useState(false);
 
   // File System Access API — Chromium (Edge/Chrome) only. Lets the user pick a
   // destination folder; falls back to the download links when unavailable.
@@ -112,6 +115,7 @@ export default function ExportDialog({ onClose }: { onClose: () => void }) {
   };
 
   const run = async () => {
+    setConfirmDemo(false);
     const s = store.getState();
     const renderer = getRendererInstance();
     if (!renderer) { setErr('Renderer not ready'); setPhase('error'); return; }
@@ -275,8 +279,19 @@ npm run dev`}</code></pre>
             })()}
           </div>
 
-          {phase === 'idle' && (
-            <button className="btn primary full" onClick={run}>Start export</button>
+          {phase === 'idle' && !confirmDemo && (
+            <button className="btn primary full" onClick={() => demoSlots > 0 ? setConfirmDemo(true) : run()}>Start export</button>
+          )}
+
+          {phase === 'idle' && confirmDemo && (
+            <div className="export-demo-warning" role="alert">
+              <strong>{demoSlots} demo {demoSlots === 1 ? 'slot is' : 'slots are'} still in use</strong>
+              <p>Demo images will appear in the exported file unless you replace them in Media.</p>
+              <div className="export-demo-actions">
+                <button className="btn" onClick={() => setConfirmDemo(false)}>Cancel</button>
+                <button className="btn primary" onClick={run}>Export anyway</button>
+              </div>
+            </div>
           )}
 
           {phase === 'preparing' && <div className="progress"><span>Preparing videos…</span></div>}

--- a/components/HistoryControls.tsx
+++ b/components/HistoryControls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useHistoryStore } from '@/store/useHistoryStore';
+import { RedoIcon, UndoIcon } from './EditorIcons';
 
 // Undo / redo, floating over the stage. It sits here rather than in the
 // transport row because it acts on the scene, not on the clock — and the stage
@@ -20,7 +21,7 @@ export default function HistoryControls() {
         title="Undo (Ctrl/⌘Z)"
         aria-label="Undo"
       >
-        <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><path d="M3 7h6.5a3.5 3.5 0 010 7H6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/><path d="M5.5 4.5L3 7l2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+        <UndoIcon size={15} />
       </button>
       <span className="stage-hist-sep" />
       <button
@@ -30,7 +31,7 @@ export default function HistoryControls() {
         title="Redo (Ctrl/⌘⇧Z)"
         aria-label="Redo"
       >
-        <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><path d="M13 7H6.5a3.5 3.5 0 000 7H10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/><path d="M10.5 4.5L13 7l-2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+        <RedoIcon size={15} />
       </button>
     </div>
   );

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -2,26 +2,27 @@
 
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
+import { AddIcon, BoardIcon, LibraryIcon, MoonIcon, ProjectsIcon, SunIcon, ThreeDIcon, WebIcon } from './EditorIcons';
 
 const NAV = [
   { id: 'projects', label: 'Projects', icon: (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M2.75 6.25A1.5 1.5 0 014.25 4.75h3l1.5 1.75h6a1.5 1.5 0 011.5 1.5v6.25a1.5 1.5 0 01-1.5 1.5h-10.5a1.5 1.5 0 01-1.5-1.5V6.25z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>
+    <ProjectsIcon />
   ) },
   { id: 'library', label: 'Library', icon: (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="3" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="11" y="3" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="3" y="11" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="11" y="11" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/></svg>
+    <LibraryIcon />
   ) },
   { id: '3d', label: '3D', icon: (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M10 2.5l6.5 3.75v7.5L10 17.5l-6.5-3.75v-7.5L10 2.5z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/><path d="M3.7 6.4L10 10l6.3-3.6M10 10v7.4" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>
+    <ThreeDIcon />
   ) },
   { id: 'web', label: 'Web', icon: (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M7.5 6.5L4 10l3.5 3.5M12.5 6.5L16 10l-3.5 3.5M11 4.5l-2 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+    <WebIcon />
   ) },
   // Board mode — a DOM playground of arranged cards with hover interactions,
   // and the entry point for the drop-in React component export. Its nav id is
   // 'board' rather than the original 'new': the + button at the top of the rail
   // now creates a project, so the two ids would collide. Kept last in the list.
   { id: 'board', label: 'Board', icon: (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="2.5" y="4.5" width="4.5" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5"/><rect x="8" y="4.5" width="4" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5" opacity="0.65"/><rect x="13" y="4.5" width="4.5" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5" opacity="0.4"/></svg>
+    <BoardIcon />
   ) },
 ];
 
@@ -52,7 +53,7 @@ export default function IconRail() {
         </div>
         <button className="rail-item rail-action" onClick={newProject} title="Create a new project">
           <span className="rail-ico">
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M10 4v12M4 10h12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/></svg>
+            <AddIcon />
           </span>
           <span className="rail-label">New</span>
         </button>
@@ -72,9 +73,9 @@ export default function IconRail() {
         >
           <span className="rail-ico">
             {theme === 'dark' ? (
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><circle cx="10" cy="10" r="3.25" stroke="currentColor" strokeWidth="1.5"/><path d="M10 2.5v2M10 15.5v2M2.5 10h2M15.5 10h2M4.7 4.7l1.4 1.4M13.9 13.9l1.4 1.4M15.3 4.7l-1.4 1.4M6.1 13.9l-1.4 1.4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+              <SunIcon />
             ) : (
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M15.7 12.6A6 6 0 017.4 4.3 6.1 6.1 0 1015.7 12.6z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>
+              <MoonIcon />
             )}
           </span>
           <span className="rail-label">{theme === 'dark' ? 'Light' : 'Dark'}</span>

--- a/components/MobileEditor.tsx
+++ b/components/MobileEditor.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import TemplatesCard from './TemplatesCard';
+import AssetsPanel from './AssetsPanel';
+import ScenePanel from './ScenePanel';
+import EffectsPanel from './EffectsPanel';
+import CanvasPanel from './CanvasPanel';
+import ProjectsPanel from './ProjectsPanel';
+import HistoryControls from './HistoryControls';
+import MobileTransport from './MobileTransport';
+import ExportDialog from './ExportDialog';
+import { useUIStore } from '@/store/useUIStore';
+import { useProjectStore } from '@/store/useProjectStore';
+import { useSceneStore } from '@/store/useSceneStore';
+import { AdjustIcon, BackIcon, CanvasIcon, ChevronDownIcon, ExportIcon, InfoIcon, LibraryIcon, MediaIcon, ProjectsIcon } from './EditorIcons';
+import { MobileInteractionProvider } from './MobileInteractions';
+
+const PreviewStage = dynamic(() => import('./PreviewStage'), { ssr: false });
+
+type Tab = 'templates' | 'media' | 'adjust' | 'canvas';
+
+const NAV: { id: Tab | 'export'; label: string; icon: React.ReactNode }[] = [
+  { id: 'templates', label: 'Templates', icon: <LibraryIcon /> },
+  { id: 'media', label: 'Media', icon: <MediaIcon /> },
+  { id: 'adjust', label: 'Adjust', icon: <AdjustIcon /> },
+  { id: 'canvas', label: 'Canvas', icon: <CanvasIcon /> },
+  { id: 'export', label: 'Export', icon: <ExportIcon size={20} /> },
+];
+
+export default function MobileEditor() {
+  const tab = useUIStore((s) => s.mobileTab);
+  const panelOpen = useUIStore((s) => s.mobilePanelOpen);
+  const projectsOpen = useUIStore((s) => s.mobileProjectsOpen);
+  const setTab = useUIStore((s) => s.setMobileTab);
+  const setPanelOpen = useUIStore((s) => s.setMobilePanelOpen);
+  const setProjectsOpen = useUIStore((s) => s.setMobileProjectsOpen);
+  const projects = useProjectStore((s) => s.projects);
+  const activeId = useProjectStore((s) => s.activeId);
+  const trackCount = useSceneStore((s) => s.tracks.length);
+  const [exportOpen, setExportOpen] = useState(false);
+  const [desktopNotice, setDesktopNotice] = useState(false);
+  const activeProject = projects.find((project) => project.id === activeId);
+
+  const selectTab = (id: Tab | 'export') => {
+    if (id === 'export') {
+      setExportOpen(true);
+      return;
+    }
+    if (id === tab && panelOpen) {
+      setPanelOpen(false);
+      return;
+    }
+    setTab(id);
+  };
+
+  return (
+    <MobileInteractionProvider>
+    <div className={`mobile-editor ${panelOpen ? 'mobile-panel-is-open' : 'mobile-panel-is-closed'}`}>
+      <header className="mobile-topbar">
+        <button className="mobile-project-button" onClick={() => setProjectsOpen(true)} aria-label="Open projects">
+          <ProjectsIcon size={18} />
+          <span>{activeProject?.name ?? 'Projects'}</span>
+          <ChevronDownIcon size={12} />
+        </button>
+        <div className="mobile-top-actions">
+          <HistoryControls />
+          <button className="mobile-icon-button" onClick={() => setDesktopNotice(true)} aria-label="Desktop tools information">
+            <InfoIcon size={18} />
+          </button>
+        </div>
+      </header>
+
+      <main className="stage-col mobile-stage">
+        <PreviewStage />
+      </main>
+
+      <MobileTransport />
+
+      <section className="mobile-panel" aria-label={`${tab} controls`}>
+        <div className="mobile-panel-handle" aria-hidden="true" />
+        <div className="mobile-panel-scroll">
+          {tab === 'templates' && (
+            <TemplatesCard
+              customPresetsEnabled={false}
+              onSelect={() => setPanelOpen(false)}
+            />
+          )}
+          {tab === 'media' && <AssetsPanel />}
+          {tab === 'adjust' && (
+            <div className="mobile-composed-panel">
+              {trackCount > 1 && <div className="mobile-desktop-hint">This project has {trackCount} layers. Manage layers and their timeline on desktop.</div>}
+              <ScenePanel />
+              <div className="hairline" />
+              <EffectsPanel />
+            </div>
+          )}
+          {tab === 'canvas' && (
+            <div className="mobile-composed-panel">
+              <CanvasPanel />
+              <div className="mobile-desktop-hint">3D, Web and Board tools are available on desktop.</div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <nav className="mobile-bottom-nav" aria-label="Editor sections">
+        {NAV.map((item) => (
+          <button
+            key={item.id}
+            className={`mobile-nav-item ${item.id === tab && panelOpen ? 'active' : ''} ${item.id === 'export' ? 'mobile-nav-export' : ''}`}
+            onClick={() => selectTab(item.id)}
+            aria-current={item.id === tab && panelOpen ? 'page' : undefined}
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </button>
+        ))}
+      </nav>
+
+      {projectsOpen && (
+        <div className="mobile-projects-screen">
+          <header className="mobile-subpage-head">
+            <button className="mobile-icon-button" onClick={() => setProjectsOpen(false)} aria-label="Back to editor">
+              <BackIcon />
+            </button>
+            <strong>Projects</strong>
+            <span />
+          </header>
+          <ProjectsPanel onProjectOpen={() => setProjectsOpen(false)} />
+        </div>
+      )}
+
+      {desktopNotice && (
+        <div className="mobile-notice-backdrop" onClick={() => setDesktopNotice(false)}>
+          <div className="mobile-notice" role="dialog" aria-modal="true" aria-labelledby="desktop-tools-title" onClick={(event) => event.stopPropagation()}>
+            <strong id="desktop-tools-title">Desktop tools</strong>
+            <p>3D, Web, Board and advanced layer timeline editing need a larger screen. Your projects remain available when you return on desktop.</p>
+            <button className="btn primary full" onClick={() => setDesktopNotice(false)}>Got it</button>
+          </div>
+        </div>
+      )}
+
+      {exportOpen && <ExportDialog onClose={() => setExportOpen(false)} />}
+    </div>
+    </MobileInteractionProvider>
+  );
+}

--- a/components/MobileInteractions.tsx
+++ b/components/MobileInteractions.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+const MobileInteractionContext = createContext(false);
+
+export function MobileInteractionProvider({ children }: { children: React.ReactNode }) {
+  return <MobileInteractionContext.Provider value>{children}</MobileInteractionContext.Provider>;
+}
+
+export function useMobileInteractions() {
+  return useContext(MobileInteractionContext);
+}

--- a/components/MobileSheet.tsx
+++ b/components/MobileSheet.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function MobileSheet({
+  title,
+  children,
+  onClose,
+}: {
+  title: string;
+  children: React.ReactNode;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div className="mobile-sheet-backdrop" onPointerDown={(event) => { event.stopPropagation(); onClose(); }}>
+      <section
+        className="mobile-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <div className="mobile-sheet-grip" aria-hidden="true" />
+        <header className="mobile-sheet-head">
+          <strong>{title}</strong>
+          <button className="mobile-sheet-close" onClick={onClose} aria-label="Close">×</button>
+        </header>
+        <div className="mobile-sheet-body">{children}</div>
+      </section>
+    </div>
+  );
+}

--- a/components/MobileTransport.tsx
+++ b/components/MobileTransport.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useSceneStore } from '@/store/useSceneStore';
+import { PauseIcon, PlayIcon } from './EditorIcons';
+
+function fmt(seconds: number) {
+  const safe = Math.max(0, seconds);
+  const minutes = Math.floor(safe / 60);
+  const remainder = Math.floor(safe % 60).toString().padStart(2, '0');
+  return `${minutes}:${remainder}`;
+}
+
+export default function MobileTransport() {
+  const frame = useSceneStore((s) => s.frame);
+  const fps = useSceneStore((s) => s.fps);
+  const duration = useSceneStore((s) => s.duration);
+  const playing = useSceneStore((s) => s.playing);
+  const setPlaying = useSceneStore((s) => s.setPlaying);
+  const setFrame = useSceneStore((s) => s.setFrame);
+  const totalFrames = Math.max(1, Math.round(duration * fps));
+
+  return (
+    <div className="mobile-transport" aria-label="Playback controls">
+      <button
+        className="mobile-play"
+        onClick={() => setPlaying(!playing)}
+        aria-label={playing ? 'Pause' : 'Play'}
+      >
+        {playing ? (
+          <PauseIcon size={18} />
+        ) : (
+          <PlayIcon size={18} />
+        )}
+      </button>
+      <span className="mobile-time">{fmt(frame / fps)}</span>
+      <input
+        className="mobile-scrubber"
+        type="range"
+        min={0}
+        max={totalFrames - 1}
+        step={1}
+        value={frame}
+        aria-label="Timeline"
+        onChange={(event) => {
+          setPlaying(false);
+          setFrame(Number(event.target.value));
+        }}
+      />
+      <span className="mobile-time mobile-time-total">{fmt(duration)}</span>
+    </div>
+  );
+}

--- a/components/PreviewStage.tsx
+++ b/components/PreviewStage.tsx
@@ -8,7 +8,7 @@ import { useSceneStore } from '@/store/useSceneStore';
 import { getTemplate } from '@/templates';
 
 export default function PreviewStage() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<IRenderer | null>(null);
   const rafRef = useRef<number>(0);
   const anchorTimeRef = useRef<number>(0);   // wall-clock at playback start
@@ -16,6 +16,10 @@ export default function PreviewStage() {
   const lastRenderedFrameRef = useRef<number | null>(null);
   const dirtyRef = useRef<boolean>(true);    // a paused preview redraws only when this is set
   const lastPlayingRef = useRef<boolean>(true);
+  // React Strict Mode deliberately starts, cleans up and starts effects again
+  // in development. The renderer import is asynchronous, so an obsolete start
+  // must not claim (and later force-loss) the canvas owned by the newer one.
+  const initGenerationRef = useRef(0);
 
   const width = useSceneStore((s) => s.width);
   const height = useSceneStore((s) => s.height);
@@ -29,12 +33,21 @@ export default function PreviewStage() {
   // layer would swap in the single-motion 3D renderer and the other layers would
   // vanish.
   const engine = useSceneStore((s) =>
-    s.tracks.length > 1 ? 'pixi' : getTemplate(s.activeTemplateId).meta.engine ?? 'pixi',
+    s.tracks.some((track) => track.visible && getTemplate(track.templateId).meta.engine === 'webgl')
+      ? 'webgl'
+      : 'pixi',
   );
 
   useEffect(() => {
+    const initGeneration = ++initGenerationRef.current;
     let mounted = true;
     let renderer: IRenderer | null = null;
+    const canvas = document.createElement('canvas');
+    canvas.className = 'stage-canvas';
+    // The canvas belongs to this exact renderer generation. Keeping it in a
+    // local variable prevents an obsolete async Pixi init/cleanup from ever
+    // claiming the canvas created for Three (or vice versa).
+    stageRef.current?.replaceChildren(canvas);
 
     // Render only when there's something new to show: while playing (frame
     // advancing), or once after any state/texture change while paused. An idle
@@ -92,10 +105,11 @@ export default function PreviewStage() {
       } else {
         renderer = new SceneRenderer();
       }
+      if (!mounted || initGeneration !== initGenerationRef.current) return;
       // async texture loads (images/videos) also need a redraw when they arrive
       renderer.onDirty = () => { dirtyRef.current = true; };
-      await renderer.init(canvasRef.current!);
-      if (!mounted) { renderer.destroy(); return; }
+      await renderer.init(canvas);
+      if (!mounted || initGeneration !== initGenerationRef.current) { renderer.destroy(); return; }
       rendererRef.current = renderer;
       setRendererInstance(renderer);
       dirtyRef.current = true;
@@ -110,6 +124,7 @@ export default function PreviewStage() {
       setRendererInstance(null);
       rendererRef.current = null;
       renderer?.destroy();
+      if (canvas.parentNode) canvas.remove();
     };
   }, [engine]);
 
@@ -120,8 +135,6 @@ export default function PreviewStage() {
   }, [width, height]);
 
   return (
-    <div className="stage-wrap">
-      <canvas key={engine} ref={canvasRef} className="stage-canvas" />
-    </div>
+    <div ref={stageRef} className="stage-wrap" />
   );
 }

--- a/components/ProjectsPanel.tsx
+++ b/components/ProjectsPanel.tsx
@@ -16,7 +16,7 @@ function ago(ms: number): string {
   return d === 1 ? 'yesterday' : `${d} days ago`;
 }
 
-export default function ProjectsPanel() {
+export default function ProjectsPanel({ onProjectOpen }: { onProjectOpen?: () => void } = {}) {
   const projects = useProjectStore((s) => s.projects);
   const activeId = useProjectStore((s) => s.activeId);
   const open = useProjectStore((s) => s.open);
@@ -36,6 +36,7 @@ export default function ProjectsPanel() {
     create(newName.trim() || `Project ${projects.length + 1}`);
     setNaming(false);
     setNewName('');
+    onProjectOpen?.();
   };
 
   const commitRename = (id: string) => {
@@ -78,7 +79,7 @@ export default function ProjectsPanel() {
               ) : (
                 <button
                   className="prj-open"
-                  onClick={() => open(p.id)}
+                  onClick={() => { open(p.id); onProjectOpen?.(); }}
                   title={isActive ? 'Project open' : 'Open project'}
                 >
                   <span className="prj-name">{p.name}</span>

--- a/components/ScenePanel.tsx
+++ b/components/ScenePanel.tsx
@@ -1,13 +1,15 @@
 'use client';
 
+import { useState } from 'react';
 import { useSceneStore } from '@/store/useSceneStore';
-import { getTemplate, templateList } from '@/templates';
-import { ControlRow } from './Controls';
+import { catalogTemplateList, getTemplate } from '@/templates';
+import { ControlRow, controlVisible } from './Controls';
 import EasingPanel from './EasingPanel';
 import TrackInspector from './TrackInspector';
 
 // Renders the SCENE + TIMING sections (no card wrapper — the page composes cards).
 export default function ScenePanel() {
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const activeTemplateId = useSceneStore((s) => s.activeTemplateId);
   const values = useSceneStore((s) => s.values);
   const setValue = useSceneStore((s) => s.setValue);
@@ -20,6 +22,11 @@ export default function ScenePanel() {
   );
 
   const template = getTemplate(activeTemplateId);
+  const visibleControls = template.controls.filter((def) => controlVisible(def, values));
+  const primaryControls = visibleControls.filter((def) => !def.advanced);
+  const advancedControls = visibleControls.filter((def) => def.advanced);
+  const sections = ['Layout', 'Motion', 'Depth', 'Finish'] as const;
+  const hasSections = primaryControls.some((def) => def.section);
 
   return (
     <>
@@ -31,7 +38,10 @@ export default function ScenePanel() {
           onChange={(e) => setActiveTemplate(e.target.value)}
           style={{ paddingRight: 22 }}
         >
-          {templateList.map((t) => <option key={t.meta.id} value={t.meta.id}>{t.meta.name}</option>)}
+          {template.meta.catalogHidden && (
+            <option value={template.meta.id}>{template.meta.name} (hidden)</option>
+          )}
+          {catalogTemplateList.map((t) => <option key={t.meta.id} value={t.meta.id}>{t.meta.name}</option>)}
         </select>
       </div>
       <div className="section-body">
@@ -40,9 +50,31 @@ export default function ScenePanel() {
         {trackCount > 1 && (
           <div className="ctl-hint">Editing the motion of <b>{activeTrackName}</b>.</div>
         )}
-        {template.controls.map((def) => (
+        {hasSections ? sections.map((section) => {
+          const controls = primaryControls.filter((def) => (def.section ?? 'Layout') === section);
+          if (!controls.length) return null;
+          return <div className="ctl-section" key={section}>
+            <div className="ctl-section-title">{section}</div>
+            {controls.map((def) => <ControlRow key={def.key} def={def} value={values[def.key]} onChange={(val) => setValue(def.key, val)} />)}
+          </div>;
+        }) : primaryControls.map((def) => (
           <ControlRow key={def.key} def={def} value={values[def.key]} onChange={(val) => setValue(def.key, val)} />
         ))}
+        {advancedControls.length > 0 && (
+          <div className="ctl-advanced">
+            <button
+              type="button"
+              className="ctl-advanced-toggle"
+              aria-expanded={advancedOpen}
+              onClick={() => setAdvancedOpen((open) => !open)}
+            >
+              Advanced settings <span>{advancedOpen ? '−' : '+'}</span>
+            </button>
+            {advancedOpen && advancedControls.map((def) => (
+              <ControlRow key={def.key} def={def} value={values[def.key]} onChange={(val) => setValue(def.key, val)} />
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="hairline" />

--- a/components/TemplateThumb.tsx
+++ b/components/TemplateThumb.tsx
@@ -12,6 +12,7 @@ const THUMB_FRAME = 40;              // ~1.3s in — useful idle pose
 const PREVIEW_FPS = 30;
 const CTX_BASE = { fps: 30, width: 810, height: 1080, duration: 8, totalFrames: 240 }; // 3:4 preview space, nominal 8s clip
 const TEX_W = 480, TEX_H = 600;      // placeholder texture proportions
+const DRAW_BUDGET = 28;              // max cards a thumbnail paints; layout still uses the real count
 const SPRITE_BASE = 340;
 
 interface CardPose {
@@ -84,13 +85,22 @@ export default function TemplateThumb({ template }: { template: Template }) {
 
   const poses = useMemo<CardPose[]>(() => {
     const v = defaultsFor(template.meta.id);
-    const count = Math.max(1, Math.min(20, Math.round(v.count ?? 6)));
+    // The REAL count. It is a layout input, not a drawing cost: lattice families
+    // derive their columns, rows and wrap period from it, so clamping it here
+    // used to lay out a different grid than the stage — measured at up to
+    // 2645px of divergence on Grid, on an 810px-wide canvas. The draw budget is
+    // enforced further down instead, by showing fewer of the correct cards.
+    const count = Math.max(1, Math.round(v.count ?? 6));
     const norm = SPRITE_BASE / Math.max(TEX_W, TEX_H);
     const ease = resolveEasing(easingFor(template.meta.id));
     const ctx = {
       ...CTX_BASE,
       ease,
       easedPhase: (phase: number) => { const b = Math.floor(phase); return b + ease(phase - b); },
+      // The thumbnail draws every card at the placeholder proportions, so a
+      // lattice template has to space them by THAT shape or its gutters come out
+      // uneven here even when they are right on the stage.
+      cardAspect: TEX_W / TEX_H,
     };
     const out: CardPose[] = [];
     for (let i = 0; i < count; i++) {
@@ -106,7 +116,21 @@ export default function TemplateThumb({ template }: { template: Template }) {
         r: (Math.min(w, h) / 2) * Math.max(0, Math.min(1, (v.cornerRadius ?? 0) / 100)),
       });
     }
-    return out;
+
+    // Draw budget. A thumbnail is a few hundred px across and the catalogue runs
+    // to 140 cards, so keep the DOM bounded — but drop whole cards rather than
+    // move them. Off-canvas ones go first, then the furthest from centre, so what
+    // survives is what a viewer would actually have seen.
+    if (out.length <= DRAW_BUDGET) return out;
+    const halfW = CTX_BASE.width / 2, halfH = CTX_BASE.height / 2;
+    const offCanvas = (p: CardPose) =>
+      Math.abs(p.x) - p.w / 2 > halfW || Math.abs(p.y) - p.h / 2 > halfH;
+    return out
+      .map((p, i) => ({ p, i, off: offCanvas(p) ? 1 : 0, d: Math.hypot(p.x, p.y) }))
+      .sort((a, b) => a.off - b.off || a.d - b.d)
+      .slice(0, DRAW_BUDGET)
+      .sort((a, b) => a.i - b.i)
+      .map((e) => e.p);
   }, [frame, template]);
 
   // scale preview space → thumbnail space (thumb is 3:4 like CTX)

--- a/components/TemplatesCard.tsx
+++ b/components/TemplatesCard.tsx
@@ -162,6 +162,9 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
                     aria-controls={panelId}
                   >
                     <span className="tpl-name">{name}</span>
+                    {/* A family is new if any of its presets is, so the marker
+                        shows on the collapsed list without opening the group. */}
+                    {items.some((t) => t.meta.isNew) && <span className="tpl-new-inline">NEW</span>}
                     <span className="tpl-accordion-chevron"><Chevron /></span>
                   </button>
                   {isOpen && (

--- a/components/TemplatesCard.tsx
+++ b/components/TemplatesCard.tsx
@@ -118,6 +118,7 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
                 onClick={() => pick(t.meta.id)}
               >
                 <TemplateThumb template={t} />
+                {t.meta.isNew && <span className="tpl-new">NEW</span>}
                 <span className="tpl-card-label">{t.meta.name}</span>
               </button>
             ))}
@@ -172,6 +173,7 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
                           onClick={() => setActiveTemplate(t.meta.id)}
                         >
                           <TemplateThumb template={t} />
+                          {t.meta.isNew && <span className="tpl-new">NEW</span>}
                           <span className="tpl-card-label">{t.meta.name}</span>
                         </button>
                       ))}

--- a/components/TemplatesCard.tsx
+++ b/components/TemplatesCard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useSceneStore } from '@/store/useSceneStore';
-import { templateList, templateGroups, getTemplate } from '@/templates';
+import { catalogTemplateList, templateList, templateGroups, getTemplate } from '@/templates';
 import TemplateThumb from './TemplateThumb';
 import { ControlRow } from './Controls';
 
@@ -17,7 +17,15 @@ const Chevron = ({ dir = 'right' }: { dir?: 'right' | 'left' }) => (
 // controls in. Selecting a template opens its sliders right here, over the same
 // left bar, keeping the search and back that already exist. Off (2D/web), the
 // card behaves exactly as before: selecting only sets the active template.
-export default function TemplatesCard({ controlsInline = false }: { controlsInline?: boolean }) {
+export default function TemplatesCard({
+  controlsInline = false,
+  onSelect,
+  customPresetsEnabled = true,
+}: {
+  controlsInline?: boolean;
+  onSelect?: () => void;
+  customPresetsEnabled?: boolean;
+}) {
   const activeTemplateId = useSceneStore((s) => s.activeTemplateId);
   const setActiveTemplate = useSceneStore((s) => s.setActiveTemplate);
   const values = useSceneStore((s) => s.values);
@@ -36,7 +44,13 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
   const [presetName, setPresetName] = useState('');
 
   // saved presets live in localStorage — pick them up after mount
-  useEffect(() => { loadCustomPresets(); }, [loadCustomPresets]);
+  useEffect(() => {
+    if (customPresetsEnabled) loadCustomPresets();
+  }, [customPresetsEnabled, loadCustomPresets]);
+
+  // Mobile deliberately exposes only the template catalogue. Keeping this as
+  // a derived value prevents custom state from leaking in if the prop changes.
+  const activeTab = customPresetsEnabled ? tab : 'templates';
 
   const activeMeta = templateList.find((t) => t.meta.id === activeTemplateId)?.meta;
 
@@ -44,6 +58,12 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
   const pick = (id: string) => {
     setActiveTemplate(id);
     if (controlsInline) setShowControls(true);
+    onSelect?.();
+  };
+
+  const pickCustom = (id: string) => {
+    applyCustomPreset(id);
+    onSelect?.();
   };
 
   const commitPreset = () => {
@@ -56,29 +76,31 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
 
   const q = query.trim().toLowerCase();
   const searching = q.length > 0;
-  const matches = templateList.filter(
+  const matches = catalogTemplateList.filter(
     (t) => t.meta.name.toLowerCase().includes(q) || t.meta.group.toLowerCase().includes(q)
   );
   return (
     <section className="card templates">
       <div className="tpl-head">
         <div className="tpl-head-row">
-          <div className="tabs">
-            <button className={`tab ${tab === 'templates' ? 'active' : ''}`} onClick={() => setTab('templates')}>Templates</button>
-            <button className={`tab ${tab === 'custom' ? 'active' : ''}`} onClick={() => setTab('custom')}>Custom</button>
-          </div>
+          {customPresetsEnabled && (
+            <div className="tabs">
+              <button className={`tab ${activeTab === 'templates' ? 'active' : ''}`} onClick={() => setTab('templates')}>Templates</button>
+              <button className={`tab ${activeTab === 'custom' ? 'active' : ''}`} onClick={() => setTab('custom')}>Custom</button>
+            </div>
+          )}
         </div>
 
         <div className="searchbox">
           <span className="ico">
             <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.4"/><path d="M11 11l3 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/></svg>
           </span>
-          <input placeholder={`Search ${templateList.length} templates`} value={query} onChange={(e) => setQuery(e.target.value)} />
+          <input placeholder={`Search ${catalogTemplateList.length} templates`} value={query} onChange={(e) => setQuery(e.target.value)} />
         </div>
       </div>
 
       <div className="tpl-list">
-        {tab === 'custom' ? (
+        {activeTab === 'custom' ? (
           customPresets.length === 0 ? (
             <div className="tpl-group-label">No custom presets yet</div>
           ) : (
@@ -91,8 +113,13 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
                     className="tpl-card tpl-card-custom"
                     role="button"
                     tabIndex={0}
-                    onClick={() => applyCustomPreset(p.id)}
-                    onKeyDown={(e) => { if (e.key === 'Enter') applyCustomPreset(p.id); }}
+                    onClick={() => pickCustom(p.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        pickCustom(p.id);
+                      }
+                    }}
                   >
                     {base && <TemplateThumb template={base} />}
                     <span className="tpl-card-label">{p.name}</span>
@@ -173,7 +200,7 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
                         <button
                           key={t.meta.id}
                           className={`tpl-card ${activeTemplateId === t.meta.id ? 'active' : ''}`}
-                          onClick={() => setActiveTemplate(t.meta.id)}
+                          onClick={() => pick(t.meta.id)}
                         >
                           <TemplateThumb template={t} />
                           {t.meta.isNew && <span className="tpl-new">NEW</span>}
@@ -189,26 +216,28 @@ export default function TemplatesCard({ controlsInline = false }: { controlsInli
         )}
       </div>
 
-      <div className="tpl-foot">
-        {naming ? (
-          <div className="tpl-save-row">
-            <input
-              className="field"
-              autoFocus
-              placeholder={`${activeMeta?.name ?? 'Preset'} custom`}
-              value={presetName}
-              onChange={(e) => setPresetName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') commitPreset();
-                if (e.key === 'Escape') { setNaming(false); setPresetName(''); }
-              }}
-            />
-            <button className="btn solid" onClick={commitPreset}>Save</button>
-          </div>
-        ) : (
-          <button className="btn full" onClick={() => setNaming(true)}>Save as custom</button>
-        )}
-      </div>
+      {customPresetsEnabled && (
+        <div className="tpl-foot">
+          {naming ? (
+            <div className="tpl-save-row">
+              <input
+                className="field"
+                autoFocus
+                placeholder={`${activeMeta?.name ?? 'Preset'} custom`}
+                value={presetName}
+                onChange={(e) => setPresetName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitPreset();
+                  if (e.key === 'Escape') { setNaming(false); setPresetName(''); }
+                }}
+              />
+              <button className="btn solid" onClick={commitPreset}>Save</button>
+            </div>
+          ) : (
+            <button className="btn full" onClick={() => setNaming(true)}>Save as custom</button>
+          )}
+        </div>
+      )}
     </section>
   );
 }

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useSceneStore } from '@/store/useSceneStore';
 import ExportDialog from './ExportDialog';
 import TrackLane from './TrackLane';
+import { ExportIcon, PauseIcon, PlayIcon } from './EditorIcons';
 
 function fmt(sec: number) {
   const s = Math.max(0, sec);
@@ -106,9 +107,9 @@ export default function Timeline({
     <div className="timeline">
       <button className="play-btn" onClick={() => setPlaying(!playing)} title={playing ? 'Pause' : 'Play'}>
         {playing ? (
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><rect x="3" y="2.5" width="3" height="9" rx="1" fill="currentColor"/><rect x="8" y="2.5" width="3" height="9" rx="1" fill="currentColor"/></svg>
+          <PauseIcon size={14} />
         ) : (
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M4 2.8v8.4c0 .8.9 1.3 1.6.9l6.6-4.2c.6-.4.6-1.4 0-1.8L5.6 1.9c-.7-.4-1.6.1-1.6.9z" fill="currentColor"/></svg>
+          <PlayIcon size={14} />
         )}
       </button>
 
@@ -156,7 +157,7 @@ export default function Timeline({
 
       {showExport && (
         <button className="export-btn" onClick={() => setShowExportDialog(true)}>
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M8 2v8m0 0L5 7m3 3l3-3M3 13h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+          <ExportIcon size={14} />
           Export
         </button>
       )}

--- a/components/TrackInspector.tsx
+++ b/components/TrackInspector.tsx
@@ -27,6 +27,8 @@ export default function TrackInspector() {
   const patch = (p: Parameters<typeof patchTrack>[1]) => patchTrack(track.id, p);
   // Which assets this layer draws. An empty list means "all of them".
   const usesAll = track.assetIds.length === 0;
+  const realAssets = assets.filter((asset) => asset.origin !== 'demo');
+  const selectedRealCount = realAssets.filter((asset) => track.assetIds.includes(asset.id)).length;
 
   return (
     <>
@@ -107,12 +109,12 @@ export default function TrackInspector() {
         )}
       </div>
       <div className="section-body">
-        {assets.length === 0 ? (
-          <div className="ctl-hint">No images in the scene.</div>
+        {realAssets.length === 0 ? (
+          <div className="ctl-hint">Add images from the Media tab to assign them to this layer.</div>
         ) : (
           <>
             <div className="trk-assets">
-              {assets.map((a, i) => {
+              {realAssets.map((a, i) => {
                 const on = usesAll || track.assetIds.includes(a.id);
                 return (
                   <button
@@ -127,7 +129,7 @@ export default function TrackInspector() {
               })}
             </div>
             <div className="ctl-hint">
-              {usesAll ? 'Using every image in the scene.' : `${track.assetIds.length} of ${assets.length} selected.`}
+              {usesAll ? 'Using every added image.' : `${selectedRealCount} of ${realAssets.length} selected.`}
             </div>
           </>
         )}

--- a/lib/demoAssets.ts
+++ b/lib/demoAssets.ts
@@ -3,10 +3,47 @@ import { BASE_PATH } from '@/lib/paths';
 // Bundled starter images (public/demo, 1080px long edge) seeded into the
 // asset list so every template opens populated with real photos instead of
 // numbered placeholders. Users can clear/replace them like any upload.
-export const DEMO_ASSETS = Array.from({ length: 12 }, (_, i) => {
+//
+// A second set can stand in for local visual-comparison work via
+// NEXT_PUBLIC_DEMO_SET. It is unset in every shipped build, so the deployed app
+// always serves the bundled photos — the alternate folder is gitignored and
+// never ships. Set it in .env.local and restart the dev server.
+interface DemoSet {
+  dir: string;
+  prefix: string;
+  ext: string;
+  count: number;
+}
+
+const DEMO_SETS: Record<string, DemoSet> = {
+  bundled: { dir: 'demo', prefix: 'demo', ext: 'jpg', count: 12 },
+  arqe: { dir: 'demo-arqe', prefix: 'sample', ext: 'png', count: 10 },
+};
+
+const activeSet = DEMO_SETS[process.env.NEXT_PUBLIC_DEMO_SET ?? ''] ?? DEMO_SETS.bundled;
+
+export const DEMO_ASSETS = Array.from({ length: activeSet.count }, (_, i) => {
   const n = String(i + 1).padStart(2, '0');
   return {
     name: `Demo ${n}`,
-    url: `${BASE_PATH}/demo/demo-${n}.jpg`,
+    url: `${BASE_PATH}/${activeSet.dir}/${activeSet.prefix}-${n}.${activeSet.ext}`,
   };
 });
+
+export function demoSourceForSlot(index: number) {
+  const source = DEMO_ASSETS[((index % DEMO_ASSETS.length) + DEMO_ASSETS.length) % DEMO_ASSETS.length];
+  return { ...source };
+}
+
+// Matches ANY known demo set, not just the active one: a scene saved while one
+// set was active still has to re-seed cleanly after the set is switched, or its
+// images silently fall back to placeholders.
+const DEMO_URL = new RegExp(
+  `/(?:${Object.values(DEMO_SETS).map((s) => s.dir).join('|')})/`
+  + `(?:${Object.values(DEMO_SETS).map((s) => s.prefix).join('|')})`
+  + `-\\d{2}\\.(?:${[...new Set(Object.values(DEMO_SETS).map((s) => s.ext))].join('|')})(?:[?#].*)?$`
+);
+
+export function isDemoAssetSource(asset: { origin?: string; url?: string }): boolean {
+  return asset.origin === 'demo' || DEMO_URL.test(asset.url ?? '');
+}

--- a/lib/demoUsage.ts
+++ b/lib/demoUsage.ts
@@ -1,0 +1,20 @@
+import type { SceneState } from '@/store/useSceneStore';
+import { getTemplate } from '@/templates';
+import { assetIndexForSlot } from '@/lib/motion';
+import { trackAssetIndices } from '@/lib/tracks';
+
+export function countDemoSlotsInUse(scene: Pick<SceneState, 'tracks' | 'assets'>): number {
+  let total = 0;
+  for (const track of scene.tracks) {
+    if (!track.visible || track.opacity <= 0) continue;
+    const pool = trackAssetIndices(track, scene.assets).map((index) => scene.assets[index]).filter(Boolean);
+    const count = Math.max(1, Math.round(track.values.count ?? 6));
+    const repeat = getTemplate(track.templateId).meta.repeatAssets === true;
+    for (let slot = 0; slot < count; slot++) {
+      let asset = pool[assetIndexForSlot(slot, pool.length, repeat)];
+      if (!asset && pool.length > 0) asset = pool[slot % pool.length];
+      if (asset?.origin === 'demo') total++;
+    }
+  }
+  return total;
+}

--- a/lib/r3fSceneBridge.tsx
+++ b/lib/r3fSceneBridge.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useLayoutEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { createPortal, createRoot, extend, type ReconcilerRoot } from '@react-three/fiber';
+import type { Slot3D } from '@/lib/renderer3d';
+
+// R3F is used as a scene-graph reconciler, not as a second renderer. The
+// Motion Studio timeline remains the only clock and SceneRenderer3D remains
+// responsible for render targets, layer composition and export.
+extend({
+  Group: THREE.Group,
+  Mesh: THREE.Mesh,
+  PlaneGeometry: THREE.PlaneGeometry,
+  MeshStandardMaterial: THREE.MeshStandardMaterial,
+});
+
+interface BoxPortalSpec {
+  id: string;
+  container: THREE.Group;
+  count: number;
+  planeGeometry: THREE.PlaneGeometry;
+  bodyGeometry: THREE.BufferGeometry;
+  register: (index: number, slot: Slot3D | null) => void;
+}
+
+function PhysicalCard({
+  index,
+  planeGeometry,
+  bodyGeometry,
+  register,
+}: Omit<BoxPortalSpec, 'id' | 'container' | 'count'> & { index: number }) {
+  const root = useRef<THREE.Group>(null);
+  const front = useRef<THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>>(null);
+  const back = useRef<THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>>(null);
+  const body = useRef<THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>>(null);
+
+  useLayoutEffect(() => {
+    if (!root.current || !front.current || !back.current || !body.current) return;
+    register(index, {
+      mesh: front.current,
+      root: root.current,
+      front: front.current,
+      back: back.current,
+      body: body.current as Slot3D['body'],
+      texW: 480,
+      texH: 600,
+      cornerR: -1,
+      bindKey: '',
+    });
+    return () => register(index, null);
+  }, [index, register]);
+
+  return (
+    <group ref={root} dispose={null}>
+      <mesh ref={body} geometry={bodyGeometry} castShadow receiveShadow>
+        <meshStandardMaterial
+          color={0x24242a}
+          roughness={0.88}
+          metalness={0}
+          transparent
+        />
+      </mesh>
+      <mesh ref={front} geometry={planeGeometry} position-z={0.501} castShadow receiveShadow>
+        <meshStandardMaterial
+          transparent
+          roughness={0.82}
+          metalness={0}
+          emissive={0xffffff}
+          emissiveIntensity={0.28}
+          depthWrite
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      <mesh ref={back} geometry={planeGeometry} position-z={-0.501} rotation-y={Math.PI} castShadow receiveShadow>
+        <meshStandardMaterial color={0x17171b} roughness={0.9} metalness={0} transparent />
+      </mesh>
+    </group>
+  );
+}
+
+function BoxPortal({ spec }: { spec: BoxPortalSpec }) {
+  return createPortal(
+    <group dispose={null}>
+      {Array.from({ length: spec.count }, (_, index) => (
+        <PhysicalCard
+          key={index}
+          index={index}
+          planeGeometry={spec.planeGeometry}
+          bodyGeometry={spec.bodyGeometry}
+          register={spec.register}
+        />
+      ))}
+    </group>,
+    spec.container,
+  );
+}
+
+function ScenePortals({ boxes }: { boxes: BoxPortalSpec[] }) {
+  return <>{boxes.map((spec) => <BoxPortal key={spec.id} spec={spec} />)}</>;
+}
+
+export class R3FSceneBridge {
+  private root: ReconcilerRoot<HTMLCanvasElement> | null = null;
+  private boxes = new Map<string, BoxPortalSpec>();
+
+  async init(
+    canvas: HTMLCanvasElement,
+    renderer: THREE.WebGLRenderer,
+    scene: THREE.Scene,
+    camera: THREE.Camera,
+    width: number,
+    height: number,
+  ) {
+    this.root = createRoot(canvas);
+    await this.root.configure({
+      gl: renderer,
+      scene,
+      camera: camera as THREE.PerspectiveCamera,
+      size: { width, height, top: 0, left: 0 },
+      frameloop: 'never',
+      flat: true,
+      shadows: { enabled: true, type: THREE.PCFShadowMap },
+      dpr: 1,
+    });
+    this.render();
+  }
+
+  upsertBox(spec: BoxPortalSpec) {
+    this.boxes.set(spec.id, spec);
+    this.render();
+  }
+
+  remove(id: string) {
+    if (!this.boxes.delete(id)) return;
+    this.render();
+  }
+
+  private render() {
+    if (!this.root) return;
+    const boxes = [...this.boxes.values()];
+    this.root.render(<ScenePortals boxes={boxes} />);
+  }
+
+  destroy() {
+    this.boxes.clear();
+    this.root?.unmount();
+    this.root = null;
+  }
+}

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -25,6 +25,7 @@ interface Slot {
   texW: number;
   texH: number;
   cornerR: number; // last-applied corner radius fraction, for mask caching
+  bindKey: string; // guards async image/video loads from overwriting a newer slot
 }
 
 // The GPU-side realization of one motion track. Each track owns its own sprite
@@ -57,6 +58,7 @@ export class SceneRenderer {
   private logoSprite: PIXI.Sprite | null = null;
   private placeholder!: PIXI.Texture;
   private textureCache = new Map<string, PIXI.Texture>();
+  private texturePromises = new Map<string, Promise<PIXI.Texture | null>>();
   private croppedCache = new Map<string, PIXI.Texture>(); // cover-crop views over cached base textures
   private videoEls = new Map<string, HTMLVideoElement>();  // live <video> per url, for playback + cleanup
   private exportVideoFrames = new Map<string, { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D; texture: PIXI.Texture }>();
@@ -116,7 +118,18 @@ export class SceneRenderer {
   // Loads via HTMLImageElement instead of PIXI.Assets: uploads are blob: URLs
   // with no file extension, which Assets can't route to a parser (resolves null).
   // Video assets decode into a VideoSource whose texture auto-updates each frame.
-  private async loadTexture(url: string, kind?: string): Promise<PIXI.Texture | null> {
+  private loadTexture(url: string, kind?: string): Promise<PIXI.Texture | null> {
+    const cached = this.textureCache.get(url);
+    if (cached) return Promise.resolve(cached);
+    const pending = this.texturePromises.get(url);
+    if (pending) return pending;
+    const promise = this.decodeTexture(url, kind)
+      .finally(() => { this.texturePromises.delete(url); });
+    this.texturePromises.set(url, promise);
+    return promise;
+  }
+
+  private async decodeTexture(url: string, kind?: string): Promise<PIXI.Texture | null> {
     const cached = this.textureCache.get(url);
     if (cached) return cached;
     try {
@@ -124,6 +137,7 @@ export class SceneRenderer {
         const video = this.videoEls.get(url) ?? createCardVideo(url);
         this.videoEls.set(url, video);
         await whenVideoReady(video); // videoWidth/height valid past here
+        if (!this.ready) return null;
         // updateFPS:0 → re-upload the frame on every render (Ticker-driven).
         const source = new PIXI.VideoSource({ resource: video, autoPlay: true, loop: true, muted: true, updateFPS: 0 });
         const tex = new PIXI.Texture({ source });
@@ -134,6 +148,7 @@ export class SceneRenderer {
       const img = new Image();
       img.src = url;
       await img.decode();
+      if (!this.ready) return null;
       const tex = PIXI.Texture.from(img);
       this.textureCache.set(url, tex);
       return tex;
@@ -218,7 +233,7 @@ export class SceneRenderer {
       label.anchor.set(0.5);
       sprite.addChild(label);
       rt.container.addChild(sprite);
-      rt.slots.push({ sprite, mask, label, texW: 480, texH: 600, cornerR: -1 });
+      rt.slots.push({ sprite, mask, label, texW: 480, texH: 600, cornerR: -1, bindKey: '' });
     }
     while (rt.slots.length > count) {
       const slot = rt.slots.pop()!;
@@ -230,6 +245,11 @@ export class SceneRenderer {
     rt.slots.forEach((slot, i) => {
       let asset = pool[assetIndexForSlot(i, pool.length, repeat)];
       if (!asset && pool.length > 0) asset = pool[i % pool.length];
+      const binding = asset
+        ? `${asset.id}|${asset.url}|${aspect.toFixed(4)}|${asset.crop?.x ?? 0.5},${asset.crop?.y ?? 0.5}`
+        : `placeholder|${i}`;
+      const bindingChanged = slot.bindKey !== binding;
+      slot.bindKey = binding;
       if (!asset || !asset.visible) {
         slot.sprite.texture = this.placeholder;
         slot.sprite.tint = PLACEHOLDER_FILL;
@@ -237,13 +257,21 @@ export class SceneRenderer {
         slot.label.visible = true;
         slot.texW = 480; slot.texH = 600; slot.cornerR = -1;
       } else {
+        if (bindingChanged) {
+          // Never leave the previous template's image visible while a new crop
+          // is decoding. Local/demo files replace this again in the same tick.
+          slot.sprite.texture = this.placeholder;
+          slot.sprite.tint = PLACEHOLDER_FILL;
+          slot.label.text = String(i + 1);
+          slot.label.visible = true;
+        }
         slot.sprite.tint = 0xffffff;
-        slot.label.visible = false;
         const { url, crop, kind } = asset;
         this.loadTexture(url, kind).then((base) => {
-          if (!base || slot.sprite.destroyed) return; // slot may be gone by now
+          if (!base || slot.sprite.destroyed || slot.bindKey !== binding) return;
           const tex = this.croppedView(url, base, aspect, crop);
           slot.sprite.texture = tex;
+          slot.label.visible = false;
           slot.texW = tex.width; slot.texH = tex.height; slot.cornerR = -1;
           this.onDirty?.(); // texture arrived — an idle preview must redraw
         });
@@ -439,6 +467,9 @@ export class SceneRenderer {
         duration: time.localTotal / Math.max(1, s.fps),
         totalFrames: time.localTotal,
         ease, easedPhase,
+        // Resolved the same way the sprites themselves are cropped, so a
+        // lattice template spaces cards by the shape actually on screen.
+        cardAspect: cardAspectFor(template.meta, s.width, s.height, s.cardShape),
       };
 
       for (let i = 0; i < count; i++) {
@@ -577,6 +608,7 @@ export class SceneRenderer {
 
   destroy() {
     this.ready = false;
+    this.texturePromises.clear();
     this.videoEls.forEach((v) => { try { v.pause(); v.removeAttribute('src'); v.load(); } catch { /* noop */ } });
     this.videoEls.clear();
     try { this.app.destroy(true, { children: true, texture: false }); } catch { /* noop */ }

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -406,6 +406,14 @@ export class SceneRenderer3D implements IRenderer {
         slot.mesh.rotation.set(t.rotationX ?? 0, t.rotationY ?? 0, t.rotationZ ?? 0);
         slot.mesh.scale.set(slot.texW * norm * t.scale, slot.texH * norm * t.scale, 1);
         slot.mesh.material.opacity = t.alpha;
+        // A fully opaque plane writes depth, so it genuinely OCCLUDES what sits
+        // behind it. The material is created with depthWrite: false — correct for
+        // blended planes, since a translucent card must not mask its neighbours —
+        // but with it off nothing ever occludes anything, and a closed solid (the
+        // Box family's prism) has no way to hide its own far side. Gating on full
+        // opacity gives real occlusion where it is unambiguous and keeps correct
+        // blending everywhere else.
+        slot.mesh.material.depthWrite = t.alpha > 0.995;
         slot.mesh.visible = t.alpha > 0.001 && t.scale > 0.0001;
       } else {
         // fallback: project the 2D transform onto the z=0 plane

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 import { getTemplate } from '@/templates';
 import { useSceneStore } from '@/store/useSceneStore';
 import { resolveEasing } from '@/lib/easing';
@@ -7,17 +8,75 @@ import { loadImage } from '@/lib/textureLoad';
 import { cardAspectFor, coverCrop, cropKey } from '@/lib/crop';
 import { advanceVideoForExport, createCardVideo, isVideoSource, prepareVideoForSequentialExport } from '@/lib/videoTexture';
 import type { IRenderer } from '@/lib/rendererTypes';
+import type { CameraPose, LayerTransform3D } from '@/lib/types';
+import { resolveTrackTime, trackAssetIndices, type MotionTrack } from '@/lib/tracks';
+import type { SceneState } from '@/store/useSceneStore';
 
 // Shared with the Pixi renderer so control values read identically in px.
 const SPRITE_BASE = 340;
 const PLACEHOLDER_FILL = '#242424';
 const PLACEHOLDER_LABEL = '#555555';
 
-interface Slot3D {
-  mesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
+export interface Slot3D {
+  // Legacy alias retained while old single-track fallback code remains
+  // unreachable below getFrameState's multicamera dispatch.
+  mesh: THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+  root: THREE.Group;
+  front: THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+  back: THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+  body: THREE.Mesh<RoundedBoxGeometry, THREE.MeshStandardMaterial>;
   texW: number;
   texH: number;
   cornerR: number; // cached rounded-corner fraction (-1 = unset)
+  bindKey: string;
+}
+
+// A normalized curved image surface inspired by PMNDRS' public bent-plane
+// example. UVs are untouched, so the same crop is used on a flat or bent card.
+// `sag` is the centre displacement as a fraction of the card width.
+function makeBentPlaneGeometry(sag: number): THREE.PlaneGeometry {
+  const bend = clamp(sag, -0.45, 0.45);
+  const geometry = new THREE.PlaneGeometry(1, 1, 20, 8);
+  if (Math.abs(bend) < 0.0001) return geometry;
+  const halfWidth = 0.5;
+  const a = new THREE.Vector2(-halfWidth, 0);
+  const b = new THREE.Vector2(0, bend);
+  const c = new THREE.Vector2(halfWidth, 0);
+  const ab = new THREE.Vector2().subVectors(a, b);
+  const bc = new THREE.Vector2().subVectors(b, c);
+  const ac = new THREE.Vector2().subVectors(a, c);
+  const radius = (ab.length() * bc.length() * ac.length()) / (2 * Math.abs(ab.cross(ac)));
+  const centre = new THREE.Vector2(0, bend - Math.sign(bend) * radius);
+  const baseAngle = new THREE.Vector2().subVectors(a, centre).angle() - Math.PI / 2;
+  const arc = baseAngle * 2;
+  const uv = geometry.attributes.uv;
+  const position = geometry.attributes.position;
+  const point = new THREE.Vector2();
+  for (let i = 0; i < uv.count; i++) {
+    const ratio = 1 - uv.getX(i);
+    const y = position.getY(i);
+    point.copy(c).rotateAround(centre, arc * ratio);
+    position.setXYZ(i, point.x, y, -point.y);
+  }
+  position.needsUpdate = true;
+  geometry.computeVertexNormals();
+  return geometry;
+}
+
+interface TrackRT3D {
+  scene: THREE.Scene;
+  group: THREE.Group;
+  camera: THREE.PerspectiveCamera | THREE.OrthographicCamera;
+  target: THREE.WebGLRenderTarget;
+  slots: Slot3D[];
+  countSig: number;
+  assetSig: string;
+  active: boolean;
+  opacity: number;
+  blend: MotionTrack['blend'];
+  keyLight: THREE.DirectionalLight;
+  r3fManaged: boolean;
+  r3fVersion: number;
 }
 
 // Rounded-rectangle alpha mask (white on black) for cornerRadius; cached by
@@ -71,17 +130,17 @@ function makePlaceholderTexture(label: string): THREE.CanvasTexture {
   return tex;
 }
 
-// Real-3D renderer for templates with meta.engine === 'webgl'. Implements the
-// same IRenderer contract as the Pixi SceneRenderer, so preview and export are
-// engine-agnostic. M1 scope: cards + solid/gradient-as-solid background; no
-// effects, image/card backgrounds, logo, safe-area, or cornerRadius yet.
+// Hybrid 2D/3D renderer. Every timeline track owns an isolated scene, camera,
+// depth buffer and RGBA render target; a full-screen compositor then applies
+// timeline order, opacity, fades and blend modes before the HUD/export pass.
 export class SceneRenderer3D implements IRenderer {
   onDirty?: () => void;   // preview loop hooks this to redraw once after async loads
   private renderer!: THREE.WebGLRenderer;
   private scene = new THREE.Scene();
   private camera = new THREE.PerspectiveCamera(50, 1, 1, 40000);
-  private slots: Slot3D[] = [];
+  private trackRTs = new Map<string, TrackRT3D>();
   private textureCache = new Map<string, THREE.Texture>();
+  private texturePromises = new Map<string, Promise<THREE.Texture | null>>();
   private croppedCache = new Map<string, THREE.Texture>(); // cover-crop clones (repeat/offset) of cached bases
   private videoEls = new Map<string, HTMLVideoElement>();   // live <video> per url, for playback + cleanup
   private exportVideoFrames = new Map<string, { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D; texture: THREE.CanvasTexture }>();
@@ -89,16 +148,29 @@ export class SceneRenderer3D implements IRenderer {
   private cornerMaps = new Map<string, THREE.CanvasTexture>();
   private gradientTex: THREE.CanvasTexture | null = null;
   private gradientSig = '';
+  private backgroundTex: THREE.CanvasTexture | null = null;
+  private backgroundSig = '';
+  private backgroundGeneration = 0;
   // HUD overlay (logo + safe-area) rendered orthographically on top.
   private hud = new THREE.Scene();
   private hudCam = new THREE.OrthographicCamera(-1, 1, 1, -1, -10, 10);
   private logoMesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial> | null = null;
   private logoUrl = '';
   private safeLine: THREE.LineLoop | null = null;
+  private composeA!: THREE.WebGLRenderTarget;
+  private composeB!: THREE.WebGLRenderTarget;
+  private composeScene = new THREE.Scene();
+  private composeCam = new THREE.OrthographicCamera(-1, 1, 1, -1, -1, 1);
+  private composeQuad!: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
+  private outputScene = new THREE.Scene();
+  private outputQuad!: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
+  private cardPlaneGeometry = new THREE.PlaneGeometry(1, 1);
+  private cardBodyGeometry = new RoundedBoxGeometry(1, 1, 1, 3, 0.055);
+  private bentCardGeometries = new Map<string, THREE.PlaneGeometry>();
+  private resolution = 1;
+  private r3f: import('@/lib/r3fSceneBridge').R3FSceneBridge | null = null;
   private width = 810;
   private height = 1080;
-  private lastCountSig = -1;
-  private lastAssetSig = '';
   ready = false;
 
   async init(canvas: HTMLCanvasElement) {
@@ -108,13 +180,19 @@ export class SceneRenderer3D implements IRenderer {
     this.renderer = new THREE.WebGLRenderer({
       canvas,
       antialias: true,
-      alpha: false,
+      alpha: true,
       preserveDrawingBuffer: true, // required for toDataURL export capture
       powerPreference: 'high-performance', // hint the browser to use the discrete GPU
     });
     this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+    this.renderer.shadowMap.enabled = true;
+    this.renderer.shadowMap.type = THREE.PCFShadowMap;
     this.renderer.setPixelRatio(1);
     this.renderer.setSize(this.width, this.height, false);
+    const { R3FSceneBridge } = await import('@/lib/r3fSceneBridge');
+    this.r3f = new R3FSceneBridge();
+    await this.r3f.init(canvas, this.renderer, this.scene, this.camera, this.width, this.height);
+    this.createCompositor();
     this.ready = true;
     this.syncAssets();
   }
@@ -123,8 +201,14 @@ export class SceneRenderer3D implements IRenderer {
     if (!this.ready) return;
     this.width = width;
     this.height = height;
+    this.resolution = resolution;
     this.renderer.setPixelRatio(resolution);
     this.renderer.setSize(width, height, false);
+    const rw = Math.max(1, Math.round(width * resolution));
+    const rh = Math.max(1, Math.round(height * resolution));
+    this.composeA?.setSize(rw, rh);
+    this.composeB?.setSize(rw, rh);
+    this.trackRTs.forEach((rt) => rt.target.setSize(rw, rh));
     this.camera.aspect = width / height;
     this.camera.updateProjectionMatrix();
   }
@@ -137,15 +221,104 @@ export class SceneRenderer3D implements IRenderer {
   // Map the house `perspective` control (0–200) onto the camera: low values =
   // long lens (near-ortho), high = wide-angle. Camera distance keeps the z=0
   // plane at exact preview-pixel scale for any fov.
-  private updateCamera(perspective: number) {
-    const fov = lerp(15, 95, clamp(perspective, 0, 200) / 200);
-    this.camera.fov = fov;
-    this.camera.aspect = this.width / this.height;
+  private updateTrackCamera(camera: THREE.PerspectiveCamera | THREE.OrthographicCamera, perspective: number, pose?: CameraPose) {
+    if (camera instanceof THREE.OrthographicCamera) {
+      camera.left = -this.width / 2;
+      camera.right = this.width / 2;
+      camera.top = this.height / 2;
+      camera.bottom = -this.height / 2;
+      camera.near = -20000;
+      camera.far = 20000;
+      camera.position.set(0, 0, 1000);
+      camera.lookAt(0, 0, 0);
+      camera.updateProjectionMatrix();
+      return;
+    }
+    const fov = pose?.fov ?? lerp(15, 95, clamp(perspective, 0, 200) / 200);
+    camera.fov = fov;
+    camera.aspect = this.width / this.height;
     const D = (this.height / 2) / Math.tan((fov * Math.PI) / 360);
-    this.camera.position.set(0, 0, D);
-    this.camera.lookAt(0, 0, 0);
-    this.camera.far = D * 8;
-    this.camera.updateProjectionMatrix();
+    const position = pose?.position ?? { x: 0, y: 0, z: D };
+    const target = pose?.target ?? { x: 0, y: 0, z: 0 };
+    camera.position.set(position.x, -position.y, position.z);
+    camera.lookAt(target.x, -target.y, target.z);
+    camera.near = pose?.near ?? 0.1;
+    camera.far = pose?.far ?? Math.max(D * 8, Math.abs(position.z) * 8);
+    camera.updateProjectionMatrix();
+  }
+
+  private makeTarget(depthBuffer: boolean) {
+    const target = new THREE.WebGLRenderTarget(
+      Math.max(1, Math.round(this.width * this.resolution)),
+      Math.max(1, Math.round(this.height * this.resolution)),
+      { depthBuffer, stencilBuffer: false },
+    );
+    target.texture.minFilter = THREE.LinearFilter;
+    target.texture.magFilter = THREE.LinearFilter;
+    target.texture.generateMipmaps = false;
+    return target;
+  }
+
+  private createCompositor() {
+    this.composeA = this.makeTarget(false);
+    this.composeB = this.makeTarget(false);
+    const geometry = new THREE.PlaneGeometry(2, 2);
+    const composeMaterial = new THREE.ShaderMaterial({
+      depthTest: false,
+      depthWrite: false,
+      uniforms: {
+        baseMap: { value: null },
+        layerMap: { value: null },
+        opacity: { value: 1 },
+        blendMode: { value: 0 },
+      },
+      vertexShader: `varying vec2 vUv; void main(){ vUv=uv; gl_Position=vec4(position.xy,0.0,1.0); }`,
+      fragmentShader: `
+        uniform sampler2D baseMap;
+        uniform sampler2D layerMap;
+        uniform float opacity;
+        uniform int blendMode;
+        varying vec2 vUv;
+        void main(){
+          vec4 base = texture2D(baseMap, vUv);
+          vec4 layer = texture2D(layerMap, vUv);
+          float a = clamp(layer.a * opacity, 0.0, 1.0);
+          vec3 straight = layer.a > 0.00001 ? layer.rgb / layer.a : vec3(0.0);
+          vec3 blend = straight;
+          if (blendMode == 1) blend = min(vec3(1.0), base.rgb + straight);
+          else if (blendMode == 2) blend = vec3(1.0) - (vec3(1.0) - base.rgb) * (vec3(1.0) - straight);
+          else if (blendMode == 3) blend = base.rgb * straight;
+          gl_FragColor = vec4(mix(base.rgb, blend, a), 1.0);
+        }
+      `,
+    });
+    this.composeQuad = new THREE.Mesh(geometry, composeMaterial);
+    this.composeScene.add(this.composeQuad);
+
+    const outputMaterial = new THREE.ShaderMaterial({
+      depthTest: false,
+      depthWrite: false,
+      uniforms: {
+        map: { value: null },
+        resolution: { value: new THREE.Vector2(this.width, this.height) },
+        pixelSize: { value: 1 },
+      },
+      vertexShader: `varying vec2 vUv; void main(){ vUv=uv; gl_Position=vec4(position.xy,0.0,1.0); }`,
+      fragmentShader: `
+        uniform sampler2D map;
+        uniform vec2 resolution;
+        uniform float pixelSize;
+        varying vec2 vUv;
+        void main(){
+          vec2 size = max(vec2(1.0), vec2(pixelSize));
+          vec2 uv = (floor(vUv * resolution / size) + 0.5) * size / resolution;
+          gl_FragColor = texture2D(map, uv);
+          #include <colorspace_fragment>
+        }
+      `,
+    });
+    this.outputQuad = new THREE.Mesh(geometry.clone(), outputMaterial);
+    this.outputScene.add(this.outputQuad);
   }
 
   // Cover-fit via UV window (repeat/offset) on a clone sharing the decoded
@@ -165,53 +338,204 @@ export class SceneRenderer3D implements IRenderer {
     return { tex, fw, fh };
   }
 
+  private loadTexture(url: string): Promise<THREE.Texture | null> {
+    const cached = this.textureCache.get(url);
+    if (cached) return Promise.resolve(cached);
+    const pending = this.texturePromises.get(url);
+    if (pending) return pending;
+    const promise = loadImage(url)
+      .then((img) => {
+        if (!img || !this.ready) return null;
+        const tex = new THREE.Texture(img);
+        tex.colorSpace = THREE.SRGBColorSpace;
+        tex.needsUpdate = true;
+        this.textureCache.set(url, tex);
+        return tex;
+      })
+      .finally(() => { this.texturePromises.delete(url); });
+    this.texturePromises.set(url, promise);
+    return promise;
+  }
+
   syncAssets() {
     if (!this.ready) return;
     const s = useSceneStore.getState();
-    const count = Math.max(1, Math.round(s.values.count ?? 6));
-    const meta = getTemplate(s.activeTemplateId).meta;
+    for (const [id, rt] of this.trackRTs) {
+      if (!s.tracks.some((track) => track.id === id)) {
+        this.r3f?.remove(id);
+        this.destroyTrack(rt);
+        this.trackRTs.delete(id);
+      }
+    }
+    s.tracks.forEach((track) => {
+      let rt = this.trackRTs.get(track.id);
+      if (!rt) {
+        const scene = new THREE.Scene();
+        const group = new THREE.Group();
+        scene.add(group);
+        const hemi = new THREE.HemisphereLight(0xffffff, 0x202028, 1.65);
+        const keyLight = new THREE.DirectionalLight(0xffffff, 2.4);
+        keyLight.position.set(-420, 560, 900);
+        keyLight.castShadow = true;
+        keyLight.shadow.bias = -0.00025;
+        keyLight.shadow.normalBias = 0.025;
+        keyLight.shadow.camera.near = 10;
+        keyLight.shadow.camera.far = 5000;
+        keyLight.shadow.camera.left = -1400;
+        keyLight.shadow.camera.right = 1400;
+        keyLight.shadow.camera.top = 1400;
+        keyLight.shadow.camera.bottom = -1400;
+        scene.add(hemi, keyLight, keyLight.target);
+        const is3d = getTemplate(track.templateId).meta.engine === 'webgl';
+        rt = {
+          scene, group,
+          camera: is3d ? new THREE.PerspectiveCamera(50, 1, 1, 40000) : new THREE.OrthographicCamera(),
+          target: this.makeTarget(true),
+          slots: [], countSig: -1, assetSig: '', active: false, opacity: 1, blend: 'normal', keyLight,
+          r3fManaged: false,
+          r3fVersion: 0,
+        };
+        this.trackRTs.set(track.id, rt);
+      }
+      const is3d = getTemplate(track.templateId).meta.engine === 'webgl';
+      if (is3d !== (rt.camera instanceof THREE.PerspectiveCamera)) {
+        rt.camera = is3d ? new THREE.PerspectiveCamera(50, 1, 1, 40000) : new THREE.OrthographicCamera();
+      }
+      this.syncTrackSlots(track, rt, s);
+    });
+  }
+
+  private syncTrackSlots(track: MotionTrack, rt: TrackRT3D, s: SceneState) {
+    const count = Math.max(1, Math.round(track.values.count ?? 6));
+    const meta = getTemplate(track.templateId).meta;
+    const r3fManaged = meta.id.startsWith('box-');
     const repeat = meta.repeatAssets === true;
     const aspect = cardAspectFor(meta, s.width, s.height, s.cardShape);
+    const pool = trackAssetIndices(track, s.assets).map((i) => s.assets[i]).filter(Boolean);
     const assetSig = (repeat ? 'R|' : '') + 'A' + aspect.toFixed(4) + '|' +
-      s.assets.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + (a.crop ? a.crop.x + ',' + a.crop.y : 'c')).join('|');
-    if (count === this.lastCountSig && assetSig === this.lastAssetSig) return;
-    this.lastCountSig = count;
-    this.lastAssetSig = assetSig;
+      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + (a.crop ? a.crop.x + ',' + a.crop.y : 'c')).join('|');
+    if (!rt.r3fManaged && r3fManaged) {
+      // Entering the R3F-managed Box from another WebGL template keeps the
+      // same renderer and track runtime. Remove the previous native meshes
+      // before mounting the portal, otherwise both effects remain in the
+      // scene and look like duplicated/glitching images behind the box.
+      rt.slots.forEach((slot) => {
+        rt.group.remove(slot.root);
+        slot.front.material.dispose();
+        slot.back.material.dispose();
+        slot.body.material.dispose();
+      });
+      rt.slots = [];
+      rt.countSig = -1;
+      rt.assetSig = '';
+    }
+    if (rt.r3fManaged && !r3fManaged) {
+      rt.r3fVersion++;
+      this.r3f?.remove(track.id);
+      rt.slots = [];
+      rt.countSig = -1;
+    }
+    rt.r3fManaged = r3fManaged;
+    if (r3fManaged && count !== rt.countSig) {
+      const version = ++rt.r3fVersion;
+      const slots: Array<Slot3D | undefined> = new Array(count);
+      this.r3f?.upsertBox({
+        id: track.id,
+        container: rt.group,
+        count,
+        planeGeometry: this.cardPlaneGeometry,
+        bodyGeometry: this.cardBodyGeometry,
+        register: (index, slot) => {
+          if (rt.r3fVersion !== version || !rt.r3fManaged) return;
+          slots[index] = slot ?? undefined;
+          rt.slots = slots.filter((item): item is Slot3D => Boolean(item));
+          // The first React commit can happen after this sync pass. Force the
+          // next pass to bind textures to the newly materialized cards.
+          queueMicrotask(() => {
+            if (rt.r3fVersion !== version || !slot) return;
+            rt.assetSig = '';
+            this.onDirty?.();
+          });
+        },
+      });
+    }
+    if (count === rt.countSig && assetSig === rt.assetSig) return;
+    rt.countSig = count;
+    rt.assetSig = assetSig;
+    const shadowSize = count <= 24 ? 1024 : 512;
+    rt.keyLight.shadow.mapSize.set(shadowSize, shadowSize);
+    rt.keyLight.shadow.map?.dispose();
 
-    while (this.slots.length < count) {
-      const mat = new THREE.MeshBasicMaterial({
+    while (!r3fManaged && rt.slots.length < count) {
+      const frontMaterial = new THREE.MeshStandardMaterial({
         transparent: true,
-        toneMapped: false,
-        depthWrite: false,
+        roughness: 0.82,
+        metalness: 0,
+        emissive: 0xffffff,
+        emissiveIntensity: 0.28,
+        depthWrite: true,
         side: THREE.DoubleSide,
       });
-      const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), mat);
-      this.scene.add(mesh);
-      this.slots.push({ mesh, texW: 480, texH: 600, cornerR: -1 });
+      const backMaterial = new THREE.MeshStandardMaterial({ color: 0x17171b, roughness: 0.9, metalness: 0, transparent: true });
+      const bodyMaterial = new THREE.MeshStandardMaterial({ color: 0x24242a, roughness: 0.88, metalness: 0, transparent: true });
+      const root = new THREE.Group();
+      const body = new THREE.Mesh(this.cardBodyGeometry, bodyMaterial);
+      const front = new THREE.Mesh(this.cardPlaneGeometry, frontMaterial);
+      const back = new THREE.Mesh(this.cardPlaneGeometry, backMaterial);
+      front.position.z = 0.501;
+      back.position.z = -0.501;
+      back.rotation.y = Math.PI;
+      front.castShadow = front.receiveShadow = true;
+      back.castShadow = back.receiveShadow = true;
+      body.castShadow = body.receiveShadow = true;
+      root.add(body, front, back);
+      rt.group.add(root);
+      rt.slots.push({ mesh: front, root, front, back, body, texW: 480, texH: 600, cornerR: -1, bindKey: '' });
     }
-    while (this.slots.length > count) {
-      const slot = this.slots.pop()!;
-      this.scene.remove(slot.mesh);
-      slot.mesh.geometry.dispose();
-      slot.mesh.material.dispose();
+    while (!r3fManaged && rt.slots.length > count) {
+      const slot = rt.slots.pop()!;
+      rt.group.remove(slot.root);
+      slot.front.material.dispose();
+      slot.back.material.dispose();
+      slot.body.material.dispose();
     }
 
-    this.slots.forEach((slot, i) => {
-      let asset = s.assets[assetIndexForSlot(i, s.assets.length, repeat)];
-      if (!asset && s.assets.length > 0) asset = s.assets[i % s.assets.length];
+    rt.slots.forEach((slot, i) => {
+      let asset = pool[assetIndexForSlot(i, pool.length, repeat)];
+      if (!asset && pool.length > 0) asset = pool[i % pool.length];
+      const binding = asset
+        ? `${asset.id}|${asset.url}|${aspect.toFixed(4)}|${asset.crop?.x ?? 0.5},${asset.crop?.y ?? 0.5}`
+        : `placeholder|${i}`;
+      const bindingChanged = slot.bindKey !== binding;
+      slot.bindKey = binding;
+      if (bindingChanged) {
+        // Never keep the previous slot's image visible while a new async
+        // image/video is loading. A numbered placeholder is deterministic and
+        // is replaced immediately when a cached source is available.
+        let ph = this.placeholders.get(i);
+        if (!ph) { ph = makePlaceholderTexture(String(i + 1)); this.placeholders.set(i, ph); }
+        slot.front.material.map = ph;
+        slot.front.material.emissiveMap = ph;
+        slot.front.material.needsUpdate = true;
+        slot.texW = 480;
+        slot.texH = 600;
+        slot.cornerR = -1;
+      }
       if (!asset || !asset.visible) {
         let ph = this.placeholders.get(i);
         if (!ph) { ph = makePlaceholderTexture(String(i + 1)); this.placeholders.set(i, ph); }
-        slot.mesh.material.map = ph;
-        slot.mesh.material.needsUpdate = true;
+        slot.front.material.map = ph;
+        slot.front.material.emissiveMap = ph;
+        slot.front.material.needsUpdate = true;
         slot.texW = 480; slot.texH = 600;
       } else if (isVideoSource(asset.url, asset.kind)) {
         const { url, crop } = asset;
         const frozen = this.exportVideoFrames.get(url);
         if (frozen) {
           const { tex, fw, fh } = this.croppedView(url, frozen.texture, aspect, crop);
-          slot.mesh.material.map = tex;
-          slot.mesh.material.needsUpdate = true;
+          slot.front.material.map = tex;
+          slot.front.material.emissiveMap = tex;
+          slot.front.material.needsUpdate = true;
           slot.texW = fw; slot.texH = fh;
           slot.cornerR = -1;
           return;
@@ -226,6 +550,7 @@ export class SceneRenderer3D implements IRenderer {
           video.play().catch(() => { /* autoplay blocked — first frame only */ });
         }
         const applyVid = (v: HTMLVideoElement) => {
+          if (slot.bindKey !== binding) return;
           const vw = v.videoWidth, vh = v.videoHeight;
           if (!vw || !vh || !this.ready) return;
           const { fx, fy, fw, fh } = coverCrop(vw, vh, aspect, crop);
@@ -239,8 +564,9 @@ export class SceneRenderer3D implements IRenderer {
             tex = vt;
             this.croppedCache.set(key, tex);
           }
-          slot.mesh.material.map = tex;
-          slot.mesh.material.needsUpdate = true;
+          slot.front.material.map = tex;
+          slot.front.material.emissiveMap = tex;
+          slot.front.material.needsUpdate = true;
           slot.texW = fw; slot.texH = fh;
           slot.cornerR = -1; // aspect changed → rebuild the corner mask
           this.onDirty?.();
@@ -250,28 +576,39 @@ export class SceneRenderer3D implements IRenderer {
       } else {
         const { url, crop } = asset;
         const applyCropped = (base: THREE.Texture) => {
+          if (slot.bindKey !== binding) return;
           const { tex, fw, fh } = this.croppedView(url, base, aspect, crop);
-          slot.mesh.material.map = tex;
-          slot.mesh.material.needsUpdate = true;
+          slot.front.material.map = tex;
+          slot.front.material.emissiveMap = tex;
+          slot.front.material.needsUpdate = true;
           slot.texW = fw; slot.texH = fh;
           slot.cornerR = -1; // aspect changed → rebuild the corner mask
           this.onDirty?.();
         };
-        const cached = this.textureCache.get(url);
-        if (cached) {
-          applyCropped(cached);
-        } else {
-          loadImage(url).then((img) => {
-            if (!img || !this.ready) return;
-            const tex = new THREE.Texture(img);
-            tex.colorSpace = THREE.SRGBColorSpace;
-            tex.needsUpdate = true;
-            this.textureCache.set(url, tex);
-            applyCropped(tex);
-          });
-        }
+        this.loadTexture(url).then((tex) => {
+          if (!tex || !this.ready || slot.bindKey !== binding) return;
+          applyCropped(tex);
+        });
+      }
+      if (bindingChanged) slot.cornerR = -1;
+    });
+  }
+
+  private invalidateTracks() {
+    this.trackRTs.forEach((rt) => { rt.countSig = -1; rt.assetSig = ''; });
+  }
+
+  private destroyTrack(rt: TrackRT3D) {
+    rt.slots.forEach((slot) => {
+      rt.group.remove(slot.root);
+      if (!rt.r3fManaged) {
+        slot.front.material.dispose();
+        slot.back.material.dispose();
+        slot.body.material.dispose();
       }
     });
+    rt.slots = [];
+    rt.target.dispose();
   }
 
   // Rounded corners via a cached alpha mask (Pixi uses a stencil mask).
@@ -280,23 +617,24 @@ export class SceneRenderer3D implements IRenderer {
     if (slot.cornerR === fracR) return;
     slot.cornerR = fracR;
     if (fracR === 0) {
-      slot.mesh.material.alphaMap = null;
-      slot.mesh.material.needsUpdate = true;
+      slot.front.material.alphaMap = null;
+      slot.front.material.needsUpdate = true;
       return;
     }
     const aspect = slot.texW / slot.texH;
     const key = `${fracR.toFixed(2)}|${aspect.toFixed(2)}`;
     let map = this.cornerMaps.get(key);
     if (!map) { map = makeCornerAlphaMap(fracR, aspect); this.cornerMaps.set(key, map); }
-    slot.mesh.material.alphaMap = map;
-    slot.mesh.material.needsUpdate = true;
+    slot.front.material.alphaMap = map;
+    slot.front.material.needsUpdate = true;
   }
 
   // Backdrop + HUD (logo, safe-area) sync from the store.
   private syncScenery() {
     const s = useSceneStore.getState();
 
-    // background: solid or 2-stop gradient (image/card sources fall back)
+    // Background parity with Pixi: solid, gradient, uploaded image, or an
+    // asset reflected from the active motion layer.
     if (s.background.source === 'color' && s.background.gradient) {
       const sig = s.background.color + '|' + s.background.color2;
       if (this.gradientSig !== sig) {
@@ -305,6 +643,14 @@ export class SceneRenderer3D implements IRenderer {
         this.gradientSig = sig;
       }
       this.scene.background = this.gradientTex;
+    } else if (s.background.source === 'image' && s.background.imageUrl) {
+      this.syncBackgroundTexture(s.background.imageUrl, s.background.blur);
+    } else if (s.background.source === 'card') {
+      const active = s.tracks.find((track) => track.id === s.activeTrackId) ?? s.tracks.find((track) => track.visible);
+      const assetIndex = active ? trackAssetIndices(active, s.assets)[0] : undefined;
+      const url = assetIndex === undefined ? null : s.assets[assetIndex]?.url;
+      if (url && !isVideoSource(url, s.assets[assetIndex!]?.kind)) this.syncBackgroundTexture(url, s.background.blur);
+      else this.scene.background = new THREE.Color(s.background.color);
     } else {
       this.scene.background = new THREE.Color(s.background.color);
     }
@@ -380,11 +726,22 @@ export class SceneRenderer3D implements IRenderer {
     this.videoEls.forEach((v) => { v.loop = s.videoEnd !== 'hold'; });
     this.syncScenery();
 
-    this.updateCamera(Number(s.values.perspective ?? 100));
+    const sceneTotal = Math.max(1, Math.round(s.duration * s.fps));
+    s.tracks.forEach((motionTrack) => {
+      const runtime = this.trackRTs.get(motionTrack.id);
+      if (runtime) this.updateTrackState(motionTrack, runtime, frame, sceneTotal, s);
+    });
+    return;
 
-    const template = getTemplate(s.activeTemplateId);
-    const count = this.slots.length;
-    const ease = resolveEasing(s.easing);
+    const track = s.tracks.find((item) => item.id === s.activeTrackId) ?? s.tracks[0];
+    if (!track) return;
+    const rt = this.trackRTs.get(track.id);
+    if (!rt) return;
+    this.updateTrackCamera(rt!.camera, Number(track.values.perspective ?? 100));
+
+    const template = getTemplate(track.templateId);
+    const count = rt!.slots.length;
+    const ease = resolveEasing(track.easing);
     const easedPhase = (phase: number) => {
       const base = Math.floor(phase);
       return base + ease(phase - base);
@@ -397,11 +754,11 @@ export class SceneRenderer3D implements IRenderer {
     };
 
     for (let i = 0; i < count; i++) {
-      const slot = this.slots[i];
+      const slot = rt!.slots[i];
       const norm = SPRITE_BASE / Math.max(slot.texW, slot.texH);
-      this.applyCorner(slot, Number(s.values.cornerRadius ?? 0));
+      this.applyCorner(slot, Number(track.values.cornerRadius ?? 0));
       if (template.transform3d) {
-        const t = template.transform3d(frame, i, count, s.values, ctx);
+        const t = template.transform3d!(frame, i, count, track.values, ctx);
         slot.mesh.position.set(t.x, -t.y, t.z); // canvas y-down → three y-up
         slot.mesh.rotation.set(t.rotationX ?? 0, t.rotationY ?? 0, t.rotationZ ?? 0);
         slot.mesh.scale.set(slot.texW * norm * t.scale, slot.texH * norm * t.scale, 1);
@@ -417,12 +774,164 @@ export class SceneRenderer3D implements IRenderer {
         slot.mesh.visible = t.alpha > 0.001 && t.scale > 0.0001;
       } else {
         // fallback: project the 2D transform onto the z=0 plane
-        const t = template.transform(frame, i, count, s.values, ctx);
+        const t = template.transform(frame, i, count, track.values, ctx);
         slot.mesh.position.set(t.x, -t.y, t.depth);
         slot.mesh.rotation.set(0, 0, -t.rotation);
         slot.mesh.scale.set(slot.texW * norm * t.scale * (t.scaleX ?? 1), slot.texH * norm * t.scale * (t.scaleY ?? 1), 1);
         slot.mesh.material.opacity = t.alpha;
         slot.mesh.visible = t.alpha > 0.001 && t.scale > 0.0001;
+      }
+    }
+  }
+
+  private syncBackgroundTexture(url: string, blur: number) {
+    const sig = `${url}|${this.width}x${this.height}|${Math.max(0, blur)}`;
+    if (sig === this.backgroundSig) {
+      if (this.backgroundTex) this.scene.background = this.backgroundTex;
+      return;
+    }
+    this.backgroundSig = sig;
+    const generation = ++this.backgroundGeneration;
+    loadImage(url).then((img) => {
+      if (!img || !this.ready || generation !== this.backgroundGeneration) return;
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.max(2, this.width);
+      canvas.height = Math.max(2, this.height);
+      const g = canvas.getContext('2d');
+      if (!g) return;
+      const cover = Math.max(canvas.width / img.width, canvas.height / img.height) * 1.08;
+      const w = img.width * cover;
+      const h = img.height * cover;
+      g.filter = blur > 0 ? `blur(${Math.max(0, blur)}px)` : 'none';
+      g.drawImage(img, (canvas.width - w) / 2, (canvas.height - h) / 2, w, h);
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.colorSpace = THREE.SRGBColorSpace;
+      this.backgroundTex?.dispose();
+      this.backgroundTex = texture;
+      this.scene.background = texture;
+      this.onDirty?.();
+    });
+  }
+
+  private applyPhysicalPose(slot: Slot3D, t: LayerTransform3D, norm: number) {
+    const alpha = clamp(t.alpha, 0, 1);
+    const thickness = Math.max(0, t.thickness ?? 0);
+    const bend = clamp(t.bend ?? 0, -0.45, 0.45);
+    const bent = Math.abs(bend) > 0.0001;
+    const physical = thickness > 0.05 && !bent;
+    const exposure = clamp(t.materialExposure ?? 1, 0.25, 2.5);
+    const shadow = (t.shadowStrength ?? 0) > 0.02;
+
+    slot.root.position.set(t.x, -t.y, t.z);
+    if (t.quaternion) {
+      slot.root.quaternion.set(t.quaternion.x, t.quaternion.y, t.quaternion.z, t.quaternion.w).normalize();
+    } else {
+      slot.root.rotation.set(t.rotationX ?? 0, t.rotationY ?? 0, t.rotationZ ?? 0);
+    }
+    slot.root.scale.set(
+      slot.texW * norm * t.scale,
+      slot.texH * norm * t.scale,
+      physical ? thickness : 1,
+    );
+    if (bent) {
+      const key = bend.toFixed(3);
+      let geometry = this.bentCardGeometries.get(key);
+      if (!geometry) {
+        geometry = makeBentPlaneGeometry(bend);
+        this.bentCardGeometries.set(key, geometry);
+      }
+      slot.front.geometry = geometry;
+    } else {
+      slot.front.geometry = this.cardPlaneGeometry;
+    }
+    slot.front.position.z = physical ? 0.501 : 0;
+    slot.front.material.opacity = alpha;
+    slot.front.material.depthWrite = alpha > 0.995;
+    if (physical) {
+      slot.front.material.color.setRGB(exposure, exposure, exposure);
+      slot.front.material.emissiveIntensity = 0.18 + exposure * 0.14;
+    } else {
+      // Match CSS 3D panels: the source image stays color-accurate while its
+      // geometry supplies the perspective. Only cards with thickness are lit.
+      slot.front.material.color.setRGB(0, 0, 0);
+      slot.front.material.emissiveIntensity = 1;
+    }
+    slot.front.castShadow = shadow;
+    slot.front.receiveShadow = shadow;
+
+    // A physical card is THREE transparent meshes — front at +T/2, body, back at
+    // -T/2. They only stack correctly while the card writes depth, and depth
+    // writing is gated on alpha > 0.995 just above. Below that the three blend in
+    // whatever order the scene graph happens to give, and the card renders as
+    // interleaved stripes of itself: the front image shredded by its own body.
+    // Measured across the library, this hit 100% of Depth Stack's cards, 86-94%
+    // of Helix 3D's and 67% of Parallax Totem's — every template that combines
+    // thickness with a depth/back fade, which is all of them.
+    //
+    // So the solid is shown on exactly the cards that can sort it. A faded card
+    // falls back to its single front plane, which is the honest degradation:
+    // you cannot see the edge of a translucent card anyway.
+    const solid = physical && alpha > 0.995;
+    slot.body.visible = solid;
+    slot.back.visible = solid;
+    slot.body.material.opacity = alpha;
+    slot.back.material.opacity = alpha;
+    slot.body.castShadow = slot.body.receiveShadow = shadow;
+    slot.back.castShadow = slot.back.receiveShadow = shadow;
+    slot.root.visible = alpha > 0.001 && t.scale > 0.0001;
+  }
+
+  private updateTrackState(track: MotionTrack, rt: TrackRT3D, frame: number, sceneTotal: number, s: SceneState) {
+    const time = resolveTrackTime(track, frame, sceneTotal);
+    rt.active = time.active;
+    rt.group.visible = time.active;
+    if (!time.active) return;
+    const template = getTemplate(track.templateId);
+    const count = rt.slots.length;
+    const ease = resolveEasing(track.easing);
+    const easedPhase = (phase: number) => {
+      const base = Math.floor(phase);
+      return base + ease(phase - base);
+    };
+    const ctx = {
+      fps: s.fps, width: s.width, height: s.height,
+      duration: time.localTotal / Math.max(1, s.fps),
+      totalFrames: time.localTotal,
+      ease, easedPhase,
+    };
+    this.updateTrackCamera(rt.camera, Number(track.values.perspective ?? 100), template.camera?.(track.values, ctx));
+    rt.group.position.set(track.transform.x, -track.transform.y, 0);
+    rt.group.scale.setScalar(track.transform.scale);
+    rt.group.rotation.set(0, 0, -(track.transform.rotation * Math.PI) / 180);
+    const layerAlpha = clamp(track.opacity, 0, 1) * time.envelope;
+    rt.opacity = layerAlpha;
+    rt.blend = track.blend;
+
+    for (let i = 0; i < count; i++) {
+      const slot = rt.slots[i];
+      const norm = SPRITE_BASE / Math.max(slot.texW, slot.texH);
+      this.applyCorner(slot, Number(track.values.cornerRadius ?? 0));
+      // Blend mode and layer opacity are applied once to the completed render
+      // target. Inside a track cards still use normal alpha + their own depth.
+      if (template.transform3d) {
+        const t = template.transform3d(time.localFrame, i, count, track.values, ctx);
+        this.applyPhysicalPose(slot, t, norm);
+      } else {
+        const t = template.transform(time.localFrame, i, count, track.values, ctx);
+        slot.front.geometry = this.cardPlaneGeometry;
+        slot.root.position.set(t.x, -t.y, t.depth);
+        slot.root.rotation.set(0, 0, -t.rotation);
+        slot.root.scale.set(slot.texW * norm * t.scale * (t.scaleX ?? 1), slot.texH * norm * t.scale * (t.scaleY ?? 1), 1);
+        slot.front.position.z = 0;
+        slot.front.material.opacity = t.alpha;
+        slot.front.material.depthWrite = false;
+        slot.front.material.color.setRGB(0, 0, 0);
+        slot.front.material.emissiveIntensity = 1;
+        slot.front.castShadow = false;
+        slot.front.receiveShadow = false;
+        slot.body.visible = false;
+        slot.back.visible = false;
+        slot.root.visible = t.alpha > 0.001 && t.scale > 0.0001;
       }
     }
   }
@@ -445,7 +954,7 @@ export class SceneRenderer3D implements IRenderer {
     });
     this.croppedCache.forEach((tex) => tex.dispose());
     this.croppedCache.clear();
-    this.lastAssetSig = '';
+    this.invalidateTracks();
     this.syncAssets();
   }
 
@@ -454,7 +963,7 @@ export class SceneRenderer3D implements IRenderer {
     this.croppedCache.clear();
     this.exportVideoFrames.forEach(({ texture }) => texture.dispose());
     this.exportVideoFrames.clear();
-    this.lastAssetSig = '';
+    this.invalidateTracks();
     this.syncAssets();
   }
 
@@ -492,8 +1001,52 @@ export class SceneRenderer3D implements IRenderer {
   renderFrame(frame: number) {
     if (!this.ready) return;
     this.getFrameState(frame);
+    const s = useSceneStore.getState();
+
+    // The accumulator begins with the opaque scene background.
+    this.renderer.setRenderTarget(this.composeA);
+    this.renderer.setClearColor(0x000000, 1);
+    this.renderer.clear(true, true, true);
     this.renderer.render(this.scene, this.camera);
-    // HUD pass (logo + safe-area) drawn on top without clearing
+
+    let read = this.composeA;
+    let write = this.composeB;
+    const composeMaterial = this.composeQuad.material;
+    s.tracks.forEach((track) => {
+      const rt = this.trackRTs.get(track.id);
+      if (!rt?.active) return;
+
+      // A layer owns its depth buffer. Z can never leak into another layer.
+      this.renderer.setRenderTarget(rt.target);
+      this.renderer.setClearColor(0x000000, 0);
+      this.renderer.clear(true, true, true);
+      this.renderer.render(rt.scene, rt.camera);
+
+      composeMaterial.uniforms.baseMap.value = read.texture;
+      composeMaterial.uniforms.layerMap.value = rt.target.texture;
+      composeMaterial.uniforms.opacity.value = rt.opacity;
+      composeMaterial.uniforms.blendMode.value = rt.blend === 'add' ? 1
+        : rt.blend === 'screen' ? 2
+        : rt.blend === 'multiply' ? 3 : 0;
+      this.renderer.setRenderTarget(write);
+      this.renderer.clear(true, false, false);
+      this.renderer.render(this.composeScene, this.composeCam);
+      [read, write] = [write, read];
+    });
+
+    const pixelate = s.effects.find((effect) => effect.enabled && effect.effectId === 'pixelate');
+    this.outputQuad.material.uniforms.map.value = read.texture;
+    this.outputQuad.material.uniforms.resolution.value.set(
+      this.width * this.resolution,
+      this.height * this.resolution,
+    );
+    this.outputQuad.material.uniforms.pixelSize.value = Number(pixelate?.values.size ?? 1) * this.resolution;
+    this.renderer.setRenderTarget(null);
+    this.renderer.setClearColor(0x000000, 1);
+    this.renderer.clear(true, true, true);
+    this.renderer.render(this.outputScene, this.composeCam);
+
+    // HUD pass (logo + safe-area) is deliberately outside global pixelation.
     this.renderer.autoClear = false;
     this.renderer.render(this.hud, this.hudCam);
     this.renderer.autoClear = true;
@@ -511,12 +1064,11 @@ export class SceneRenderer3D implements IRenderer {
 
   destroy() {
     this.ready = false;
-    for (const slot of this.slots) {
-      this.scene.remove(slot.mesh);
-      slot.mesh.geometry.dispose();
-      slot.mesh.material.dispose();
-    }
-    this.slots = [];
+    this.texturePromises.clear();
+    this.r3f?.destroy();
+    this.r3f = null;
+    this.trackRTs.forEach((rt) => this.destroyTrack(rt));
+    this.trackRTs.clear();
     this.textureCache.forEach((t) => t.dispose());
     this.textureCache.clear();
     this.croppedCache.forEach((t) => t.dispose());
@@ -528,11 +1080,22 @@ export class SceneRenderer3D implements IRenderer {
     this.cornerMaps.forEach((t) => t.dispose());
     this.cornerMaps.clear();
     this.gradientTex?.dispose();
+    this.backgroundTex?.dispose();
+    this.backgroundGeneration++;
+    this.composeA?.dispose();
+    this.composeB?.dispose();
+    this.composeQuad?.geometry.dispose();
+    this.composeQuad?.material.dispose();
+    this.outputQuad?.geometry.dispose();
+    this.outputQuad?.material.dispose();
+    this.cardPlaneGeometry.dispose();
+    this.cardBodyGeometry.dispose();
+    this.bentCardGeometries.forEach((geometry) => geometry.dispose());
+    this.bentCardGeometries.clear();
     if (this.logoMesh) { this.logoMesh.geometry.dispose(); this.logoMesh.material.map?.dispose(); this.logoMesh.material.dispose(); }
     if (this.safeLine) { this.safeLine.geometry.dispose(); (this.safeLine.material as THREE.Material).dispose(); }
     try {
       this.renderer.dispose();
-      this.renderer.forceContextLoss(); // avoid WebGL context accumulation on engine swaps
     } catch { /* already lost */ }
   }
 }

--- a/lib/tilt3d.ts
+++ b/lib/tilt3d.ts
@@ -1,0 +1,144 @@
+import { clamp } from './motion';
+
+export const DEG = Math.PI / 180;
+export const RAD = 180 / Math.PI;
+
+export interface Vec3 { x: number; y: number; z: number }
+export interface TiltRig { pitch?: number; yaw?: number; roll?: number }
+export interface Quaternion { x: number; y: number; z: number; w: number }
+
+// Apply Ry(yaw) * Rx(pitch) * Rz(roll) in Three's world coordinates while
+// accepting/returning the app's canvas convention (positive Y points down).
+// Every planar template uses this one function so card centres and normals can
+// never drift onto subtly different planes.
+export function tiltPointCanvas(point: Vec3, rig: TiltRig): Vec3 {
+  const ax = (rig.pitch ?? 0) * DEG;
+  const ay = (rig.yaw ?? 0) * DEG;
+  const az = (rig.roll ?? 0) * DEG;
+  const sx = Math.sin(ax), cx = Math.cos(ax);
+  const sy = Math.sin(ay), cy = Math.cos(ay);
+  const sz = Math.sin(az), cz = Math.cos(az);
+
+  // canvas -> world, then Rz, Rx, Ry
+  const wx = point.x;
+  const wy = -point.y;
+  const wz = point.z;
+  const xz = wx * cz - wy * sz;
+  const yz = wx * sz + wy * cz;
+  const zz = wz;
+  const xx = xz;
+  const yx = yz * cx - zz * sx;
+  const zx = yz * sx + zz * cx;
+  const xy = xx * cy + zx * sy;
+  const yy = yx;
+  const zy = -xx * sy + zx * cy;
+  return { x: xy, y: -yy, z: zy };
+}
+
+export function tiltNormalCanvas(normal: Vec3, rig: TiltRig): Vec3 {
+  const p = tiltPointCanvas(normal, rig);
+  const length = Math.hypot(p.x, p.y, p.z) || 1;
+  return { x: p.x / length, y: p.y / length, z: p.z / length };
+}
+
+export function softLimit(value: number, limit: number, softness = 1): number {
+  if (limit <= 0) return 0;
+  return Math.tanh((value / limit) * softness) * limit;
+}
+
+export function smoother(t: number): number {
+  const x = clamp(t, 0, 1);
+  return x * x * x * (x * (x * 6 - 15) + 10);
+}
+
+// Symmetric seam envelope. `edge` is the fraction at each end used to hide a
+// wrapped ownership hand-off; 0 keeps the item fully visible.
+export function wrapEnvelope(phase01: number, edge: number): number {
+  const e = clamp(edge, 0, 0.49);
+  if (e <= 0) return 1;
+  const p = ((phase01 % 1) + 1) % 1;
+  return smoother(Math.min(p / e, (1 - p) / e, 1));
+}
+
+export function backfaceFade(normalZ: number, amount: number): number {
+  const a = clamp(amount / 100, 0, 1);
+  const facing = smoother((normalZ + 0.15) / 1.15);
+  return 1 - a * (1 - facing);
+}
+
+export function perspectiveFov(value: number, max = 100): number {
+  return 15 + clamp(value / max, 0, 1) * 80;
+}
+
+export function shortestAngle(from: number, to: number): number {
+  const d = ((to - from + Math.PI) % (Math.PI * 2) + Math.PI * 2) % (Math.PI * 2) - Math.PI;
+  return from + d;
+}
+
+export function normalizeQuaternion(q: Quaternion): Quaternion {
+  const n = Math.hypot(q.x, q.y, q.z, q.w) || 1;
+  return { x: q.x / n, y: q.y / n, z: q.z / n, w: q.w / n };
+}
+
+// Same intrinsic XYZ convention used by THREE.Euler. Kept dependency-free so
+// template transforms remain pure and can run in Node verification scripts.
+export function quaternionFromEuler(x: number, y: number, z: number): Quaternion {
+  const c1 = Math.cos(x / 2), c2 = Math.cos(y / 2), c3 = Math.cos(z / 2);
+  const s1 = Math.sin(x / 2), s2 = Math.sin(y / 2), s3 = Math.sin(z / 2);
+  return normalizeQuaternion({
+    x: s1 * c2 * c3 + c1 * s2 * s3,
+    y: c1 * s2 * c3 - s1 * c2 * s3,
+    z: c1 * c2 * s3 + s1 * s2 * c3,
+    w: c1 * c2 * c3 - s1 * s2 * s3,
+  });
+}
+
+export function slerpQuaternion(a: Quaternion, b: Quaternion, t: number): Quaternion {
+  let end = b;
+  let dot = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+  if (dot < 0) {
+    dot = -dot;
+    end = { x: -b.x, y: -b.y, z: -b.z, w: -b.w };
+  }
+  if (dot > 0.9995) {
+    return normalizeQuaternion({
+      x: a.x + (end.x - a.x) * t,
+      y: a.y + (end.y - a.y) * t,
+      z: a.z + (end.z - a.z) * t,
+      w: a.w + (end.w - a.w) * t,
+    });
+  }
+  const theta = Math.acos(clamp(dot, -1, 1));
+  const sinTheta = Math.sin(theta);
+  const wa = Math.sin((1 - t) * theta) / sinTheta;
+  const wb = Math.sin(t * theta) / sinTheta;
+  return normalizeQuaternion({
+    x: a.x * wa + end.x * wb,
+    y: a.y * wa + end.y * wb,
+    z: a.z * wa + end.z * wb,
+    w: a.w * wa + end.w * wb,
+  });
+}
+
+export function multiplyQuaternion(a: Quaternion, b: Quaternion): Quaternion {
+  return normalizeQuaternion({
+    x: a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+    y: a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+    z: a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
+    w: a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z,
+  });
+}
+
+export function criticallyDamped(t: number, response = 7): number {
+  const x = Math.max(0, t);
+  return 1 - (1 + response * x) * Math.exp(-response * x);
+}
+
+export function springOvershoot(t: number, damping = 7, frequency = 10): number {
+  const x = Math.max(0, t);
+  return 1 - Math.exp(-damping * x) * (Math.cos(frequency * x) + (damping / frequency) * Math.sin(frequency * x));
+}
+
+export function velocityLean(speed: number, referenceSpeed: number, maxDegrees = 3): number {
+  return softLimit(speed / Math.max(1e-6, referenceSpeed), 1, 1.15) * maxDegrees;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,12 @@ export interface ControlDef {
   min?: number; max?: number; step?: number;  // slider
   options?: string[];          // pills / select / toggle
   default: number | string | boolean | { x: number; y: number };
+  section?: 'Layout' | 'Motion' | 'Depth' | 'Finish';
+  unit?: '°' | '%' | 'px' | '×' | '';
+  description?: string;
+  precision?: number;
+  visibleWhen?: { key: string; equals?: any; not?: any };
+  advanced?: boolean;
 }
 
 // ----- What a template's transform returns for ONE layer at ONE frame -----
@@ -45,6 +51,12 @@ export interface LayerTransform3D {
   rotationX?: number;  // radians
   rotationY?: number;
   rotationZ?: number;
+  quaternion?: { x: number; y: number; z: number; w: number };
+  thickness?: number;        // px before the card's uniform pose scale
+  shadowStrength?: number;   // 0..1, per-card cast/receive contribution
+  materialExposure?: number; // linear multiplier, 1 = neutral
+  bend?: number;             // centre sag in normalized card-width units; 0 = flat
+  velocity?: { x: number; y: number; z: number }; // px/s, used by finish passes
   scale: number;
   alpha: number;
 }
@@ -62,6 +74,22 @@ export interface TransformCtx {
   // loop seamless: floor(p) + ease(frac(p)). Templates route their raw
   // (time·speed) phase through this to inherit the scene easing.
   easedPhase: (phase: number) => number;
+  // The card's RESOLVED width/height, after the scene's card shape has had its
+  // say over the template's declared `cardAspect` (see lib/crop cardAspectFor).
+  // Templates that lay out a lattice need this: the renderer normalizes a
+  // sprite's LONG edge, so a card's other dimension — and therefore the gap left
+  // between neighbours — moves with the shape the user picked. Assuming the
+  // declared aspect instead leaves the horizontal and vertical gutters unequal.
+  // Optional so older ctx builders keep compiling; fall back to the declared one.
+  cardAspect?: number;
+}
+
+export interface CameraPose {
+  fov?: number;
+  position?: { x: number; y: number; z: number };
+  target?: { x: number; y: number; z: number };
+  near?: number;
+  far?: number;
 }
 
 // ----- A motion template (SEAM 1) -----
@@ -72,6 +100,8 @@ export interface Template {
     isNew?: boolean;                          // shows a NEW badge on the template card
     repeatAssets?: boolean;                   // slot i shows asset i % assets.length (high-count fields)
     engine?: 'pixi' | 'webgl';                // renderer backend; default 'pixi'
+    catalog3d?: boolean;                      // visual family is genuinely spatial; display as "<group> 3D"
+    catalogHidden?: boolean;                  // keep loading old scenes while hiding an unfinished preset from pickers
     cardAspect?: number | 'canvas';           // cover-crop shape: w/h ratio (default 4/5) or the canvas aspect (full-bleed)
   };
   controls: ControlDef[];                     // its FULL own set
@@ -91,6 +121,7 @@ export interface Template {
     values: Record<string, any>,
     ctx: TransformCtx
   ) => LayerTransform3D;                       // PURE. no side effects.
+  camera?: (values: Record<string, any>, ctx: TransformCtx) => CameraPose;
 }
 
 // ----- An effect (SEAM 2) -----

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -69,6 +69,7 @@ export interface Template {
   meta: {
     id: string; name: string; group: string; thumbnail?: string;
     defaultEasing?: EasingSpec;               // curve the template ships with
+    isNew?: boolean;                          // shows a NEW badge on the template card
     repeatAssets?: boolean;                   // slot i shows asset i % assets.length (high-count fields)
     engine?: 'pixi' | 'webgl';                // renderer backend; default 'pixi'
     cardAspect?: number | 'canvas';           // cover-crop shape: w/h ratio (default 4/5) or the canvas aspect (full-bleed)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@react-three/fiber": "^9.0.0",
         "@tailwindcss/browser": "^4.3.3",
         "jszip": "^3.10.1",
         "mp4-muxer": "^5.2.2",
@@ -19,6 +23,7 @@
         "react-dom": "^19.2.7",
         "sucrase": "^3.35.1",
         "three": "^0.185.1",
+        "use-sync-external-store": "^1.5.0",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -31,12 +36,74 @@
         "typescript": "^5.9.3"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.2",
@@ -718,6 +785,61 @@
         }
       }
     },
+    "node_modules/@react-three/fiber": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.0.0.tgz",
+      "integrity": "sha512-yfX7PzGFVMAvLbOf3ONw3WrVENasCZ2Vw/CxQ/6iSG/sgOwxPB7+gOTu1au5o7/TlXLm2dJo6H62k2CgMdPgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.28.9",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "^0.31.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.25.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -772,7 +894,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -786,6 +907,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/stats.js": {
@@ -814,7 +944,6 @@
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/wicg-file-system-access": {
@@ -870,6 +999,26 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
@@ -880,6 +1029,30 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -959,7 +1132,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -1064,6 +1236,26 @@
         "js-binary-schema-parser": "^2.0.3"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -1087,6 +1279,18 @@
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
       "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
       "license": "MIT"
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
     },
     "node_modules/js-binary-schema-parser": {
       "version": "2.0.3",
@@ -1410,6 +1614,42 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-reconciler": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
+      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -1598,6 +1838,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -1689,6 +1938,15 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Motion Studio — an open-source factory for quick videos and GIFs.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node scripts/verify-tilt.cjs",
     "dev": "next dev",
+    "dev:network": "next dev -H 0.0.0.0",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "start:network": "next start -H 0.0.0.0"
   },
   "keywords": [],
   "author": "",
@@ -15,9 +17,13 @@
   "type": "module",
   "private": "true",
   "dependencies": {
-    "mp4-muxer": "^5.2.2",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@react-three/fiber": "^9.0.0",
     "@tailwindcss/browser": "^4.3.3",
     "jszip": "^3.10.1",
+    "mp4-muxer": "^5.2.2",
     "next": "^16.2.10",
     "pixi-filters": "^6.1.5",
     "pixi.js": "^8.19.0",
@@ -25,6 +31,7 @@
     "react-dom": "^19.2.7",
     "sucrase": "^3.35.1",
     "three": "^0.185.1",
+    "use-sync-external-store": "^1.5.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/scripts/_raw_probe.cjs
+++ b/scripts/_raw_probe.cjs
@@ -1,0 +1,37 @@
+const puppeteer = require('puppeteer-core');
+const fs = require('node:fs');
+async function main() {
+  const browser = await puppeteer.launch({
+    executablePath: 'C:/Program Files/Google/Chrome/Application/chrome.exe',
+    headless: 'shell',
+    args: ['--use-gl=angle','--use-angle=swiftshader','--enable-unsafe-swiftshader'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1600, height: 1000, deviceScaleFactor: 1 });
+  await page.goto('http://localhost:3000', { waitUntil: 'networkidle2', timeout: 90000 });
+  const box = await page.$('input[type=checkbox]');
+  if (box) { await box.click(); await new Promise(r=>setTimeout(r,150));
+    for (const b of await page.$$('button')) { const t=(await page.evaluate(el=>el.textContent,b))||''; if(/library|agree|continue|start/i.test(t)&&t.length<40){await b.click();break;} }
+    await new Promise(r=>setTimeout(r,500)); }
+  await page.waitForSelector('canvas.stage-canvas');
+  const dataUrl = await page.evaluate(async (id, targetFrame) => {
+    const raf = () => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+    const setInput = (el, value) => {
+      const proto = el instanceof HTMLSelectElement ? HTMLSelectElement.prototype : HTMLInputElement.prototype;
+      Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, String(value));
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+    const select = document.querySelector('select');
+    setInput(select, id);
+    for (let i=0;i<6;i++) await raf();
+    const scrub = document.querySelector('.scrubber input[type=range]');
+    setInput(scrub, targetFrame);
+    for (let i=0;i<4;i++) await raf();
+    const canvas = document.querySelector('canvas.stage-canvas');
+    return canvas.toDataURL('image/png');
+  }, process.argv[2], Number(process.argv[3]));
+  fs.writeFileSync(process.argv[4], Buffer.from(dataUrl.split(',')[1], 'base64'));
+  await browser.close();
+}
+main();

--- a/scripts/shoot.cjs
+++ b/scripts/shoot.cjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// ============================================================
+//  shoot — take deterministic photographs of a template
+//
+//  Every verification this project has (scripts/verify-tilt.cjs and the loop
+//  seam suites) measures CORRECTNESS: coplanarity, seam closure, finiteness,
+//  quaternion normalization. None of them looks at a pixel. That gap is why a
+//  template can pass everything and still look wrong.
+//
+//  This drives the real app in a real Chrome, steps the timeline to fixed
+//  frames, reads the stage canvas, and writes a contact sheet you can open.
+//  Nothing here touches production code — it drives the UI exactly as a person
+//  would, so it cannot change how the app behaves.
+//
+//  Usage:
+//    node scripts/shoot.cjs orbit-3d-01
+//    node scripts/shoot.cjs orbit-3d-01 globe-01 box-01
+//    MS_FRAMES=9 node scripts/shoot.cjs helix3d-01
+//    MS_URL=http://localhost:3001 node scripts/shoot.cjs box-01
+//
+//  Output: .shots/<template-id>.jpg
+// ============================================================
+
+const fs = require('node:fs');
+const path = require('node:path');
+const puppeteer = require('puppeteer-core');
+
+const ROOT = path.resolve(__dirname, '..');
+const OUT_DIR = path.join(ROOT, '.shots');
+const URL = process.env.MS_URL || 'http://localhost:3000';
+const SHOTS = Math.max(2, Number(process.env.MS_FRAMES || 6));
+const COLS = Number(process.env.MS_COLS || 3);
+
+// puppeteer-core ships no browser; point it at the installed Chrome.
+const CHROME_CANDIDATES = [
+  process.env.MS_CHROME,
+  'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+  'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+  process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, 'Google/Chrome/Application/chrome.exe'),
+].filter(Boolean);
+
+function findChrome() {
+  for (const p of CHROME_CANDIDATES) if (fs.existsSync(p)) return p;
+  throw new Error('Chrome not found. Set MS_CHROME to the executable path.');
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  const ids = process.argv.slice(2);
+  if (!ids.length) {
+    console.error('usage: node scripts/shoot.cjs <template-id> [more ids...]');
+    process.exit(1);
+  }
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  const browser = await puppeteer.launch({
+    executablePath: findChrome(),
+    headless: 'shell',
+    args: [
+      // Headless Chrome has no GPU; SwiftShader gives it a real WebGL context so
+      // the Three renderer draws instead of silently producing a blank canvas.
+      '--use-gl=angle',
+      '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader',
+      '--disable-lcd-text',
+      '--hide-scrollbars',
+    ],
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1600, height: 1000, deviceScaleFactor: 1 });
+    page.on('pageerror', (e) => console.error('  [page error]', e.message));
+
+    await page.goto(URL, { waitUntil: 'networkidle2', timeout: 90_000 });
+    await dismissWelcome(page);
+    await page.waitForSelector('canvas.stage-canvas', { timeout: 30_000 });
+    await page.waitForSelector('.scrubber input[type=range]', { timeout: 30_000 });
+
+    for (const id of ids) {
+      process.stdout.write(`shooting ${id} ... `);
+      const result = await shoot(page, id);
+      if (result.error) { console.log('FAILED: ' + result.error); continue; }
+      const file = path.join(OUT_DIR, `${id}.jpg`);
+      fs.writeFileSync(file, Buffer.from(result.dataUrl.split(',')[1], 'base64'));
+      console.log(`${result.frames.join(', ')}  ->  .shots/${id}.jpg  (${result.w}x${result.h}, ${(fs.statSync(file).size / 1024).toFixed(0)} KB)`);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+async function dismissWelcome(page) {
+  // The dialog is first-run only; skip quietly when it is already gone.
+  const box = await page.$('input[type=checkbox]');
+  if (!box) return;
+  await box.click();
+  await sleep(150);
+  const buttons = await page.$$('button');
+  for (const b of buttons) {
+    const t = (await page.evaluate((el) => (el.textContent || '').trim(), b)) || '';
+    if (/library|agree|continue|start/i.test(t) && t.length < 40) { await b.click(); break; }
+  }
+  await sleep(500);
+}
+
+async function shoot(page, templateId) {
+  return page.evaluate(async (id, shots, cols) => {
+    const raf = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    const settle = async (n = 3) => { for (let i = 0; i < n; i++) await raf(); };
+
+    // React tracks input values on the DOM node; bypass its cache with the
+    // native setter so the change event carries the new value.
+    const setInput = (el, value) => {
+      const proto = el instanceof HTMLSelectElement ? HTMLSelectElement.prototype : HTMLInputElement.prototype;
+      Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, String(value));
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+
+    const select = document.querySelector('select');
+    if (!select) return { error: 'template <select> not found' };
+    if (![...select.options].some((o) => o.value === id)) return { error: `unknown template ${id}` };
+    setInput(select, id);
+    await settle(6);
+
+    const scrub = document.querySelector('.scrubber input[type=range]');
+    if (!scrub) return { error: 'scrubber not found' };
+    // Setting the scrubber also pauses playback (Timeline.tsx onChange), so the
+    // frames below are the frames drawn — never a wall-clock race.
+    const total = Number(scrub.max) + 1;
+
+    const canvas = document.querySelector('canvas.stage-canvas');
+    if (!canvas) return { error: 'stage canvas not found' };
+
+    // Sample evenly across one loop, excluding the duplicate end frame.
+    const frames = Array.from({ length: shots }, (_, i) => Math.round((i / shots) * total) % total);
+
+    const cellW = 380;
+    const cellH = Math.round(cellW * (canvas.height / canvas.width));
+    const rows = Math.ceil(frames.length / cols);
+    const pad = 8, label = 18;
+    const sheet = document.createElement('canvas');
+    sheet.width = cols * cellW + (cols + 1) * pad;
+    sheet.height = rows * (cellH + label) + (rows + 1) * pad;
+    const g = sheet.getContext('2d');
+    g.fillStyle = '#101014';
+    g.fillRect(0, 0, sheet.width, sheet.height);
+    g.font = '12px ui-monospace, monospace';
+    g.textBaseline = 'top';
+
+    for (let i = 0; i < frames.length; i++) {
+      setInput(scrub, frames[i]);
+      await settle(4);
+      const col = i % cols, row = Math.floor(i / cols);
+      const x = pad + col * (cellW + pad);
+      const y = pad + row * (cellH + label + pad);
+      g.fillStyle = '#8a8a94';
+      g.fillText(`f${frames[i]} / ${total}`, x, y);
+      g.drawImage(canvas, x, y + label, cellW, cellH);
+    }
+
+    // Is anything actually drawn? A blank sheet means the WebGL context failed,
+    // not that the template is empty — worth catching here rather than in my eyes.
+    const probe = g.getImageData(0, 0, sheet.width, sheet.height).data;
+    let lit = 0;
+    for (let i = 0; i < probe.length; i += 4 * 97) {
+      if (Math.abs(probe[i] - 16) + Math.abs(probe[i + 1] - 16) + Math.abs(probe[i + 2] - 20) > 24) lit++;
+    }
+    if (lit < 8) return { error: 'sheet is blank — WebGL context probably failed in headless' };
+
+    return { dataUrl: sheet.toDataURL('image/jpeg', 0.86), frames, w: sheet.width, h: sheet.height };
+  }, templateId, SHOTS, COLS);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/verify-demo-slots.cjs
+++ b/scripts/verify-demo-slots.cjs
@@ -1,0 +1,56 @@
+const path = require('path');
+const Module = require('module');
+
+require('sucrase/register');
+const root = path.resolve(__dirname, '..');
+const originalResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (request.startsWith('@/')) request = path.join(root, request.slice(2));
+  return originalResolve.call(this, request, parent, isMain, options);
+};
+
+const { useSceneStore } = require('../store/useSceneStore');
+const { DEMO_ASSETS } = require('../lib/demoAssets');
+const { countDemoSlotsInUse } = require('../lib/demoUsage');
+
+let assertions = 0;
+function assert(ok, message) {
+  assertions++;
+  if (!ok) throw new Error(message);
+}
+
+const store = useSceneStore.getState();
+store.resetScene();
+let scene = useSceneStore.getState();
+assert(scene.assets.length === 12, 'fresh scene should keep twelve preview slots');
+assert(scene.assets.every((asset) => asset.origin === 'demo'), 'fresh slots should be demos');
+assert(countDemoSlotsInUse(scene) === 6, 'default six-card template should report six demo slots');
+
+const firstId = scene.assets[0].id;
+store.addAssets([{ name: 'Real 01', url: 'https://example.com/real-01.jpg', origin: 'remote' }]);
+scene = useSceneStore.getState();
+assert(scene.assets[0].id === firstId, 'filling a slot should preserve its id');
+assert(scene.assets[0].origin === 'remote', 'upload should replace the first demo');
+assert(countDemoSlotsInUse(scene) === 5, 'one filled slot should leave five demos in use');
+
+store.removeAsset(firstId);
+scene = useSceneStore.getState();
+assert(scene.assets[0].id === firstId, 'removing should preserve the slot id');
+assert(scene.assets[0].origin === 'demo', 'removing should restore the demo fallback');
+
+store.addAssets([
+  { name: 'Real 01', url: 'https://example.com/real-01.jpg', origin: 'remote' },
+  { name: 'Real 02', url: 'https://example.com/real-02.jpg', origin: 'remote' },
+]);
+assert(useSceneStore.getState().assets.slice(0, 2).every((asset) => asset.origin !== 'demo'), 'multi-add should fill demos first');
+store.clearAssets();
+assert(useSceneStore.getState().assets.every((asset) => asset.origin === 'demo'), 'clear should restore demos');
+
+store.hydrate({
+  assets: [{ ...DEMO_ASSETS[0], id: 'legacy_1', visible: false, origin: 'remote' }],
+});
+scene = useSceneStore.getState();
+assert(scene.assets[0].origin === 'demo', 'legacy bundled remote should migrate to demo');
+assert(scene.assets[0].visible === true, 'migrated demo should be visible in preview');
+
+console.log(`${assertions} demo-slot assertions passed`);

--- a/scripts/verify-tilt.cjs
+++ b/scripts/verify-tilt.cjs
@@ -1,0 +1,135 @@
+const path = require('path');
+const Module = require('module');
+
+require('sucrase/register');
+const root = path.resolve(__dirname, '..');
+const originalResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (request.startsWith('@/')) request = path.join(root, request.slice(2));
+  return originalResolve.call(this, request, parent, isMain, options);
+};
+
+const { templateList, catalogTemplateList, templateGroups, getTemplate, defaultsFor } = require('../templates');
+const { tiltPointCanvas, tiltNormalCanvas } = require('../lib/tilt3d');
+
+let assertions = 0;
+function assert(ok, message) {
+  assertions++;
+  if (!ok) throw new Error(message);
+}
+function finitePose(pose, label) {
+  for (const [key, value] of Object.entries(pose)) {
+    if (typeof value === 'number') assert(Number.isFinite(value), `${label}.${key} is not finite`);
+    if (value && typeof value === 'object') {
+      for (const [childKey, child] of Object.entries(value)) {
+        if (typeof child === 'number') assert(Number.isFinite(child), `${label}.${key}.${childKey} is not finite`);
+      }
+    }
+  }
+  if (pose.quaternion) {
+    const q = pose.quaternion;
+    assert(Math.abs(Math.hypot(q.x, q.y, q.z, q.w) - 1) < 1e-6, `${label}.quaternion is not normalized`);
+  }
+  if (pose.thickness !== undefined) assert(pose.thickness >= 0, `${label}.thickness is negative`);
+}
+function angleDistance(a, b) {
+  return Math.abs(((a - b + Math.PI) % (Math.PI * 2) + Math.PI * 2) % (Math.PI * 2) - Math.PI);
+}
+function samePose(a, b, label) {
+  const angular = new Set(['rotation', 'rotationX', 'rotationY', 'rotationZ']);
+  for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+    if (typeof a[key] !== 'number' || typeof b[key] !== 'number') continue;
+    const delta = angular.has(key) ? angleDistance(a[key], b[key]) : Math.abs(a[key] - b[key]);
+    assert(delta < 1e-5, `${label}.${key} loop delta ${delta}`);
+  }
+}
+
+// Rotations are rigid: points keep their distance and normals stay normalized.
+for (const rig of [{ pitch: 35 }, { yaw: -42, roll: 17 }, { pitch: 22, yaw: 31, roll: -9 }]) {
+  const point = { x: 120, y: -75, z: 240 };
+  const rotated = tiltPointCanvas(point, rig);
+  assert(Math.abs(Math.hypot(point.x, point.y, point.z) - Math.hypot(rotated.x, rotated.y, rotated.z)) < 1e-8, 'Tilt changed point length');
+  const normal = tiltNormalCanvas({ x: 0.2, y: -0.4, z: 0.8 }, rig);
+  assert(Math.abs(Math.hypot(normal.x, normal.y, normal.z) - 1) < 1e-8, 'Tilt normal is not normalized');
+}
+
+// Plane tilt keeps every card centre on one plane.
+const planeRig = { pitch: 37, yaw: -24, roll: 8 };
+const plane = [
+  tiltPointCanvas({ x: -200, y: -120, z: 0 }, planeRig),
+  tiltPointCanvas({ x: 200, y: -120, z: 0 }, planeRig),
+  tiltPointCanvas({ x: -200, y: 120, z: 0 }, planeRig),
+  tiltPointCanvas({ x: 200, y: 120, z: 0 }, planeRig),
+];
+const ab = { x: plane[1].x-plane[0].x, y: plane[1].y-plane[0].y, z: plane[1].z-plane[0].z };
+const ac = { x: plane[2].x-plane[0].x, y: plane[2].y-plane[0].y, z: plane[2].z-plane[0].z };
+const normal = { x: ab.y*ac.z-ab.z*ac.y, y: ab.z*ac.x-ab.x*ac.z, z: ab.x*ac.y-ab.y*ac.x };
+const ad = { x: plane[3].x-plane[0].x, y: plane[3].y-plane[0].y, z: plane[3].z-plane[0].z };
+assert(Math.abs(normal.x*ad.x + normal.y*ad.y + normal.z*ad.z) < 1e-6, 'Plane tilt broke coplanarity');
+
+// Ring and curved-surface tilts are rigid rotations: radius and pairwise
+// distances cannot change when pitch/yaw/roll change.
+for (let i = 0; i < 24; i++) {
+  const a = i / 24 * Math.PI * 2;
+  const p = tiltPointCanvas({ x: Math.sin(a)*380, y: 0, z: Math.cos(a)*380 }, planeRig);
+  assert(Math.abs(Math.hypot(p.x, p.y, p.z) - 380) < 1e-7, 'Ring tilt changed radius');
+}
+
+const ctx = {
+  fps: 30, width: 1080, height: 1080, duration: 8, totalFrames: 240,
+  ease: (t) => t,
+  easedPhase: (p) => p,
+};
+const groupedTemplates = templateGroups.flatMap((group) => group.items);
+assert(groupedTemplates.length === catalogTemplateList.length, 'The catalogue dropped a published template while grouping');
+assert(new Set(groupedTemplates.map((item) => item.meta.id)).size === catalogTemplateList.length, 'The catalogue duplicated a template while grouping');
+for (const hidden of templateList.filter((item) => item.meta.catalogHidden)) {
+  assert(!groupedTemplates.some((item) => item.meta.id === hidden.meta.id), `${hidden.meta.id} leaked into the catalogue`);
+  assert(getTemplate(hidden.meta.id).meta.id === hidden.meta.id, `${hidden.meta.id} can no longer load persisted scenes`);
+}
+assert(templateGroups.every((group) => group.items.every((item) => group.group === (item.meta.catalog3d ? `${item.meta.group} 3D` : item.meta.group))), 'A template leaked into a different visual family');
+const relevantGroups = new Set(['Runway', 'Orbit', 'Globe', 'Surface', 'Helix', 'Isometric', 'Coverflow', 'Ticker', 'Deck', 'Depth', 'Box', 'Bounce', 'Dock', 'Editorial']);
+
+// Box Carousel follows the CSS 3D model: it rests on a face, then rotates
+// exactly one face step. Seven assets repeat after seven steps, not after the
+// least-common-multiple of asset and physical-face ownership.
+const box = templateList.find((item) => item.meta.id === 'box-01');
+const boxValues = defaultsFor('box-01');
+assert(box && box.transform3d, 'Box 01 must provide a WebGL transform');
+const boxCount = boxValues.count;
+for (let i = 0; i < boxCount; i++) {
+  const rest = box.transform3d(0, i, boxCount, boxValues, ctx);
+  const held = box.transform3d(10, i, boxCount, boxValues, ctx);
+  samePose(rest, held, `box-01 hold[${i}]`);
+}
+const turningFaces = Array.from({ length: boxCount }, (_, i) => box.transform3d(23, i, boxCount, boxValues, ctx))
+  .filter((pose) => pose.alpha > 0.01);
+assert(turningFaces.length === 2, `Box turn should expose exactly two faces, got ${turningFaces.length}`);
+
+for (const template of templateList.filter((item) => relevantGroups.has(item.meta.group))) {
+  const values = defaultsFor(template.meta.id);
+  const count = Math.max(1, Math.round(values.count ?? 6));
+  const controls = template.controls.filter((control) => control.type === 'slider' && ['tilt','tiltX','tiltAmount','ringTilt','curvature','perspective'].includes(control.key));
+  const samples = [values, ...controls.flatMap((control) => [
+    { ...values, [control.key]: control.min },
+    { ...values, [control.key]: control.max },
+  ])];
+
+  for (const sample of samples) {
+    for (const index of [0, Math.floor(count / 2), count - 1]) {
+      if (index < 0 || index >= count) continue;
+      const p0 = template.transform(0, index, count, sample, ctx);
+      const pN = template.transform(ctx.totalFrames, index, count, sample, ctx);
+      finitePose(p0, `${template.meta.id}[${index}]`);
+      samePose(p0, pN, `${template.meta.id}[${index}]`);
+      if (template.transform3d) {
+        const q0 = template.transform3d(0, index, count, sample, ctx);
+        const qN = template.transform3d(ctx.totalFrames, index, count, sample, ctx);
+        finitePose(q0, `${template.meta.id}.3d[${index}]`);
+        samePose(q0, qN, `${template.meta.id}.3d[${index}]`);
+      }
+    }
+  }
+}
+
+console.log(`Tilt verification passed (${assertions} assertions across ${templateList.length} templates).`);

--- a/store/useSceneStore.ts
+++ b/store/useSceneStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { defaultsFor, easingFor, templates } from '@/templates';
 import type { EasingSpec } from '@/lib/easing';
 import type { CropFocus } from '@/lib/crop';
-import { DEMO_ASSETS } from '@/lib/demoAssets';
+import { DEMO_ASSETS, demoSourceForSlot, isDemoAssetSource } from '@/lib/demoAssets';
 import { idbPut, idbGet, idbDelete } from '@/lib/assetDb';
 import { DEFAULT_TRACK_TRANSFORM, TRACK_END, type BlendMode, type MotionTrack } from '@/lib/tracks';
 
@@ -30,7 +30,7 @@ export interface AssetItem {
   url: string;
   visible: boolean;
   kind?: 'image' | 'video'; // media type; undefined = image (backward compatible)
-  origin?: 'remote' | 'upload'; // 'upload' bytes live in IndexedDB and restore on reload
+  origin?: 'demo' | 'remote' | 'upload'; // demos preview empty slots; upload bytes live in IndexedDB
   crop?: CropFocus; // cover-fit focal point 0..1 per axis; undefined = centre
 }
 
@@ -277,7 +277,7 @@ function initialSceneState() {
     audioUrl: null,
 
     // start populated with the bundled demo set so every template shows real motion
-    assets: DEMO_ASSETS.map((a) => ({ ...a, id: nid('asset'), visible: true, origin: 'remote' as const })),
+    assets: DEMO_ASSETS.map((a) => ({ ...a, id: nid('asset'), visible: true, origin: 'demo' as const })),
     cardShape: 'auto',
     videoEnd: 'loop' as const,
     effects: [],
@@ -384,7 +384,9 @@ export const useSceneStore = create<SceneState>((set, get) => ({
       if (!t) return {};
       // An empty list means "all" — materialize it before removing one, or the
       // first click would read as adding to nothing.
-      const current = t.assetIds.length > 0 ? t.assetIds : s.assets.map((a) => a.id);
+      const current = t.assetIds.length > 0
+        ? t.assetIds
+        : s.assets.filter((asset) => asset.origin !== 'demo').map((asset) => asset.id);
       const next = current.includes(assetId)
         ? current.filter((x) => x !== assetId)
         : [...current, assetId];
@@ -418,39 +420,49 @@ export const useSceneStore = create<SceneState>((set, get) => ({
   setLogo: (patch) => set((s) => ({ logo: { ...s.logo, ...patch } })),
   setAudioUrl: (url) => set(() => ({ audioUrl: url })),
 
-  addAssets: (items) => {
-    const added: AssetItem[] = items.map(({ blob, ...it }) => {
-      const id = nid('asset');
-      const origin: 'remote' | 'upload' = blob || it.url.startsWith('blob:') ? 'upload' : (it.origin ?? 'remote');
-      if (blob) idbPut(id, blob).catch(() => { /* quota — this upload won't persist */ });
-      return { ...it, id, visible: true, origin };
-    });
-    set((s) => ({ assets: [...s.assets, ...added] }));
-  },
+  addAssets: (items) => set((s) => {
+    const next = s.assets.slice();
+    for (const { blob, ...item } of items) {
+      const demoIndex = next.findIndex((asset) => asset.origin === 'demo');
+      const origin: 'remote' | 'upload' = blob || item.url.startsWith('blob:') ? 'upload' : 'remote';
+      if (demoIndex >= 0) {
+        const previous = next[demoIndex];
+        if (blob) idbPut(previous.id, blob).catch(() => {});
+        next[demoIndex] = { ...previous, ...item, visible: true, origin, crop: undefined };
+      } else {
+        const id = nid('asset');
+        if (blob) idbPut(id, blob).catch(() => {});
+        next.push({ ...item, id, visible: true, origin });
+      }
+    }
+    return { assets: next };
+  }),
   // Set the image at a specific slot; appends if the slot is the next empty one.
   // A new image gets a fresh (centre) crop — the old focal point rarely fits it.
   replaceAssetAt: (index, item) => {
     const { blob, ...it } = item;
-    const origin: 'remote' | 'upload' = blob || it.url.startsWith('blob:') ? 'upload' : (it.origin ?? 'remote');
+    const origin: 'remote' | 'upload' = blob || it.url.startsWith('blob:') ? 'upload' : 'remote';
     set((s) => {
       const next = s.assets.slice();
-      if (index < next.length) {
-        const prev = next[index];
-        if (prev.origin === 'upload') idbDelete(prev.id).catch(() => {}); // drop the replaced upload's bytes
-        if (blob) idbPut(prev.id, blob).catch(() => {});                  // store new bytes under the kept id
-        next[index] = { ...prev, name: it.name, url: it.url, kind: it.kind, origin, crop: undefined };
-      } else {
-        const id = nid('asset');
-        if (blob) idbPut(id, blob).catch(() => {});
-        next.push({ ...it, id, visible: true, origin });
+      while (next.length <= index) {
+        next.push({ ...demoSourceForSlot(next.length), id: nid('asset'), visible: true, origin: 'demo' });
       }
+      const prev = next[index];
+      if (prev.origin === 'upload') idbDelete(prev.id).catch(() => {});
+      if (blob) idbPut(prev.id, blob).catch(() => {});
+      next[index] = { ...prev, name: it.name, url: it.url, kind: it.kind, origin, visible: true, crop: undefined };
       return { assets: next };
     });
   },
   removeAsset: (id) => {
-    const a = get().assets.find((x) => x.id === id);
+    const current = get().assets;
+    const index = current.findIndex((asset) => asset.id === id);
+    const a = current[index];
     if (a?.origin === 'upload') idbDelete(id).catch(() => {});
-    set((s) => ({ assets: s.assets.filter((x) => x.id !== id) }));
+    if (index < 0 || a?.origin === 'demo') return;
+    set((s) => ({ assets: s.assets.map((asset, slot) => slot === index
+      ? { ...demoSourceForSlot(slot), id: asset.id, visible: true, origin: 'demo' as const }
+      : asset) }));
   },
   toggleAsset: (id) =>
     set((s) => ({
@@ -465,7 +477,14 @@ export const useSceneStore = create<SceneState>((set, get) => ({
     }),
   clearAssets: () => {
     for (const a of get().assets) if (a.origin === 'upload') idbDelete(a.id).catch(() => {});
-    set(() => ({ assets: [] }));
+    set((s) => ({
+      assets: Array.from({ length: Math.max(DEMO_ASSETS.length, s.assets.length) }, (_, index) => ({
+        ...demoSourceForSlot(index),
+        id: s.assets[index]?.id ?? nid('asset'),
+        visible: true,
+        origin: 'demo' as const,
+      })),
+    }));
   },
   setAssetCrop: (id, crop) =>
     set((s) => ({ assets: s.assets.map((a) => (a.id === id ? { ...a, crop } : a)) })),
@@ -479,7 +498,16 @@ export const useSceneStore = create<SceneState>((set, get) => ({
   // added/removed controls.
   hydrate: (partial) =>
     set((s) => {
-      const assets = partial.assets ?? s.assets;
+      // Demo slots are re-pointed at the CURRENT demo source rather than kept at
+      // whatever URL the scene was saved with. A demo asset is a placeholder for
+      // "slot n", not a specific file: a scene saved under one BASE_PATH and
+      // opened under another (local vs the Pages build's path prefix) would
+      // otherwise hold URLs that 404. Identity and crop survive; only the source
+      // is refreshed.
+      const assets = (partial.assets ?? s.assets).map((asset, index) => isDemoAssetSource(asset)
+        ? { ...asset, ...demoSourceForSlot(index), origin: 'demo' as const, visible: true }
+        : asset);
+      const realAssetIds = new Set(assets.filter((asset) => asset.origin !== 'demo').map((asset) => asset.id));
       seedIdCounter(assets);
 
       // Scenes saved before motion tracks existed carry only the flat
@@ -509,6 +537,7 @@ export const useSceneStore = create<SceneState>((set, get) => ({
           values: { ...defaultsFor(t.templateId), ...(t.values ?? {}) },
           easing: t.easing ?? easingFor(t.templateId),
           transform: { ...DEFAULT_TRACK_TRANSFORM, ...(t.transform ?? {}) },
+          assetIds: (t.assetIds ?? []).filter((id) => realAssetIds.has(id)),
         }));
       seedIdCounter(tracks);
 
@@ -520,6 +549,7 @@ export const useSceneStore = create<SceneState>((set, get) => ({
       return {
         ...s,
         ...partial,
+        assets,
         ...projectActive(safeTracks, activeId),
         frame: 0, // always start at the clip head
       };

--- a/store/useUIStore.ts
+++ b/store/useUIStore.ts
@@ -8,11 +8,17 @@ export interface UIState {
   leftCollapsed: boolean;
   rightCollapsed: boolean;
   tplCollapsed: boolean;    // left column folded to the original compact strip
+  mobileTab: 'templates' | 'media' | 'adjust' | 'canvas';
+  mobileProjectsOpen: boolean;
+  mobilePanelOpen: boolean;
   setNav: (nav: string) => void;
   toggleTheme: () => void;
   toggleLeftPanel: () => void;
   toggleRightPanel: () => void;
   toggleTplCollapsed: () => void;
+  setMobileTab: (tab: UIState['mobileTab']) => void;
+  setMobileProjectsOpen: (open: boolean) => void;
+  setMobilePanelOpen: (open: boolean) => void;
   hydratePreferences: () => void;
 }
 
@@ -37,6 +43,9 @@ export const useUIStore = create<UIState>((set) => ({
   leftCollapsed: false,
   rightCollapsed: false,
   tplCollapsed: false,
+  mobileTab: 'templates',
+  mobileProjectsOpen: false,
+  mobilePanelOpen: false,
   setNav: (nav) => set({ nav }),
   toggleTheme: () => set((state) => {
     const next = { ...state, theme: state.theme === 'dark' ? 'light' as const : 'dark' as const };
@@ -58,6 +67,9 @@ export const useUIStore = create<UIState>((set) => ({
     savePreferences(next);
     return { tplCollapsed: next.tplCollapsed };
   }),
+  setMobileTab: (mobileTab) => set({ mobileTab, mobilePanelOpen: true }),
+  setMobileProjectsOpen: (mobileProjectsOpen) => set({ mobileProjectsOpen }),
+  setMobilePanelOpen: (mobilePanelOpen) => set({ mobilePanelOpen }),
   hydratePreferences: () => set((state) => {
     if (typeof window === 'undefined') return {};
     let saved: Partial<UIPreferences> = {};

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -11,7 +11,7 @@
   /* Grid on the stage backdrop. Without it the canvas edge vanishes
      whenever the scene background matches --stage — which the defaults do
      exactly, in dark mode (#0d0d0d on #0d0d0d). */
-  --stage-dot:  rgba(0,0,0,0.05);
+  --stage-dot:  rgba(0,0,0,0.085);
   /* 1px ring around the canvas, so the frame edge is stated outright rather
      than inferred from where the dot grid stops. */
   --stage-edge: rgba(0,0,0,0.16);
@@ -104,7 +104,7 @@
 
 :root[data-theme="dark"] {
   --stage:      #0d0d0d;
-  --stage-dot:  rgba(255,255,255,0.05);
+  --stage-dot:  rgba(255,255,255,0.085);
   --stage-edge: rgba(255,255,255,0.18);
   /* Heavier than light mode: a black shadow on a near-black stage (#0d0d0d)
      has very little room to darken before it stops reading at all. */

--- a/templates/bloom.ts
+++ b/templates/bloom.ts
@@ -1,0 +1,142 @@
+import type { Template } from '@/lib/types';
+import type { EasingSpec } from '@/lib/easing';
+import { clamp, lerp, loopCycles } from '@/lib/motion';
+import { variant } from './variant';
+
+const BASE = 340;
+
+// ============================================================
+//  BLOOM — full-frame images that take the frame by SCALE
+//
+//  Takeover pushes the incoming image in from an edge. Dive holds one image and
+//  Ken-Burns-zooms it with a cross-fade. Bloom is the third case: the image
+//  arrives by growing, dead centre, and hard-covers what was there — no travel,
+//  no dissolve. The whole family is one axis: size.
+//
+//  Measured on the reference tool, which is what pins the two styles down. Every
+//  card sits at the canvas centre (540,720 on its 1080x1440 stage) and only its
+//  size changes:
+//
+//  · bloom  — the newest card enters at 719/1080 = 66% and grows to full, so it
+//    swallows the frame. Older cards sit behind, already at full size.
+//  · recede — the newest enters AT full size and shrinks away, measured down
+//    through 1052, 983, 848, 586, 174 before it leaves.
+//
+//  Cadence is two separate numbers, and conflating them is the easy mistake:
+//  `stagger` is the gap between entries and `duration` is how long one card
+//  takes to finish growing. On the reference base they are 0.4s and 2s, so five
+//  cards are mid-growth at any moment and ten enter over the 4s clip — exactly
+//  its `count`. Here that is `speed` (entries/sec) and `grow` (turns to finish).
+//
+//  Seamless loop: `loopCycles` locks the clip to a whole number of `count`-long
+//  lifecycles, the same guarantee Dive and Shuffle make, so the card that owns
+//  the frame at frame 0 owns it again at frame totalFrames.
+// ============================================================
+
+const bloom: Template = {
+  meta: {
+    id: 'bloom-01',
+    name: 'Bloom 01',
+    group: 'Bloom',
+    isNew: true,
+    // The reference curve: an instant start and a very long settle.
+    defaultEasing: { id: 'custom', bezier: [0, 0, 0, 0.99] },
+    cardAspect: 'canvas',
+    repeatAssets: true,
+  },
+
+  controls: [
+    { key: 'count',        label: 'Count',         type: 'slider', min: 2, max: 20, step: 1,     default: 10 },
+    { key: 'style',        label: 'Style',         type: 'pills',  options: ['bloom','recede'],  default: 'bloom', section: 'Motion', description: 'bloom grows in to cover; recede starts full and shrinks away.' },
+    { key: 'growFrom',     label: 'Grow From',     type: 'pills',  options: ['center','bottom'], default: 'center', section: 'Layout' },
+    { key: 'planeSize',    label: 'Plane Size',    type: 'slider', min: 20, max: 120, step: 1,   default: 100, unit: '%', description: 'Full size as a share of the frame.' },
+    { key: 'startScale',   label: 'Start Scale',   type: 'slider', min: 0, max: 100, step: 1,    default: 12, unit: '%', visibleWhen: { key: 'style', equals: 'bloom' }, description: 'Size an image enters at before it grows.' },
+    { key: 'grow',         label: 'Grow Turns',    type: 'slider', min: 1, max: 10, step: 0.1,   default: 5, section: 'Motion', description: 'Turns an image takes to finish. Above 1, images overlap.' },
+    { key: 'spin',         label: 'Spin',          type: 'slider', min: -90, max: 90, step: 1,   default: 0, section: 'Motion', unit: '°', description: 'Rotation unwound over the growth.' },
+    { key: 'fade',         label: 'Fade',          type: 'slider', min: 0, max: 100, step: 1,    default: 0, section: 'Finish', unit: '%' },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,    default: 0 },
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0.2, max: 6, step: 0.05, default: 2.5 }, // entries/sec
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                                default: { x: 0, y: 0 } },
+  ],
+
+  transform: (frame, index, count, v, ctx) => {
+    // Lifecycle w ∈ [0, count): 0 = this image just entered. Period is `count`
+    // so the clip covers whole lifecycles and the loop closes.
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count);
+    const w = (((phase - index) % count) + count) % count;
+
+    // `grow` turns to finish, so age runs 0 → 1 over that many turns and then
+    // clamps: a bloomed card parks at full size instead of overshooting.
+    const span = Math.max(0.001, v.grow);
+    const age = clamp(w / span, 0, 1);
+
+    // Fitted to the reference's measured card widths, not guessed. Its curve is
+    // bezier [0,0,0,0.99], i.e. y = 2.97t² - 1.97t³ over x = t³, and bloom is
+    // that curve run FORWARD from `startScale`:
+    //     progress 0.4 → 913px predicted vs 915 measured
+    //     progress 0.6 → 1014 vs 1018
+    //     progress 0.8 → 1064 vs 1067
+    // Recede is the same curve run BACKWARD — not one minus it. That distinction
+    // is the whole character: one minus it puts a card at 38% a fifth of the way
+    // through its life, where the reference measured 97%. Recede barely moves at
+    // first and then drops away fast; inverting the wrong way makes it collapse
+    // instantly and then crawl.
+    const full = v.planeSize / 100;
+    const start = v.startScale / 100;
+    const recede = v.style === 'recede';
+
+    // `settle` runs 0 → 1 across a card's life in whichever direction its style
+    // means, so spin and fade read the same for both and only `s` differs.
+    const settle = recede ? 1 - ctx.ease(1 - age) : ctx.ease(age);
+    const s = recede ? full * (1 - settle) : full * lerp(start, 1, settle);
+
+    // A card is done once it has left its growth window. Bloom parks at full
+    // size and keeps covering; recede has scaled to nothing and is spent.
+    const spent = recede && age >= 1;
+
+    // `bottom` pins the card's bottom edge to the frame's, so growth reads as
+    // rising out of the floor rather than opening from the middle.
+    const cardH = ctx.height * s;
+    const y = v.growFrom === 'bottom' ? (ctx.height - cardH) / 2 : 0;
+
+    const alpha = spent ? 0 : 1 - (v.fade / 100) * (1 - settle);
+    const rotation = ((v.spin * (1 - settle)) * Math.PI) / 180;
+
+    // The renderer normalizes a sprite's LONG edge, and a full-bleed card is
+    // cropped to the canvas — so covering the frame means matching the canvas's
+    // long edge, not its height. Using the height works only while the canvas is
+    // portrait; on 4:3 it left a 270px band and on 16:9 a 472px one.
+    const longEdge = Math.max(ctx.width, ctx.height);
+
+    return {
+      x: v.offset.x,
+      y: y + v.offset.y,
+      scale: (longEdge / BASE) * s,
+      rotation,
+      alpha,
+      // Newest in front: bloom must cover as it grows, and recede must be the
+      // thing that shrinks away rather than something hidden behind.
+      depth: -w,
+    };
+  },
+};
+
+// `variant` only patches control defaults; a preset with its own curve needs
+// `meta` patched too.
+function preset(id: string, name: string, patch: Record<string, any>, easing: EasingSpec): Template {
+  const t = variant(bloom, id, name, patch);
+  return { ...t, meta: { ...t.meta, defaultEasing: easing } };
+}
+
+export const bloomVariants: Template[] = [
+  bloom,
+  // Recede's window is measurably shorter than bloom's. Solving the mirrored
+  // curve against its measured widths pins the span at 1.88s rather than 2.0s,
+  // which at 2.5 entries/sec is 4.7 turns — that one number takes the worst
+  // deviation from 85px down to 12px on a 1080px frame.
+  preset('bloom-02', 'Bloom 02', { style: 'recede', grow: 4.7 }, { id: 'custom', bezier: [0, 0, 0, 0.99] }),
+  preset('bloom-03', 'Bloom 03', { spin: -45 }, { id: 'expoOut' }),
+  // The reference preset behind this one runs a 4s clip at 0.6s between
+  // entries, so it holds ~6.7 turns of growth rather than 5.
+  preset('bloom-04', 'Bloom 04', { growFrom: 'bottom', grow: 6.5, speed: 1.67 }, { id: 'ease' }),
+];

--- a/templates/box.ts
+++ b/templates/box.ts
@@ -4,112 +4,218 @@ import { variant } from './variant';
 
 const BASE = 340;
 
+// Corner bleed. The derived apothem makes adjacent faces meet EXACTLY at the
+// prism's edge — geometrically ideal, visually wrong: the shared edge is a line
+// where two antialiased, transparent planes blend, so the background leaks
+// through it and every corner reads as a seam. (The renderer's planes are
+// `transparent: true, depthWrite: false`, so there is no depth-buffer occlusion
+// to close the join.) Pulling the faces in by a fraction of a percent makes
+// their edges cross instead of touch, and the overlap hides the seam. This is a
+// rendering necessity, not a design choice, so it is not a user control.
+const CORNER_BLEED = 0.985;
+
+// Positive modulo — `%` keeps the sign of the dividend, and `turns` goes negative
+// when the prism spins in reverse.
+const mod = (a: number, n: number) => ((a % n) + n) % n;
+
+const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b));
+
+// A prism has `faces` sides but can carry more images than that, so each face
+// hands its slot over to the next image while it is turned away.
+//
+// Ownership runs face → image, not image → face. Face p in its generation g
+// shows image (g·F + p) mod N. Deriving it the other way — pinning image i to
+// face i % F — leaves holes: with 10 images on 4 faces the last generation only
+// has 2 images, so two faces would draw nothing and the prism would show gaps.
+//
+// `gens` is N / gcd(N, F), the smallest number of generations after which
+// g·F ≡ 0 (mod N). That is what closes the loop: after that many turns every
+// face is back on its starting image. It also guarantees full coverage — as g
+// runs over one period, (g·F + p) reaches every image.
+function prismGeo(count: number, v: Record<string, any>) {
+  const faces = clamp(Math.round(v.faces ?? 4), 3, 12);
+  const images = Math.max(faces, Math.round(count));
+  return { faces, images, gens: images / gcd(images, faces) };
+}
+
+// Which face this slot occupies right now, or -1 when another image owns every
+// face this frame.
+//
+// Each face keeps its OWN generation counter. Face p's angle is θ = TAU·u with
+// u = turns + p/faces, so u is that face's rotation measured in whole turns, and
+// floor(u + 0.5) increments exactly when frac(u) crosses 0.5 — the instant the
+// face points straight away from the camera. Every handover therefore happens
+// out of sight, and faces swap at their own moment rather than all at once.
+function faceForSlot(index: number, turns: number, geo: { faces: number; images: number }) {
+  for (let p = 0; p < geo.faces; p++) {
+    const g = Math.floor(turns + p / geo.faces + 0.5);
+    if (mod(g * geo.faces + p, geo.images) === index) return p;
+  }
+  return -1;
+}
+
 // ============================================================
-//  BOX — a rotating prism, one image per face
+//  BOX — a real 3D prism, one image per face
 //
-//  A closed drum that turns on its own axis: each slot is one face, and the
-//  faces are laid out around a regular N-gon so they meet at the edges. With
-//  count 4 it is a cube, 6 a hexagonal drum, 3 a triangular prism.
+//  This is a `webgl` template: `transform3d` places each face as an actual plane
+//  in 3D space and the Three.js renderer views it through a perspective camera,
+//  so the turn has genuine keystone — the receding edge of a face is shorter
+//  than the near one.
 //
-//  There is no real 3D here. A face is a flat plane whose normal points out at
-//  angle θ from the viewer, so it needs three things to read as part of a solid:
+//  That distinction is why the first version of this family was wrong.
+//  LayerTransform (the Pixi seam) offers x, y, scale, rotation, skew and
+//  scaleX/scaleY. Every one of those is AFFINE, and affine transforms map
+//  parallel lines to parallel lines. Perspective is PROJECTIVE. No combination
+//  of squash and shear can produce a keystone, so a sprite-only box can never
+//  read as solid — it reads as flat panels sliding past each other, however the
+//  numbers are tuned.
 //
-//  · foreshortening — the face compresses by cos(θ) across the turn axis, which
-//    is exactly what `scaleX` / `scaleY` are for. At θ = 90° it is edge-on and
-//    vanishes, which is what hides the seam between faces.
-//  · offset — its centre sits at sin(θ)·apothem along the axis-perpendicular,
-//    so faces sweep across rather than rotating in place.
-//  · occlusion — a face with cos(θ) < 0 points away from the viewer and must not
-//    draw at all, or the far side of the drum shows through the near side.
+//  Geometry. Faces sit around a regular N-gon: face i's outward normal points
+//  along θ = φ + i·(2π/N) and its centre sits `apothem` out along that normal.
+//  A PlaneGeometry faces +Z, so rotationY = θ aims its normal along θ — position
+//  and orientation agree, and the prism is closed.
 //
-//  The apothem (axis → face centre) is derived from the face width so the prism
-//  is closed: for a regular N-gon of side w, apothem = w / (2·tan(π/N)). Leaving
-//  it free would let the faces float apart or overlap into a mess.
+//  The apothem is derived, not free. Adjacent faces meet exactly when the gap
+//  between their centres equals the sum of their half-widths, which solves to
+//  cardSize / (2·tan(π/N)). Any other value gaps or overlaps.
+//
+//  `cardAspect: 1` because that apothem depends on the face dimension
+//  perpendicular to the spin axis — width for a vertical axis, height for a
+//  horizontal one. With the 4:5 default those differ and one axis would always
+//  leave the prism open.
 // ============================================================
 
 const box: Template = {
-  // Square faces are a geometric requirement, not a style choice. The apothem
-  // that closes the prism depends on the face dimension PERPENDICULAR to the
-  // spin axis — width for a vertical axis, height for a horizontal one. With the
-  // 4:5 default those two differ, so one of the two axes would always leave the
-  // faces gapping or overlapping. cardAspect 1 makes a single `Face Size` valid
-  // on either axis.
-  meta: { id: 'box-01', name: 'Box 01', group: 'Box', isNew: true, cardAspect: 1, defaultEasing: { id: 'linear' } },
+  meta: {
+    id: 'box-01', name: 'Box 01', group: 'Box', isNew: true,
+    cardAspect: 1, engine: 'webgl', defaultEasing: { id: 'linear' },
+  },
 
   controls: [
     { key: 'axis',         label: 'Spin Axis',     type: 'pills',  options: ['vertical','horizontal'], default: 'vertical' },
     { key: 'direction',    label: 'Direction',     type: 'toggle', options: ['forward','reverse'], default: 'forward' },
-    // Count IS the face count: one slot per face, so the drum stays closed.
-    { key: 'count',        label: 'Faces',         type: 'slider', min: 3, max: 12, step: 1,     default: 4 },
+    // `count` is how many IMAGES ride the prism; `faces` is how many sides it
+    // has. More images than faces is the point: each face hands its slot over to
+    // the next image while it is turned away.
+    { key: 'count',        label: 'Images',        type: 'slider', min: 3, max: 24, step: 1,     default: 8 },
+    { key: 'faces',        label: 'Faces',         type: 'slider', min: 3, max: 12, step: 1,     default: 4 },
     { key: 'cardSize',     label: 'Face Size',     type: 'slider', min: 80, max: 600, step: 1,   default: 330 },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,    default: 0 },
-    { key: 'girth',        label: 'Girth',         type: 'slider', min: 0.5, max: 2, step: 0.05, default: 1 },   // ×apothem: <1 squeezes the drum, >1 opens it out
-    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 100, step: 1,    default: 35 },  // near faces grow, far ones shrink
-    { key: 'shade',        label: 'Edge Shade',    type: 'slider', min: 0, max: 100, step: 1,    default: 40 },  // darkens faces as they turn away
-    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -30, max: 30, step: 1,   default: 0 },   // degrees, whole drum
+    { key: 'girth',        label: 'Girth',         type: 'slider', min: 0.5, max: 2, step: 0.05, default: 1 }, // ×apothem: <1 squeezes, >1 opens the prism
+    // Drives the 3D camera's field of view in renderer3d: low is a long lens
+    // (little keystone), high is wide (strong keystone).
+    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 200, step: 1,    default: 110 },
+    { key: 'shade',        label: 'Edge Shade',    type: 'slider', min: 0, max: 100, step: 1,    default: 35 }, // dims faces as they turn away
+    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -45, max: 45, step: 1,   default: 0 },  // rolls the whole prism in the view plane
     { key: 'offset',       label: 'Offset',        type: 'xypad',                                default: { x: 0, y: 0 } },
     { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.1,    default: 0.35 }, // turns/sec
   ],
 
+  // ---- Real 3D pose. y is canvas-down; the renderer flips it. ----
+  transform3d: (frame, index, count, v, ctx) => {
+    const vertical = v.axis === 'vertical';
+    const dir = v.direction === 'reverse' ? -1 : 1;
+
+    const geo = prismGeo(count, v);
+
+    // Period = generations, so every face is back on its starting image at the
+    // loop point and frame totalFrames poses like frame 0.
+    const turns = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, geo.gens)) * dir;
+
+    const pos = faceForSlot(index, turns, geo);
+    // Not this image's turn: park it fully transparent. Position still has to be
+    // finite, so it waits at face 0's spot.
+    const waiting = pos < 0;
+    const u = turns + (waiting ? 0 : pos) / geo.faces;
+    const theta = u * TAU;
+
+    const apothem = (v.cardSize / (2 * Math.tan(Math.PI / geo.faces))) * v.girth * CORNER_BLEED;
+
+    // Face centre on the prism surface, plus the orientation that aims its
+    // normal outward. A plane's normal starts at +Z.
+    let px: number, py: number, pz: number;
+    let rotX = 0, rotY = 0;
+    if (vertical) {
+      px = Math.sin(theta) * apothem;
+      py = 0;
+      pz = Math.cos(theta) * apothem;
+      rotY = theta;                       // normal → (sin θ, 0, cos θ)
+    } else {
+      px = 0;
+      py = Math.sin(theta) * apothem;     // world-up offset
+      pz = Math.cos(theta) * apothem;
+      rotX = -theta;                      // normal → (0, sin θ, cos θ)
+    }
+
+    // Tilt rolls the whole prism in the view plane: the face centres rotate
+    // about Z and each face takes the matching roll, so the drum leans as one
+    // rigid body instead of the faces shearing off its surface.
+    const roll = (v.tilt * Math.PI) / 180;
+    if (roll !== 0) {
+      const c = Math.cos(roll), s = Math.sin(roll);
+      const rx = px * c - py * s;
+      const ry = px * s + py * c;
+      px = rx; py = ry;
+    }
+
+    // The material is DoubleSide, so nothing is back-face culled for us. A face
+    // whose normal points away is on the far side of a CLOSED prism and must be
+    // hidden, or the back of the drum shows through the front.
+    const facing = smooth(clamp(Math.cos(theta) / 0.12, 0, 1));
+    // Faces turning away also darken — the drum has no real lighting.
+    const shaded = 1 - (v.shade / 100) * (1 - Math.max(0, Math.cos(theta)));
+    const mine = waiting ? 0 : 1;
+
+    return {
+      x: px + v.offset.x,
+      // The renderer negates y (canvas-down → three y-up), so a world-up offset
+      // is handed over negated.
+      y: -py + v.offset.y,
+      z: pz,
+      rotationX: rotX,
+      rotationY: rotY,
+      rotationZ: roll,
+      scale: v.cardSize / BASE,
+      alpha: clamp(facing * shaded * mine, 0, 1),
+    };
+  },
+
+  // ---- Cheap 2D projection, for thumbnails and the non-webgl fallback. ----
+  // Orthographic on purpose: it cannot express keystone, so it does not pretend
+  // to. Scale is held constant across faces so the derived apothem still tiles
+  // them exactly — an earlier version scaled faces by depth here, which changed
+  // their width and reopened the prism the apothem exists to close.
   transform: (frame, index, count, v, ctx) => {
     const vertical = v.axis === 'vertical';
     const dir = v.direction === 'reverse' ? -1 : 1;
 
-    // One slot per face. Clamped to the control's own range so a stale saved
-    // value can't produce a degenerate prism.
-    const faces = clamp(Math.round(count), 3, 12);
-    const step = TAU / faces;
+    const geo = prismGeo(count, v);
+    const turns = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, geo.gens)) * dir;
 
-    // Period 1 = one full turn per cycle, so a whole number of turns fits the
-    // clip and frame totalFrames lands back on frame 0.
-    const turns = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, 1)) * dir;
+    // Same ownership as the 3D path, so a thumbnail shows the image the stage
+    // shows at that frame.
+    const pos = faceForSlot(index, turns, geo);
+    const waiting = pos < 0;
+    const theta = (turns + (waiting ? 0 : pos) / geo.faces) * TAU;
 
-    // Angle between this face's outward normal and the viewer.
-    const theta = turns * TAU + index * step;
     const cosT = Math.cos(theta);
-    const sinT = Math.sin(theta);
+    const apothem = (v.cardSize / (2 * Math.tan(Math.PI / geo.faces))) * v.girth * CORNER_BLEED;
+    const along = Math.sin(theta) * apothem;
 
-    const sizeFactor = v.cardSize / BASE;
-    // Closed-prism apothem. The renderer normalizes a sprite's longest edge to
-    // BASE and then applies our scale, so a face lands exactly `cardSize` px
-    // wide — the apothem is therefore in cardSize px directly. Multiplying by
-    // sizeFactor here (as this first did) scaled it a second time and pushed the
-    // faces apart, leaving the prism open.
-    const apothem = (v.cardSize / (2 * Math.tan(Math.PI / faces))) * v.girth;
-
-    // Face centre: swept along the axis-perpendicular, depth from cos.
-    const along = sinT * apothem;
-    const z = cosT * apothem;
-
-    // Perspective: nearer faces (z > 0) grow, far ones shrink.
-    const persp = v.perspective / 100;
-    const depthScale = 1 + persp * (z / Math.max(1, apothem)) * 0.35;
-
-    // Foreshortening across the turn axis. Negative cos means the face points
-    // away — it is culled below, so only the magnitude matters here.
-    const squash = Math.abs(cosT);
-
-    // Cull the far side. The fade is only wide enough to avoid a one-frame
-    // artefact at the crossing; the squash already takes the face to zero width.
     const facing = smooth(clamp(cosT / 0.12, 0, 1));
-
-    // Faces turning away also darken, which is what separates them from the one
-    // pointing at the viewer on a flat-lit drum.
     const shaded = 1 - (v.shade / 100) * (1 - Math.max(0, cosT));
-
-    const x = (vertical ? along : 0) + v.offset.x;
-    const y = (vertical ? 0 : along) + v.offset.y;
+    const squash = Math.abs(cosT);
+    const mine = waiting ? 0 : 1;
 
     return {
-      x,
-      y,
-      scale: sizeFactor * depthScale,
+      x: (vertical ? along : 0) + v.offset.x,
+      y: (vertical ? 0 : along) + v.offset.y,
+      scale: v.cardSize / BASE,
       rotation: (v.tilt * Math.PI) / 180,
-      alpha: clamp(facing * shaded, 0, 1),
-      // A vertical axis compresses horizontally; a horizontal axis vertically.
+      alpha: clamp(facing * shaded * mine, 0, 1),
       scaleX: vertical ? squash : 1,
       scaleY: vertical ? 1 : squash,
-      depth: z,
+      depth: cosT * apothem,
     };
   },
 };
@@ -117,9 +223,10 @@ const box: Template = {
 export const boxVariants: Template[] = [
   box,
   variant(box, 'box-02', 'Box Tumble', {
-    axis: 'horizontal', count: 4, cardSize: 300, perspective: 50, shade: 55, speed: 0.3,
+    axis: 'horizontal', count: 4, faces: 4, cardSize: 300, perspective: 140, shade: 50, speed: 0.3,
   }),
+  // A wide drum: every image gets its own side, so there is no handover at all.
   variant(box, 'box-03', 'Box Drum', {
-    count: 8, cardSize: 200, girth: 1.1, perspective: 60, shade: 50, tilt: -8, speed: 0.45,
+    count: 8, faces: 8, cardSize: 200, girth: 1.1, perspective: 160, shade: 45, tilt: -10, speed: 0.45,
   }),
 ];

--- a/templates/box.ts
+++ b/templates/box.ts
@@ -1,0 +1,125 @@
+import type { Template } from '@/lib/types';
+import { TAU, clamp, loopCycles, smooth } from '@/lib/motion';
+import { variant } from './variant';
+
+const BASE = 340;
+
+// ============================================================
+//  BOX — a rotating prism, one image per face
+//
+//  A closed drum that turns on its own axis: each slot is one face, and the
+//  faces are laid out around a regular N-gon so they meet at the edges. With
+//  count 4 it is a cube, 6 a hexagonal drum, 3 a triangular prism.
+//
+//  There is no real 3D here. A face is a flat plane whose normal points out at
+//  angle θ from the viewer, so it needs three things to read as part of a solid:
+//
+//  · foreshortening — the face compresses by cos(θ) across the turn axis, which
+//    is exactly what `scaleX` / `scaleY` are for. At θ = 90° it is edge-on and
+//    vanishes, which is what hides the seam between faces.
+//  · offset — its centre sits at sin(θ)·apothem along the axis-perpendicular,
+//    so faces sweep across rather than rotating in place.
+//  · occlusion — a face with cos(θ) < 0 points away from the viewer and must not
+//    draw at all, or the far side of the drum shows through the near side.
+//
+//  The apothem (axis → face centre) is derived from the face width so the prism
+//  is closed: for a regular N-gon of side w, apothem = w / (2·tan(π/N)). Leaving
+//  it free would let the faces float apart or overlap into a mess.
+// ============================================================
+
+const box: Template = {
+  // Square faces are a geometric requirement, not a style choice. The apothem
+  // that closes the prism depends on the face dimension PERPENDICULAR to the
+  // spin axis — width for a vertical axis, height for a horizontal one. With the
+  // 4:5 default those two differ, so one of the two axes would always leave the
+  // faces gapping or overlapping. cardAspect 1 makes a single `Face Size` valid
+  // on either axis.
+  meta: { id: 'box-01', name: 'Box 01', group: 'Box', isNew: true, cardAspect: 1, defaultEasing: { id: 'linear' } },
+
+  controls: [
+    { key: 'axis',         label: 'Spin Axis',     type: 'pills',  options: ['vertical','horizontal'], default: 'vertical' },
+    { key: 'direction',    label: 'Direction',     type: 'toggle', options: ['forward','reverse'], default: 'forward' },
+    // Count IS the face count: one slot per face, so the drum stays closed.
+    { key: 'count',        label: 'Faces',         type: 'slider', min: 3, max: 12, step: 1,     default: 4 },
+    { key: 'cardSize',     label: 'Face Size',     type: 'slider', min: 80, max: 600, step: 1,   default: 330 },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,    default: 0 },
+    { key: 'girth',        label: 'Girth',         type: 'slider', min: 0.5, max: 2, step: 0.05, default: 1 },   // ×apothem: <1 squeezes the drum, >1 opens it out
+    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 100, step: 1,    default: 35 },  // near faces grow, far ones shrink
+    { key: 'shade',        label: 'Edge Shade',    type: 'slider', min: 0, max: 100, step: 1,    default: 40 },  // darkens faces as they turn away
+    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -30, max: 30, step: 1,   default: 0 },   // degrees, whole drum
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                                default: { x: 0, y: 0 } },
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.1,    default: 0.35 }, // turns/sec
+  ],
+
+  transform: (frame, index, count, v, ctx) => {
+    const vertical = v.axis === 'vertical';
+    const dir = v.direction === 'reverse' ? -1 : 1;
+
+    // One slot per face. Clamped to the control's own range so a stale saved
+    // value can't produce a degenerate prism.
+    const faces = clamp(Math.round(count), 3, 12);
+    const step = TAU / faces;
+
+    // Period 1 = one full turn per cycle, so a whole number of turns fits the
+    // clip and frame totalFrames lands back on frame 0.
+    const turns = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, 1)) * dir;
+
+    // Angle between this face's outward normal and the viewer.
+    const theta = turns * TAU + index * step;
+    const cosT = Math.cos(theta);
+    const sinT = Math.sin(theta);
+
+    const sizeFactor = v.cardSize / BASE;
+    // Closed-prism apothem. The renderer normalizes a sprite's longest edge to
+    // BASE and then applies our scale, so a face lands exactly `cardSize` px
+    // wide — the apothem is therefore in cardSize px directly. Multiplying by
+    // sizeFactor here (as this first did) scaled it a second time and pushed the
+    // faces apart, leaving the prism open.
+    const apothem = (v.cardSize / (2 * Math.tan(Math.PI / faces))) * v.girth;
+
+    // Face centre: swept along the axis-perpendicular, depth from cos.
+    const along = sinT * apothem;
+    const z = cosT * apothem;
+
+    // Perspective: nearer faces (z > 0) grow, far ones shrink.
+    const persp = v.perspective / 100;
+    const depthScale = 1 + persp * (z / Math.max(1, apothem)) * 0.35;
+
+    // Foreshortening across the turn axis. Negative cos means the face points
+    // away — it is culled below, so only the magnitude matters here.
+    const squash = Math.abs(cosT);
+
+    // Cull the far side. The fade is only wide enough to avoid a one-frame
+    // artefact at the crossing; the squash already takes the face to zero width.
+    const facing = smooth(clamp(cosT / 0.12, 0, 1));
+
+    // Faces turning away also darken, which is what separates them from the one
+    // pointing at the viewer on a flat-lit drum.
+    const shaded = 1 - (v.shade / 100) * (1 - Math.max(0, cosT));
+
+    const x = (vertical ? along : 0) + v.offset.x;
+    const y = (vertical ? 0 : along) + v.offset.y;
+
+    return {
+      x,
+      y,
+      scale: sizeFactor * depthScale,
+      rotation: (v.tilt * Math.PI) / 180,
+      alpha: clamp(facing * shaded, 0, 1),
+      // A vertical axis compresses horizontally; a horizontal axis vertically.
+      scaleX: vertical ? squash : 1,
+      scaleY: vertical ? 1 : squash,
+      depth: z,
+    };
+  },
+};
+
+export const boxVariants: Template[] = [
+  box,
+  variant(box, 'box-02', 'Box Tumble', {
+    axis: 'horizontal', count: 4, cardSize: 300, perspective: 50, shade: 55, speed: 0.3,
+  }),
+  variant(box, 'box-03', 'Box Drum', {
+    count: 8, cardSize: 200, girth: 1.1, perspective: 60, shade: 50, tilt: -8, speed: 0.45,
+  }),
+];

--- a/templates/box.ts
+++ b/templates/box.ts
@@ -1,5 +1,5 @@
 import type { Template } from '@/lib/types';
-import { TAU, clamp, loopCycles, smooth } from '@/lib/motion';
+import { TAU, clamp, loopCycles, smooth, stepHold } from '@/lib/motion';
 import { variant } from './variant';
 
 const BASE = 340;
@@ -12,13 +12,12 @@ const BASE = 340;
 // to close the join.) Pulling the faces in by a fraction of a percent makes
 // their edges cross instead of touch, and the overlap hides the seam. This is a
 // rendering necessity, not a design choice, so it is not a user control.
-const CORNER_BLEED = 0.985;
+const CORNER_BLEED = 0.997;
+const BOX_ASPECT = 350 / 250;
 
 // Positive modulo — `%` keeps the sign of the dividend, and `turns` goes negative
 // when the prism spins in reverse.
 const mod = (a: number, n: number) => ((a % n) + n) % n;
-
-const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b));
 
 // A prism has `faces` sides but can carry more images than that, so each face
 // hands its slot over to the next image while it is turned away.
@@ -35,7 +34,20 @@ const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b));
 function prismGeo(count: number, v: Record<string, any>) {
   const faces = clamp(Math.round(v.faces ?? 4), 3, 12);
   const images = Math.max(faces, Math.round(count));
-  return { faces, images, gens: images / gcd(images, faces) };
+  return { faces, images };
+}
+
+function carouselFace(index: number, travel: number, geo: { faces: number; images: number }) {
+  const step = Math.floor(travel);
+  const progress = travel - step;
+  let relative = mod(index - mod(step, geo.images), geo.images);
+  if (relative > geo.images / 2) relative -= geo.images;
+  const low = -Math.floor((geo.faces - 1) / 2);
+  const high = Math.ceil((geo.faces - 1) / 2);
+  return {
+    theta: (relative - progress) * TAU / geo.faces,
+    active: relative >= low && relative <= high,
+  };
 }
 
 // Which face this slot occupies right now, or -1 when another image owns every
@@ -46,14 +58,6 @@ function prismGeo(count: number, v: Record<string, any>) {
 // floor(u + 0.5) increments exactly when frac(u) crosses 0.5 — the instant the
 // face points straight away from the camera. Every handover therefore happens
 // out of sight, and faces swap at their own moment rather than all at once.
-function faceForSlot(index: number, turns: number, geo: { faces: number; images: number }) {
-  for (let p = 0; p < geo.faces; p++) {
-    const g = Math.floor(turns + p / geo.faces + 0.5);
-    if (mod(g * geo.faces + p, geo.images) === index) return p;
-  }
-  return -1;
-}
-
 // ============================================================
 //  BOX — a real 3D prism, one image per face
 //
@@ -79,6 +83,18 @@ function faceForSlot(index: number, turns: number, geo: { faces: number; images:
 //  between their centres equals the sum of their half-widths, which solves to
 //  cardSize / (2·tan(π/N)). Any other value gaps or overlaps.
 //
+//  The prism is then pushed BACK by one apothem, so the front face lands on
+//  z = 0 instead of the prism's centre. This is the CSS box's
+//  `translateZ(-depth/2)`: there the box container is shifted back by half its
+//  depth precisely so the front face sits in the container's own plane. It
+//  matters here because renderer3d parks the camera at
+//  D = (height/2)/tan(fov/2), which makes z = 0 the plane of exact preview-pixel
+//  scale. Centring the prism instead leaves the front face an apothem closer to
+//  the lens, so it renders magnified by D/(D−apothem) — 1.22× at the defaults,
+//  and 3.1× at 12 faces, where the apothem outgrows the face itself. Anchored,
+//  `Face Width` means the pixel width you actually get, and Faces/Girth change
+//  the depth of the box behind that face rather than its size on screen.
+//
 //  `cardAspect: 1` because that apothem depends on the face dimension
 //  perpendicular to the spin axis — width for a vertical axis, height for a
 //  horizontal one. With the 4:5 default those differ and one axis would always
@@ -88,7 +104,12 @@ function faceForSlot(index: number, turns: number, geo: { faces: number; images:
 const box: Template = {
   meta: {
     id: 'box-01', name: 'Box 01', group: 'Box', isNew: true,
-    cardAspect: 1, engine: 'webgl', defaultEasing: { id: 'linear' },
+    // The reference component snaps each quarter turn with a spring of
+    // stiffness 200 / damping 30 — ζ ≈ 1.06, so it is very slightly overdamped
+    // and never overshoots. That is an ease-OUT, not the symmetric ease-in-out
+    // `smooth` was giving; cubicOut is the closest curve in the house set
+    // (within ~0.04 of the spring's normalized response across the step).
+    cardAspect: BOX_ASPECT, engine: 'webgl', catalog3d: true, defaultEasing: { id: 'cubicOut' },
   },
 
   controls: [
@@ -97,19 +118,47 @@ const box: Template = {
     // `count` is how many IMAGES ride the prism; `faces` is how many sides it
     // has. More images than faces is the point: each face hands its slot over to
     // the next image while it is turned away.
-    { key: 'count',        label: 'Images',        type: 'slider', min: 3, max: 24, step: 1,     default: 8 },
+    { key: 'count',        label: 'Images',        type: 'slider', min: 4, max: 24, step: 1,     default: 7 },
     { key: 'faces',        label: 'Faces',         type: 'slider', min: 3, max: 12, step: 1,     default: 4 },
-    { key: 'cardSize',     label: 'Face Size',     type: 'slider', min: 80, max: 600, step: 1,   default: 330 },
+    { key: 'cardSize',     label: 'Face Width',    type: 'slider', min: 80, max: 600, step: 1,   default: 350 },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,    default: 0 },
     { key: 'girth',        label: 'Girth',         type: 'slider', min: 0.5, max: 2, step: 0.05, default: 1 }, // ×apothem: <1 squeezes, >1 opens the prism
-    // Drives the 3D camera's field of view in renderer3d: low is a long lens
-    // (little keystone), high is wide (strong keystone).
-    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 200, step: 1,    default: 110 },
-    { key: 'shade',        label: 'Edge Shade',    type: 'slider', min: 0, max: 100, step: 1,    default: 35 }, // dims faces as they turn away
+    // Not the house 0–200 lens control — this is the CSS `perspective` distance
+    // in px, the same number and the same default the reference component takes
+    // (`CSSBox` ships 600; the carousel example passes 800). See `camera` below.
+    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 200, max: 2400, step: 10, default: 600 },
+    { key: 'shade',        label: 'Edge Shade',    type: 'slider', min: 0, max: 100, step: 1,    default: 12 }, // dims faces as they turn away
+    { key: 'hold',         label: 'Hold',          type: 'slider', min: 0, max: 85, step: 1,     default: 42 },
     { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -45, max: 45, step: 1,   default: 0 },  // rolls the whole prism in the view plane
     { key: 'offset',       label: 'Offset',        type: 'xypad',                                default: { x: 0, y: 0 } },
-    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.1,    default: 0.35 }, // turns/sec
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.1,    default: 0.8 }, // face steps/sec
   ],
+
+  // ---- Camera. This is what makes the box read as a box. ----
+  //
+  // CSS `perspective: Npx` on a wrapper puts the viewer exactly N px in front of
+  // the element plane and projects with the factor N/(N−z). A Three perspective
+  // camera does the same thing when it sits at z = N AND its fov subtends the
+  // canvas at that distance — fov = 2·atan((height/2)/N). Deriving both from one
+  // number is what makes `Perspective` here mean what it means in the reference
+  // component, and it keeps z = 0 at exact preview-pixel scale, which the
+  // front-face anchor above depends on.
+  //
+  // Without this the house 0–200 control ran the show, and its distance is a
+  // function of the CANVAS, not the box: `D = (height/2)/tan(fov/2)`. On a
+  // 1080-tall stage the old default landed at D = 954 px against a 350 px face —
+  // a 2.7× lens. The reference is 600 px against a 400 px face, 1.5×. That gap
+  // is the whole complaint: at 2.7× the keystone is so shallow the box reads as
+  // two hinged flat panels, and no amount of correct geometry fixes it, because
+  // the geometry was never what was wrong.
+  camera: (v, ctx) => {
+    const p = clamp(Number(v.perspective) || 600, 200, 2400);
+    return {
+      position: { x: 0, y: 0, z: p },
+      target: { x: 0, y: 0, z: 0 },
+      fov: (2 * Math.atan((ctx.height / 2) / p) * 180) / Math.PI,
+    };
+  },
 
   // ---- Real 3D pose. y is canvas-down; the renderer flips it. ----
   transform3d: (frame, index, count, v, ctx) => {
@@ -118,18 +167,12 @@ const box: Template = {
 
     const geo = prismGeo(count, v);
 
-    // Period = generations, so every face is back on its starting image at the
-    // loop point and frame totalFrames poses like frame 0.
-    const turns = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, geo.gens)) * dir;
-
-    const pos = faceForSlot(index, turns, geo);
-    // Not this image's turn: park it fully transparent. Position still has to be
-    // finite, so it waits at face 0's spot.
-    const waiting = pos < 0;
-    const u = turns + (waiting ? 0 : pos) / geo.faces;
-    const theta = u * TAU;
-
-    const apothem = (v.cardSize / (2 * Math.tan(Math.PI / geo.faces))) * v.girth * CORNER_BLEED;
+    const rawSteps = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, geo.images);
+    const travel = stepHold(rawSteps, v.hold / 100, ctx.ease) * dir;
+    const face = carouselFace(index, travel, geo);
+    const theta = face.theta;
+    const crossSize = vertical ? v.cardSize : v.cardSize / BOX_ASPECT;
+    const apothem = (crossSize / (2 * Math.tan(Math.PI / geo.faces))) * v.girth * CORNER_BLEED;
 
     // Face centre on the prism surface, plus the orientation that aims its
     // normal outward. A plane's normal starts at +Z.
@@ -164,19 +207,26 @@ const box: Template = {
     const facing = smooth(clamp(Math.cos(theta) / 0.12, 0, 1));
     // Faces turning away also darken — the drum has no real lighting.
     const shaded = 1 - (v.shade / 100) * (1 - Math.max(0, Math.cos(theta)));
-    const mine = waiting ? 0 : 1;
+    const mine = face.active ? 1 : 0;
 
     return {
       x: px + v.offset.x,
       // The renderer negates y (canvas-down → three y-up), so a world-up offset
       // is handed over negated.
       y: -py + v.offset.y,
-      z: pz,
+      // `translateZ(-depth/2)`. The roll above turns the prism about Z, which
+      // leaves Z alone, so the shift is a plain world-space subtraction here.
+      z: pz - apothem,
       rotationX: rotX,
       rotationY: rotY,
       rotationZ: roll,
       scale: v.cardSize / BASE,
       alpha: clamp(facing * shaded * mine, 0, 1),
+      // The prism itself supplies the volume. Giving every face a separate
+      // thick rounded body creates doubled corners and visible gaps.
+      thickness: 0,
+      shadowStrength: 0,
+      materialExposure: shaded,
     };
   },
 
@@ -190,22 +240,20 @@ const box: Template = {
     const dir = v.direction === 'reverse' ? -1 : 1;
 
     const geo = prismGeo(count, v);
-    const turns = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, geo.gens)) * dir;
-
-    // Same ownership as the 3D path, so a thumbnail shows the image the stage
-    // shows at that frame.
-    const pos = faceForSlot(index, turns, geo);
-    const waiting = pos < 0;
-    const theta = (turns + (waiting ? 0 : pos) / geo.faces) * TAU;
+    const rawSteps = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, geo.images);
+    const travel = stepHold(rawSteps, v.hold / 100, ctx.ease) * dir;
+    const face = carouselFace(index, travel, geo);
+    const theta = face.theta;
 
     const cosT = Math.cos(theta);
-    const apothem = (v.cardSize / (2 * Math.tan(Math.PI / geo.faces))) * v.girth * CORNER_BLEED;
+    const crossSize = vertical ? v.cardSize : v.cardSize / BOX_ASPECT;
+    const apothem = (crossSize / (2 * Math.tan(Math.PI / geo.faces))) * v.girth * CORNER_BLEED;
     const along = Math.sin(theta) * apothem;
 
     const facing = smooth(clamp(cosT / 0.12, 0, 1));
     const shaded = 1 - (v.shade / 100) * (1 - Math.max(0, cosT));
     const squash = Math.abs(cosT);
-    const mine = waiting ? 0 : 1;
+    const mine = face.active ? 1 : 0;
 
     return {
       x: (vertical ? along : 0) + v.offset.x,
@@ -222,11 +270,16 @@ const box: Template = {
 
 export const boxVariants: Template[] = [
   box,
+  // Perspective is a px distance now, so each variant carries its own — the
+  // number that matters is the ratio to the face, and the reference sits at
+  // 1.5–2×. 520/300 = 1.7 here.
   variant(box, 'box-02', 'Box Tumble', {
-    axis: 'horizontal', count: 4, faces: 4, cardSize: 300, perspective: 140, shade: 50, speed: 0.3,
+    axis: 'horizontal', count: 4, faces: 4, cardSize: 300, perspective: 520, shade: 50, speed: 0.3,
   }),
   // A wide drum: every image gets its own side, so there is no handover at all.
+  // Eight faces make the solid much deeper than it is wide, so this one takes a
+  // longer lens (480/200 = 2.4) — at 1.5× the far side of the drum smears.
   variant(box, 'box-03', 'Box Drum', {
-    count: 8, faces: 8, cardSize: 200, girth: 1.1, perspective: 160, shade: 45, tilt: -10, speed: 0.45,
+    count: 8, faces: 8, cardSize: 200, girth: 1.1, perspective: 480, shade: 45, tilt: -10, speed: 0.45,
   }),
 ];

--- a/templates/carousel.ts
+++ b/templates/carousel.ts
@@ -1,5 +1,5 @@
 import type { Template } from '@/lib/types';
-import { clamp, loopCycles } from '@/lib/motion';
+import { clamp, loopCycles, smooth } from '@/lib/motion';
 import { cardPath } from '@/lib/cardPath';
 
 // Reference size (px) shared with the renderer's sprite normalization, so that
@@ -7,7 +7,7 @@ import { cardPath } from '@/lib/cardPath';
 const BASE = 340;
 
 export const carousel: Template = {
-  meta: { id: 'carousel', name: 'Runway', group: 'Runway', defaultEasing: { id: 'glide' } },
+  meta: { id: 'carousel', name: 'Runway', group: 'Runway', engine: 'webgl', defaultEasing: { id: 'glide' } },
 
   controls: [
     // Four-way direction (as in the reference tool): left/right run the strip
@@ -21,7 +21,7 @@ export const carousel: Template = {
     { key: 'scaleFocus',   label: 'Scale Focus',   type: 'pills', options: ['center','start','end'], default: 'center' }, // where the featured card sits
     { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 200, step: 1,  default: 0 },
     { key: 'tiltStyle',    label: 'Tilt Style',    type: 'pills', options: ['off','fan','uniform','alternate'], default: 'off' },
-    { key: 'tiltAmount',   label: 'Tilt Amount',   type: 'slider', min: 0, max: 30, step: 1,   default: 8 },   // degrees
+    { key: 'tiltAmount',   label: 'Tilt Amount',   type: 'slider', min: 0, max: 30, step: 1,   default: 8, section: 'Depth', unit: '°', visibleWhen: { key: 'tiltStyle', not: 'off' }, description: 'Tilts cards in real 3D while their runway path stays unchanged.' },
     { key: 'offset',       label: 'Offset',        type: 'xypad',                              default: { x: 0, y: 0 } },
     { key: 'fade',         label: 'Fade',          type: 'slider', min: 0, max: 100, step: 1,  default: 0 },   // centre-distance fade %
     { key: 'outerFade',    label: 'Outer Fade',    type: 'slider', min: 0, max: 100, step: 1,  default: 100 }, // fade out while leaving the frame %
@@ -57,8 +57,12 @@ export const carousel: Template = {
     // Tilt Style: fan = tilt ∝ signed centre distance; uniform = constant;
     // alternate = ±tilt by card parity.                                          ← Tilt
     const tiltRad = (v.tiltAmount * Math.PI) / 180;
+    // tanh gives the fan a continuous slope through the centre and a soft
+    // saturation toward the edges. The old clamp had visible velocity kinks
+    // when a card crossed ±3 slots.
+    const fan = Math.tanh(offset * 0.72);
     const rotation =
-      v.tiltStyle === 'fan'       ? clamp(offset, -3, 3) * tiltRad * 0.5 :
+      v.tiltStyle === 'fan'       ? fan * tiltRad :
       v.tiltStyle === 'uniform'   ? tiltRad :
       v.tiltStyle === 'alternate' ? (index % 2 ? -tiltRad : tiltRad) : 0;
 
@@ -70,6 +74,14 @@ export const carousel: Template = {
 
     // Edge fade                                                                  ← Fade
     let alpha = 1 - (v.fade / 100) * (1 - p.depthNorm);
+
+    // A wrapped card teleports from one end of the strip to the other. Make
+    // that hand-off fully transparent even when a small gap keeps the final
+    // slot inside the canvas; otherwise the recycle reads as a pop.
+    if (count > 1) {
+      const wrapFade = smooth(clamp((count / 2 - Math.abs(offset)) / 0.7, 0, 1));
+      alpha *= wrapFade;
+    }
 
     // Outer fade: as the card starts leaving the frame, fade it out — fully     ← Outer Fade
     // transparent by the time it has fully exited. Axis-aware.
@@ -93,5 +105,28 @@ export const carousel: Template = {
       depth: p.depthNorm + featured,                             // featured card always wins the draw order
     };
     // cornerRadius is applied where the sprite mask is built, not here.          ← Corner Radius
+  },
+  transform3d: (frame, index, count, v, ctx) => {
+    const flat = carousel.transform(frame, index, count, v, ctx);
+    const horiz = v.direction === 'left' || v.direction === 'right';
+    const dir = (v.direction === 'left' || v.direction === 'up') ? 1 : -1;
+    const phase = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir);
+    const path = cardPath({ kind: 'line', index, count, phase, gap: 1, wrap: true });
+    const fan = Math.tanh(path.x * 0.72);
+    const signed = v.tiltStyle === 'fan' ? fan
+      : v.tiltStyle === 'alternate' ? (index % 2 ? -1 : 1)
+      : v.tiltStyle === 'uniform' ? 1 : 0;
+    const angle = signed * v.tiltAmount * Math.PI / 180;
+    const depth = -(1 - path.depthNorm) * (v.perspective / 100) * v.cardSize * 0.65;
+    return {
+      x: flat.x,
+      y: flat.y,
+      z: depth,
+      rotationX: horiz ? 0 : -angle,
+      rotationY: horiz ? angle : 0,
+      rotationZ: 0,
+      scale: flat.scale,
+      alpha: flat.alpha,
+    };
   },
 };

--- a/templates/coverflow.ts
+++ b/templates/coverflow.ts
@@ -1,0 +1,119 @@
+import type { Template } from '@/lib/types';
+import { clamp, loopCycles, smooth } from '@/lib/motion';
+import { cardPath } from '@/lib/cardPath';
+import { variant } from './variant';
+
+const BASE = 340;
+
+// ============================================================
+//  COVERFLOW — a face-on centre card with the rest turned away
+//
+//  The look is a row of covers where the middle one faces the viewer and the
+//  neighbours are rotated away on the vertical axis, receding into two tight
+//  packs. There is no real 3D here: the turn is faked with the two fields
+//  LayerTransform already provides for it — `scaleX` compresses the card as it
+//  rotates away (cos of the turn angle) and `skewY` shears it into the matching
+//  parallelogram. The type's own comments call these out for "fake-3D tilt" and
+//  "flips/page turns".
+//
+//  The other half of the effect is the SPACING: side cards must bunch up rather
+//  than stay evenly spread, or the row reads as a plain carousel. Past the first
+//  neighbour the step shrinks to `sideStep`, which is what creates the packs.
+// ============================================================
+
+const coverflow: Template = {
+  meta: { id: 'coverflow-01', name: 'Coverflow 01', group: 'Coverflow', isNew: true, defaultEasing: { id: 'glide' } },
+
+  controls: [
+    { key: 'axis',         label: 'Axis',          type: 'pills',  options: ['horizontal','vertical'], default: 'horizontal' },
+    { key: 'direction',    label: 'Direction',     type: 'toggle', options: ['forward','reverse'], default: 'forward' },
+    { key: 'count',        label: 'Count',         type: 'slider', min: 3, max: 20, step: 1,     default: 8 },
+    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 60, max: 600, step: 1,   default: 300 },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,    default: 10 },
+    { key: 'centreGap',    label: 'Centre Gap',    type: 'slider', min: 60, max: 500, step: 1,   default: 230 }, // centre card → first neighbour
+    { key: 'sideStep',     label: 'Side Step',     type: 'slider', min: 10, max: 220, step: 1,   default: 62 },  // step between packed side cards
+    { key: 'turn',         label: 'Turn',          type: 'slider', min: 0, max: 85, step: 1,     default: 58 },  // degrees a side card rotates away
+    { key: 'shear',        label: 'Shear',         type: 'slider', min: 0, max: 100, step: 1,    default: 55 },  // % of the turn expressed as skew
+    { key: 'recede',       label: 'Recede',        type: 'slider', min: 0, max: 60, step: 1,     default: 22 },  // % size lost turning away
+    { key: 'depthScale',   label: 'Depth Falloff', type: 'slider', min: 0, max: 60, step: 1,     default: 26 },  // % further size lost across the pack
+    { key: 'vanish',       label: 'Vanish Drift',  type: 'slider', min: -120, max: 120, step: 1, default: 0 },   // px the pack drifts toward a vanishing point
+    { key: 'curve',        label: 'Curve',         type: 'slider', min: -200, max: 200, step: 1, default: 0 },   // bows the row into an arc
+    { key: 'fade',         label: 'Depth Fade',    type: 'slider', min: 0, max: 100, step: 1,    default: 45 },
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                                default: { x: 0, y: 0 } },
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.1,    default: 0.5 }, // covers/sec
+  ],
+
+  transform: (frame, index, count, v, ctx) => {
+    const horiz = v.axis === 'horizontal';
+    const dir = v.direction === 'reverse' ? -1 : 1;
+
+    // period = count so every cover returns to its own slot at the loop point.
+    const phase = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir);
+    const p = cardPath({ kind: 'line', index, count, phase, gap: 1, wrap: true });
+    const offset = p.x;              // signed distance from centre, in card units
+    const dist = Math.abs(offset);
+    const side = Math.sign(offset);
+
+    const sizeFactor = v.cardSize / BASE;
+
+    // Turn: none at dead centre, full by the first neighbour and beyond. Smooth
+    // so a cover eases into facing the viewer instead of snapping.
+    const t = smooth(clamp(dist, 0, 1));
+    const angle = (v.turn * Math.PI) / 180 * t;
+
+    // Fake 3D: compress across the turn axis, shear along it.
+    const compress = Math.cos(angle);
+    const shear = -side * Math.sin(angle) * (v.shear / 100);
+
+    // Packed spacing: the first neighbour sits at centreGap, everything past it
+    // steps by the much smaller sideStep — that bunching is the whole look.
+    const packed = dist <= 1
+      ? dist * v.centreGap
+      : v.centreGap + (dist - 1) * v.sideStep;
+    const along = side * packed * sizeFactor;
+
+    // How deep into the side pack this cover sits, 0..1. `turn` saturates at the
+    // first neighbour, so without this every card in a pack would share one size
+    // and the pack would read flat. This keeps size and opacity falling with
+    // distance, which is what gives the pack depth.
+    const far = smooth(clamp((dist - 1) / Math.max(1, count / 2 - 1), 0, 1));
+
+    // Curve bows the row, which is what turns a flat strip into a ring. The
+    // vanishing drift pulls the pack off-axis as it recedes, so the two packs
+    // converge instead of running parallel.
+    const across = (v.curve * sizeFactor) * (1 - Math.cos(clamp(dist, 0, 3) * 0.5))
+      + v.vanish * sizeFactor * far;
+
+    const x = (horiz ? along : across) + v.offset.x;
+    const y = (horiz ? across : along) + v.offset.y;
+
+    const scale = sizeFactor * (1 - (v.recede / 100) * t) * (1 - (v.depthScale / 100) * far);
+    const alpha = clamp(1 - (v.fade / 100) * far, 0, 1);
+
+    return {
+      x,
+      y,
+      scale,
+      rotation: 0,
+      alpha,
+      // Compression and shear swap axes with the row, so a vertical coverflow
+      // turns about the horizontal axis instead.
+      scaleX: horiz ? compress : 1,
+      scaleY: horiz ? 1 : compress,
+      skewX: horiz ? 0 : shear,
+      skewY: horiz ? shear : 0,
+      // Centre cover always on top; the packs stack inward behind it.
+      depth: -dist,
+    };
+  },
+};
+
+export const coverflowVariants: Template[] = [
+  coverflow,
+  variant(coverflow, 'coverflow-02', 'Coverflow Vertical', {
+    axis: 'vertical', centreGap: 200, sideStep: 48, turn: 52, cardSize: 260, count: 9,
+  }),
+  variant(coverflow, 'coverflow-03', 'Coverflow Ring', {
+    curve: 150, turn: 70, sideStep: 78, centreGap: 250, recede: 34, fade: 60, count: 12,
+  }),
+];

--- a/templates/coverflow.ts
+++ b/templates/coverflow.ts
@@ -32,7 +32,7 @@ const coverflow: Template = {
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,    default: 10 },
     { key: 'centreGap',    label: 'Centre Gap',    type: 'slider', min: 60, max: 500, step: 1,   default: 230 }, // centre card → first neighbour
     { key: 'sideStep',     label: 'Side Step',     type: 'slider', min: 10, max: 220, step: 1,   default: 62 },  // step between packed side cards
-    { key: 'turn',         label: 'Turn',          type: 'slider', min: 0, max: 85, step: 1,     default: 58 },  // degrees a side card rotates away
+    { key: 'turn',         label: 'Turn',          type: 'slider', min: 0, max: 85, step: 1,     default: 58 },
     { key: 'shear',        label: 'Shear',         type: 'slider', min: 0, max: 100, step: 1,    default: 55 },  // % of the turn expressed as skew
     { key: 'recede',       label: 'Recede',        type: 'slider', min: 0, max: 60, step: 1,     default: 22 },  // % size lost turning away
     { key: 'depthScale',   label: 'Depth Falloff', type: 'slider', min: 0, max: 60, step: 1,     default: 26 },  // % further size lost across the pack
@@ -44,7 +44,7 @@ const coverflow: Template = {
   ],
 
   transform: (frame, index, count, v, ctx) => {
-    const horiz = v.axis === 'horizontal';
+    const horiz = v.axis !== 'vertical';
     const dir = v.direction === 'reverse' ? -1 : 1;
 
     // period = count so every cover returns to its own slot at the loop point.

--- a/templates/deck.ts
+++ b/templates/deck.ts
@@ -1,0 +1,79 @@
+import type { Template } from '@/lib/types';
+import { clamp, loopCycles, smooth } from '@/lib/motion';
+import { cardPath } from '@/lib/cardPath';
+import { variant } from './variant';
+
+const BASE = 340;
+const DEG = Math.PI / 180;
+
+// A depth conveyor whose cards turn as they travel through the centre. This is
+// the home for the WebGL tilt that was previously exposed as its own template:
+// Tilt is a property of the deck, not a motion family.
+const deck: Template = {
+  meta: {
+    id: 'deck-01', name: 'Deck 01', group: 'Deck', isNew: true,
+    defaultEasing: { id: 'smooth' },
+  },
+
+  controls: [
+    { key: 'direction',    label: 'Direction',     type: 'pills', options: ['up','down','left','right'], default: 'up' },
+    { key: 'flipAxis',     label: 'Flip Axis',     type: 'pills', options: ['vertical','horizontal'], default: 'vertical' },
+    { key: 'twoSided',     label: 'Two Sided',     type: 'toggle', options: ['off','on'], default: 'on' },
+    { key: 'solo',         label: 'Solo',          type: 'toggle', options: ['off','on'], default: 'off' },
+    { key: 'count',        label: 'Count',         type: 'slider', min: 2, max: 12, step: 1, default: 6 },
+    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 80, max: 700, step: 1, default: 320 },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1, default: 16 },
+    { key: 'distance',     label: 'Distance',      type: 'slider', min: 200, max: 5000, step: 10, default: 1000 },
+    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 200, step: 1, default: 100 },
+    { key: 'gap',          label: 'Gap',           type: 'slider', min: 0.1, max: 1, step: 0.01, default: 0.29 },
+    { key: 'maxScale',     label: 'Max Scale',     type: 'slider', min: 1, max: 2, step: 0.01, default: 1.15 },
+    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -30, max: 30, step: 0.5, default: 4.5 },
+    { key: 'fade',         label: 'Fade',          type: 'slider', min: 0, max: 100, step: 1, default: 0 },
+    { key: 'thickness',    label: 'Thickness',     type: 'slider', min: 0, max: 24, step: 1, default: 9, section: 'Finish', unit: 'px', advanced: true },
+    { key: 'shadow',       label: 'Shadow',        type: 'toggle', options: ['on','off'], default: 'on', section: 'Finish' },
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 2, step: 0.1, default: 0.25 },
+  ],
+
+  // Pixi fallback for thumbnails and multi-layer scenes. It keeps the timing,
+  // tilt and front/back hand-off but does not pretend to provide 3D depth.
+  transform: (frame, index, count, v, ctx) => {
+    const verticalTravel = v.direction === 'up' || v.direction === 'down';
+    const dir = v.direction === 'up' || v.direction === 'left' ? 1 : -1;
+    const phase = ctx.easedPhase(
+      (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir
+    );
+    const path = cardPath({ kind: 'line', index, count, phase, gap: 1, wrap: true });
+    const offset = path.x;
+    const dist = Math.abs(offset);
+    const centre = smooth(clamp(1 - dist, 0, 1));
+    const turn = Math.cos(offset * Math.PI);
+    const wrapFade = count > 1
+      ? smooth(clamp((count / 2 - dist) / 0.8, 0, 1))
+      : 1;
+    const soloFade = v.solo === 'on' ? centre : 1;
+    const backVisible = v.twoSided === 'on' ? 1 : smooth(clamp(turn / 0.18, 0, 1));
+    const along = offset * v.distance * v.gap;
+    return {
+      x: verticalTravel ? 0 : along,
+      y: verticalTravel ? along : 0,
+      scale: (v.cardSize / BASE) * (1 + (v.maxScale - 1) * centre),
+      scaleX: v.flipAxis === 'horizontal' ? turn : 1,
+      scaleY: v.flipAxis === 'vertical' ? turn : 1,
+      rotation: v.tilt * DEG,
+      alpha: clamp(wrapFade * soloFade * backVisible * (1 - (v.fade / 100) * (1 - path.depthNorm)), 0, 1),
+      depth: centre,
+    };
+  },
+};
+
+export const deckVariants: Template[] = [
+  deck,
+  variant(deck, 'deck-02', 'Deck 02', {
+    direction: 'down', flipAxis: 'horizontal', cardSize: 375,
+    gap: 0.44, tilt: 0, perspective: 100,
+  }),
+  variant(deck, 'deck-03', 'Deck 03', {
+    direction: 'left', cardSize: 445, distance: 1500,
+    gap: 0.44, maxScale: 1, tilt: -8, fade: 30, perspective: 70,
+  }),
+];

--- a/templates/flipgrid.ts
+++ b/templates/flipgrid.ts
@@ -1,0 +1,112 @@
+import type { Template } from '@/lib/types';
+import { TAU, clamp, loopCycles, staggered } from '@/lib/motion';
+import { variant } from './variant';
+
+const BASE = 340;
+
+// ============================================================
+//  FLIP — a grid of tiles turning on their own axis
+//
+//  Each tile turns about its centre line, staggered so the grid ripples rather
+//  than flipping as a block. The turn is a cosine on `scaleX` (or `scaleY`),
+//  which squashes the tile to nothing edge-on and expands it mirrored on the
+//  far side. That mirror is deliberate: a sprite has no back face to show, so a
+//  real 180° flip would reveal nothing — the squash-through-zero is what reads
+//  as a flip in 2D, and it is exactly what `scaleX`/`scaleY` exist for
+//  ("flips/page turns", per LayerTransform).
+//
+//  `edgeFade` dims the tile as it passes edge-on. Without it the mirrored face
+//  arrives at full opacity and the eye notices the image is reversed; a short
+//  dip at the crossing hides the handoff.
+// ============================================================
+
+const flipgrid: Template = {
+  meta: { id: 'flip-01', name: 'Flip 01', group: 'Flip', isNew: true, defaultEasing: { id: 'smooth' }, repeatAssets: true },
+
+  controls: [
+    { key: 'axis',         label: 'Flip Axis',     type: 'pills',  options: ['y','x'],          default: 'y' }, // y = turns left/right
+    { key: 'count',        label: 'Count',         type: 'slider', min: 2, max: 60, step: 1,    default: 12 },
+    { key: 'cols',         label: 'Columns',       type: 'slider', min: 1, max: 10, step: 1,    default: 4 },
+    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 40, max: 400, step: 1,  default: 170 },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,   default: 8 },
+    { key: 'gapX',         label: 'Gap X',         type: 'slider', min: 0, max: 400, step: 1,   default: 190 },
+    { key: 'gapY',         label: 'Gap Y',         type: 'slider', min: 0, max: 400, step: 1,   default: 210 },
+    { key: 'stagger',      label: 'Stagger',       type: 'slider', min: 0, max: 2, step: 0.05,  default: 0.5 },
+    { key: 'order',        label: 'Order',         type: 'pills',  options: ['index','row','col','diagonal'], default: 'diagonal' },
+    { key: 'edgeFade',     label: 'Edge Fade',     type: 'slider', min: 0, max: 100, step: 1,   default: 70 },  // dip as the tile passes edge-on
+    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 100, step: 1,   default: 45 },  // shear that makes the near edge lead
+    { key: 'lift',         label: 'Lift',          type: 'slider', min: 0, max: 40, step: 1,    default: 10 },  // % scale gain mid-flip
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                               default: { x: 0, y: 0 } },
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.1,   default: 0.4 }, // flips/sec
+  ],
+
+  transform: (frame, index, count, v, ctx) => {
+    const cols = Math.max(1, Math.round(v.cols));
+    const rows = Math.max(1, Math.ceil(count / cols));
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+
+    const sizeFactor = v.cardSize / BASE;
+    const x = (col - (cols - 1) / 2) * v.gapX * sizeFactor + v.offset.x;
+    const y = (row - (rows - 1) / 2) * v.gapY * sizeFactor + v.offset.y;
+
+    // Period 1: a full turn per cycle, so a whole number of cycles per clip
+    // lands frame totalFrames back on frame 0.
+    const t = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, 1));
+
+    // Which tile leads the ripple. `staggered` offsets each tile's own clock by
+    // its normalized position and wraps with frac(), so it stays loop-safe.
+    const span =
+      v.order === 'row'      ? row / Math.max(1, rows - 1) :
+      v.order === 'col'      ? col / Math.max(1, cols - 1) :
+      v.order === 'diagonal' ? (col + row) / Math.max(1, (cols - 1) + (rows - 1)) :
+                               index / Math.max(1, count - 1);
+    // staggered() wants a normalized index; feed it the chosen ordering directly.
+    const local = staggered(t, span * Math.max(1, count - 1), Math.max(2, count), v.stagger);
+
+    // The turn. cos goes 1 → 0 → −1 → 0 → 1 over one cycle: face, edge-on,
+    // mirrored face, edge-on, back to face.
+    const turn = Math.cos(local * TAU);
+
+    // Edge-on is where |turn| is small — dip the opacity through the crossing.
+    const edge = 1 - Math.abs(turn);           // 0 face-on, 1 edge-on
+    const alpha = clamp(1 - (v.edgeFade / 100) * edge, 0, 1);
+    // A little size gain mid-turn sells the tile leaving the plane.
+    const scale = sizeFactor * (1 + (v.lift / 100) * edge);
+
+    const flipY = v.axis === 'y';
+
+    // A cosine on scaleX alone is a squash, not a turn: both halves of the tile
+    // narrow equally, so nothing reads as coming toward the viewer. Shearing by
+    // sin of the same angle skews the tile the other way through the crossing,
+    // which is what makes the leading edge look nearer. sin is zero whenever
+    // cos is ±1, so the tile is unsheared whenever it faces the viewer — and
+    // the loop seam is untouched.
+    const shear = Math.sin(local * TAU) * (v.perspective / 100) * 0.45;
+
+    return {
+      x,
+      y,
+      scale,
+      rotation: 0,
+      alpha,
+      scaleX: flipY ? turn : 1,
+      scaleY: flipY ? 1 : turn,
+      skewY: flipY ? shear : 0,
+      skewX: flipY ? 0 : shear,
+      // Tiles crossing edge-on lift over their neighbours, so the ripple reads
+      // as passing in front rather than clipping through.
+      depth: edge,
+    };
+  },
+};
+
+export const flipVariants: Template[] = [
+  flipgrid,
+  variant(flipgrid, 'flip-02', 'Flip 02', {
+    axis: 'x', cols: 6, count: 24, cardSize: 120, gapX: 135, gapY: 150, order: 'row', stagger: 0.9, edgeFade: 85, speed: 0.3,
+  }),
+  variant(flipgrid, 'flip-03', 'Flip 03', {
+    cols: 2, count: 4, cardSize: 300, gapX: 330, gapY: 360, order: 'index', stagger: 0.25, lift: 22, speed: 0.6,
+  }),
+];

--- a/templates/frames.ts
+++ b/templates/frames.ts
@@ -1,0 +1,214 @@
+import type { Template } from '@/lib/types';
+import type { EasingSpec } from '@/lib/easing';
+import { clamp, stepHold } from '@/lib/motion';
+import { variant } from './variant';
+
+// Reference size (px) shared with the renderer's sprite normalization, so that
+// `cardSize` reads directly in on-screen pixels.
+const BASE = 340;
+
+// ============================================================
+//  FRAMES — a gallery wall that drifts past the frame
+//
+//  Every other conveyor in the catalogue moves cards along ONE axis: Ticker
+//  runs a band, Runway glides a row, Dock magnifies a static grid. Frames is
+//  the two-axis case — a masonry wall of hung pictures, larger than the canvas,
+//  so new work keeps entering from the edge. The camera never stops on a hero
+//  card; the wall itself is the subject.
+//
+//  The wall is WOVEN, not rigid, and that is the whole family. Measuring the
+//  reference wall makes the split explicit: the gap between rows stays pinned at
+//  one cell for the entire clip, while the horizontal offset BETWEEN rows keeps
+//  changing (three sampled rows sat at +277/+148 apart, later at +109/-395,
+//  later at -200/+61). So the stack scrolls vertically as one block, and each
+//  row slides sideways on its own. A wall that pans as a single rigid sheet
+//  reads mechanical — it is the independent row drift that reads as a gallery.
+//
+//  Four things define it:
+//
+//  · Masonry — rows start offset like brickwork (`rowsSkipped`), so vertical
+//    seams never line up. Aligned columns read as a spreadsheet.
+//
+//  · Weave — `weave` picks whether rows share a drift rate, alternate, or each
+//    take their own. `sweep` scales how far they drift.
+//
+//  · Hold — the wall can advance cell by cell and pause on each, the way a
+//    viewer stops in front of each picture. Routes through `stepHold` so a
+//    stop-and-go wall stays loop-safe.
+//
+//  Seamless loop, on both axes independently. Vertically the block travels a
+//  whole number of cells, snapped to a multiple of `rows` so the lattice lands
+//  back on itself. Horizontally each row travels a whole number of LATTICE
+//  WIDTHS — a multiple of one cell is not enough, since shifting a row by k
+//  cells puts a different picture in every slot and the export pops once per
+//  cycle. Both clocks share `advance`, whose f(0)=0 and f(n)=n make the closure
+//  exact rather than approximate.
+// ============================================================
+
+// The divisor of `n` closest to `want`, preferring the wider grid on a tie so
+// the wall stays landscape-ish rather than collapsing to a single column.
+// Shared with the Grid family, which has the same no-half-row requirement.
+export function divisorNear(n: number, want: number): number {
+  let best = 1;
+  for (let d = 1; d <= n; d++) {
+    if (n % d !== 0) continue;
+    if (Math.abs(d - want) < Math.abs(best - want)) best = d;
+  }
+  return best;
+}
+
+const framesBase: Template = {
+  meta: {
+    id: 'wall-01',
+    name: 'Frames 01',
+    group: 'Frames',
+    isNew: true,
+    // The reference wall ships a firm in-out curve, steeper than Smooth.
+    defaultEasing: { id: 'custom', bezier: [0.7, 0, 0.3, 1] },
+    repeatAssets: true,
+    // Hung pictures are portrait 3:4, not the 4:5 default.
+    cardAspect: 3 / 4,
+  },
+
+  controls: [
+    { key: 'direction',    label: 'Direction',     type: 'pills',  options: ['forward','reverse'], default: 'forward' },
+    { key: 'count',        label: 'Count',         type: 'slider', min: 2, max: 60, step: 1,   default: 9 },
+    { key: 'columns',      label: 'Columns',       type: 'slider', min: 1, max: 10, step: 1,   default: 3, section: 'Layout', description: 'Snaps to a divisor of Count so the wall has no half-filled row.' },
+    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 60, max: 1000, step: 1, default: 762 },
+    { key: 'gap',          label: 'Gap',           type: 'slider', min: 0, max: 300, step: 1,  default: 30 },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,  default: 0 },
+    { key: 'rowsSkipped',  label: 'Rows Skipped',  type: 'slider', min: 0, max: 2, step: 1,    default: 1, section: 'Layout', description: 'Masonry offset: 0 aligns columns, 1 shifts every other row, 2 steps in thirds.' },
+    { key: 'weave',        label: 'Weave',         type: 'pills',  options: ['same','opposed','varied'], default: 'varied', section: 'Motion', description: 'Whether rows share a sideways drift, alternate direction, or each take their own rate.' },
+    { key: 'sweep',        label: 'Sweep',         type: 'slider', min: 0, max: 1, step: 0.1,  default: 0.4, section: 'Motion', description: 'How far rows drift sideways. 0 is a straight vertical lift.' },
+    { key: 'hold',         label: 'Hold',          type: 'slider', min: 0, max: 90, step: 1,   default: 30, section: 'Motion', unit: '%', description: 'Share of each cell step spent stopped.' },
+    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -15, max: 15, step: 0.5, default: 0, section: 'Depth', unit: '°', description: 'Rotates the complete wall.' },
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                              default: { x: 0, y: 0 } },
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.05, default: 0.5 }, // cells/sec
+  ],
+
+  transform: (frame, index, count, v, ctx) => {
+    // The wall wraps as a torus, so a half-filled last row is not a cosmetic
+    // detail: the empty cells scroll straight through the frame as holes.
+    // Snapping Columns to a divisor of Count makes the lattice a complete
+    // rectangle for every count, without hiding a card or doubling one up.
+    const cols = divisorNear(count, clamp(Math.round(v.columns), 1, 10));
+    const rows = Math.max(1, Math.round(count / cols));
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+
+    // The renderer normalizes a sprite's LONG edge to BASE, so cardSize is that
+    // edge and the short one follows the card's RESOLVED aspect — which the
+    // scene's card shape can override away from this family's declared 3:4.
+    // Spacing off the declared value leaves one mount right and the other wrong.
+    // `gap` is a true edge gap in canvas px, which is why it is not scaled:
+    // pitch has to stay readable as "card plus mount".
+    const aspect = ctx.cardAspect ?? 3 / 4;
+    const sizeFactor = v.cardSize / BASE;
+    const cardW = aspect < 1 ? v.cardSize * aspect : v.cardSize;
+    const cardH = aspect < 1 ? v.cardSize : v.cardSize / aspect;
+    const pitchX = cardW + v.gap;
+    const pitchY = cardH + v.gap;
+
+    // Masonry: rowsSkipped 0 aligns columns, 1 shifts alternate rows half a
+    // cell, 2 steps in thirds. The shift is fractional so it survives wrapping.
+    const period = Math.round(clamp(v.rowsSkipped, 0, 2)) + 1;
+    const rowShift = period > 1 ? (row % period) / period : 0;
+
+    // The wall is a torus: each axis wraps over its full lattice span, so cards
+    // leaving one edge re-enter at the opposite one.
+    const spanX = cols * pitchX;
+    const spanY = rows * pitchY;
+
+    // Vertical: the stack scrolls as ONE block — measuring the reference wall,
+    // the gap between rows never changes. Whole cells, snapped to a multiple of
+    // `rows` so the lattice lands back on itself at the loop point.
+    const stepsY = rows * Math.max(1, Math.round((v.speed * ctx.duration) / rows));
+
+    const dir = v.direction === 'reverse' ? -1 : 1;
+    const t = frame / ctx.totalFrames;
+
+    // One phase unit = one cell, so a hold pauses on whole cells. `stepHold` is
+    // loop-safe (f(n) = n at integers) and takes the scene curve, so stepping
+    // and easing compose instead of fighting. Both axes read this one clock, so
+    // a held wall stops completely instead of shearing.
+    const hold = clamp(v.hold / 100, 0, 0.95);
+    const advance = hold > 0
+      ? stepHold(t * stepsY, hold, ctx.ease)
+      : ctx.easedPhase(t * stepsY);
+    const panY = advance * pitchY * dir;
+
+    // Horizontal: each row rides its own ring. `laps` counts whole LATTICE
+    // WIDTHS, not cells — shifting a row by k cells would leave a different
+    // picture in every slot at the loop point, and the export would pop once per
+    // cycle. Integer laps keep each row's own loop exact while letting the rows
+    // disagree with each other, and that disagreement is the weave.
+    const baseLaps = v.sweep > 0
+      ? Math.max(1, Math.round((v.sweep * stepsY * pitchY) / spanX))
+      : 0;
+    const alternate = row % 2 === 1 ? -1 : 1;
+    const laps = baseLaps === 0 ? 0
+      : v.weave === 'same' ? baseLaps
+      : v.weave === 'opposed' ? baseLaps * alternate
+      // `varied` — a distinct rate per row, so no two rows ever re-align.
+      : (baseLaps + (row % 3)) * alternate;
+    const panX = (advance / stepsY) * laps * spanX * dir;
+
+    const wrapCentred = (u: number, span: number) => (((u % span) + span) % span) - span / 2;
+
+    const px = wrapCentred((col + rowShift) * pitchX - panX, spanX);
+    const py = wrapCentred(row * pitchY - panY, spanY);
+
+    const roll = (Number(v.tilt ?? 0) * Math.PI) / 180;
+    const x = px * Math.cos(roll) - py * Math.sin(roll) + v.offset.x;
+    const y = px * Math.sin(roll) + py * Math.cos(roll) + v.offset.y;
+
+    return {
+      x,
+      y,
+      scale: sizeFactor,
+      rotation: roll,
+      alpha: 1,
+      // Stable, lattice-derived order — a hung wall never restacks mid-pan.
+      depth: row + col * 0.01,
+    };
+  },
+};
+
+// `variant` intentionally only patches control defaults. A preset that also
+// ships its own curve needs the meta patched too, which is what this adds.
+function preset(
+  base: Template,
+  id: string,
+  name: string,
+  patch: Record<string, any>,
+  easing?: EasingSpec
+): Template {
+  const t = variant(base, id, name, patch);
+  return easing ? { ...t, meta: { ...t.meta, defaultEasing: easing } } : t;
+}
+
+export const framesVariants: Template[] = [
+  framesBase,
+  preset(framesBase, 'wall-02', 'Frames 02', {
+    cardSize: 670, rowsSkipped: 0, hold: 0,
+  }),
+  preset(framesBase, 'wall-03', 'Frames 03', {
+    cardSize: 610, rowsSkipped: 2, hold: 50, direction: 'reverse',
+  }),
+  preset(framesBase, 'wall-04', 'Frames 04', {
+    cardSize: 610, hold: 0,
+  }, { id: 'linear' }),
+  preset(framesBase, 'wall-05', 'Frames 05', {
+    tilt: -15, hold: 0,
+  }, { id: 'flow' }),
+  // A dense wall of small prints: more cells, wide mounts between them. The
+  // lattice has to stay larger than the canvas, so a smaller card needs more
+  // of them — count and columns move together with cardSize.
+  preset(framesBase, 'wall-06', 'Frames 06', {
+    cardSize: 152, gap: 80, hold: 0, count: 30, columns: 6, direction: 'reverse',
+  }, { id: 'linear' }),
+  // Gapless — the wall reads as one continuous tiled surface.
+  preset(framesBase, 'wall-07', 'Frames 07', {
+    cardSize: 465, gap: 0, hold: 0, count: 16, columns: 4,
+  }, { id: 'linear' }),
+];

--- a/templates/globe.ts
+++ b/templates/globe.ts
@@ -1,30 +1,49 @@
 import type { Template } from '@/lib/types';
 import { loopCycles } from '@/lib/motion';
+import { backfaceFade, tiltNormalCanvas, tiltPointCanvas } from '@/lib/tilt3d';
 import { variant } from './variant';
 
 const BASE = 340;
 const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
 
+function globeCardPx(radius: number, count: number, requested: number, gap: number) {
+  // Approximate the Fibonacci cell's geodesic diameter from sphere area, then
+  // reserve visible breathing room. Large cards previously converged into one
+  // bright central slab while their dark edges flickered around it.
+  const cell = radius * Math.sqrt((4 * Math.PI) / Math.max(6, count));
+  const fill = 0.54 * (1 - Math.min(40, Math.max(0, gap)) / 100);
+  return Math.min(requested, cell * fill);
+}
+
 // Globe — images tiled evenly over a slowly spinning sphere (Fibonacci
 // distribution). Front tiles sit large and opaque; rear tiles shrink and fade.
 const globe: Template = {
-  meta: { id: 'globe-01', name: 'Globe 01', group: 'Globe', defaultEasing: { id: 'linear' } },
+  meta: { id: 'globe-01', name: 'Globe Base', group: 'Globe', engine: 'webgl', catalog3d: true, repeatAssets: true, defaultEasing: { id: 'linear' } },
 
   controls: [
     { key: 'direction',    label: 'Direction',     type: 'toggle', options: ['forward','reverse'], default: 'forward' },
-    { key: 'count',        label: 'Count',         type: 'slider', min: 6, max: 60, step: 1,   default: 36 },
-    { key: 'radius',       label: 'Radius',        type: 'slider', min: 100, max: 700, step: 1, default: 420 },
-    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 20, max: 300, step: 1, default: 120 },
+    { key: 'count',        label: 'Count',         type: 'slider', min: 6, max: 60, step: 1,   default: 24 },
+    { key: 'radius',       label: 'Globe Size',    type: 'slider', min: 100, max: 700, step: 1, default: 280, section: 'Layout', unit: 'px' },
+    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 20, max: 300, step: 1, default: 90 },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,  default: 12 },
+    { key: 'gap',          label: 'Gap',           type: 'slider', min: 0, max: 40, step: 1, default: 8, section: 'Layout', unit: '%' },
+    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -45, max: 45, step: 1, default: 0, section: 'Depth', unit: '°', description: 'Rotates the sphere axis while preserving the Fibonacci distribution.' },
+    { key: 'facing',       label: 'Facing',        type: 'pills', options: ['camera','surface'], default: 'surface', section: 'Depth' },
+    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 100, step: 1, default: 35, section: 'Depth', unit: '%' },
+    { key: 'backFade',     label: 'Back Fade',     type: 'slider', min: 0, max: 100, step: 1, default: 55, section: 'Finish', unit: '%' },
+    { key: 'thickness',    label: 'Thickness',     type: 'slider', min: 0, max: 20, step: 1, default: 0, section: 'Finish', unit: 'px', advanced: true },
+    { key: 'shadow',       label: 'Shadow',        type: 'toggle', options: ['on','off'], default: 'off', section: 'Finish' },
     { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.1,  default: 0.4 },
     { key: 'offset',       label: 'Offset',        type: 'xypad',                              default: { x: 0, y: 0 } },
   ],
+
+  camera: (v) => ({ fov: 18 + Math.min(100, Math.max(0, v.perspective)) * 0.2 }),
 
   transform: (frame, index, count, v, ctx) => {
     const dir = v.direction === 'reverse' ? -1 : 1;
     // Revolutions per clip, loop-locked to a whole number (lon has period t=1).
     const t = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration) * dir;
-    const sizeFactor = v.cardSize / BASE;
+    const sizeFactor = globeCardPx(v.radius, count, v.cardSize, v.gap) / BASE;
 
     // Fibonacci sphere: even latitude bands, golden-angle longitude + spin.
     const gold = Math.PI * (3 - Math.sqrt(5));
@@ -51,17 +70,44 @@ const globe: Template = {
       depth: depthN,
     };
   },
+  transform3d: (frame, index, count, v, ctx) => {
+    const dir = v.direction === 'reverse' ? -1 : 1;
+    const t = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration) * dir;
+    const gold = Math.PI * (3 - Math.sqrt(5));
+    const lat = Math.asin(-1 + 2 * (index + 0.5) / count);
+    const lon = index * gold + t * Math.PI * 2;
+    const normal = {
+      x: Math.cos(lat) * Math.sin(lon),
+      y: Math.sin(lat),
+      z: Math.cos(lat) * Math.cos(lon),
+    };
+    const n = tiltNormalCanvas(normal, { pitch: v.tilt });
+    const p = tiltPointCanvas({ x: normal.x * v.radius, y: normal.y * v.radius, z: normal.z * v.radius }, { pitch: v.tilt });
+    return {
+      x: p.x + v.offset.x,
+      y: p.y + v.offset.y,
+      z: p.z,
+      rotationX: v.facing === 'surface' ? -Math.asin(Math.max(-1, Math.min(1, n.y))) : 0,
+      rotationY: v.facing === 'surface' ? Math.atan2(n.x, n.z) : 0,
+      rotationZ: 0,
+      scale: globeCardPx(v.radius, count, v.cardSize, v.gap) / BASE,
+      alpha: backfaceFade(n.z, v.backFade),
+      thickness: v.thickness,
+      shadowStrength: v.shadow === 'on' ? 1 : 0,
+      materialExposure: 0.68 + Math.max(0, n.z) * 0.4,
+    };
+  },
 };
 
 export const globeVariants: Template[] = [
   globe, // Globe 01 — full sphere
-  variant(globe, 'globe-02', 'Globe 02', {
-    count: 24, radius: 300, cardSize: 150,
+  variant(globe, 'globe-02', 'Globe Focus', {
+    count: 18, radius: 230, cardSize: 135, tilt: 27, backFade: 82,
   }),
   variant(globe, 'globe-03', 'Globe 03', {
-    count: 60, radius: 560, cardSize: 90,
+    count: 42, radius: 330, cardSize: 78,
   }),
   variant(globe, 'globe-04', 'Globe 04', {
-    count: 48, radius: 680, cardSize: 110, speed: 0.7,
+    count: 36, radius: 360, cardSize: 88, speed: 0.7,
   }),
 ];

--- a/templates/gravity.ts
+++ b/templates/gravity.ts
@@ -1,5 +1,6 @@
 import type { Template } from '@/lib/types';
 import { variant } from './variant';
+import { smoother } from '@/lib/tilt3d';
 
 const BASE = 340;
 const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
@@ -50,6 +51,7 @@ const gravity: Template = {
     { key: 'stagger',      label: 'Stagger',       type: 'slider', min: 0, max: 0.6, step: 0.02, default: 0.18 },
     { key: 'spread',       label: 'Spread',        type: 'slider', min: 100, max: 800, step: 1,  default: 500 },
     { key: 'spin',         label: 'Spin',          type: 'slider', min: 0, max: 3, step: 0.1,    default: 1 },
+    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: 0, max: 45, step: 1,     default: 18 },
     // A drop settles in a couple of seconds, so on a default 8s clip the pile
     // sat frozen for most of it and then teleported back to the top. `drops`
     // fits whole drops into the clip instead, and `recycleFade` dissolves each
@@ -114,14 +116,16 @@ const gravity: Template = {
     const driftVx = (h(index + 11) - 0.5) * 500 * (1 - v.friction);
     const airX = spawnX + driftVx * Math.min(tau, tTotal);
     const settle = tTotal > 1e-6 ? clamp(tau / tTotal, 0, 1) : 1;
-    const settle2 = settle * settle;                     // ease toward the column
+    // Quintic smoothstep has zero velocity and acceleration at both ends, so
+    // horizontal drift and resting tilt do not kink at the final impact.
+    const settle2 = smoother(settle);
     const x = clamp(lerp(airX, columnX, settle2), -ctx.width / 2, ctx.width / 2);
 
     // ---- Rotation: tumble in the air, relax to a slight resting tilt ----
     const spinDir = h(index + 17) < 0.5 ? -1 : 1;
     const spinSpeed = v.spin * 4;                        // rad/s at spin=1
     const airRot = spinDir * spinSpeed * Math.min(tau, tTotal);
-    const restTilt = (h(index + 13) - 0.5) * 0.25;       // small ±0.125 rad
+    const restTilt = (h(index + 13) - 0.5) * 2 * v.tilt * Math.PI / 180;
     const rotation = lerp(airRot, restTilt, settle2);
 
     // Dissolve the settled pile over the tail of the drop, so the recycle reads
@@ -158,6 +162,6 @@ export const gravityVariants: Template[] = [
   }),
   variant(gravity, 'gravity-03', 'Bounce 03', {
     // Slow-mo: low gravity, gentle spin, wide lazy scatter.
-    gravity: 0.35, bounce: 0.3, friction: 0.5, spin: 0.5, stagger: 0.3, cardSize: 160,
+    gravity: 0.35, bounce: 0.3, friction: 0.5, spin: 0.5, tilt: 12, stagger: 0.3, cardSize: 160,
   }),
 ];

--- a/templates/grid.ts
+++ b/templates/grid.ts
@@ -1,0 +1,179 @@
+import type { Template } from '@/lib/types';
+import type { EasingSpec } from '@/lib/easing';
+import { TAU, clamp, stepHold } from '@/lib/motion';
+import { variant } from './variant';
+import { divisorNear } from './frames';
+
+const BASE = 340;
+
+// ============================================================
+//  GRID — a tiled wall that steps diagonally, cell by cell
+//
+//  This is Frames' squared-off sibling, and the difference is the weave. Frames
+//  offsets its rows like brickwork and lets each one drift at its own rate; Grid
+//  keeps its columns ALIGNED and moves as one piece, advancing in discrete cell
+//  steps with a beat of stillness between them. Frames wanders, Grid marches.
+//  (Dock is a third thing again: a grid that magnifies near a moving focus.)
+//
+//  Measured on the reference tool, with the playhead paused — which matters,
+//  because reading its card list while it plays returns half-written frames and
+//  produced two rounds of nonsense before this:
+//
+//  · The lattice is rigid. Every visible card shares one position residue
+//    (spread 0 across 9 cards), so the whole wall moves as one piece.
+//  · Columns are aligned — all three rows sat on the same set of x values, with
+//    no masonry offset anywhere in the clip.
+//  · Cards are 3:4 at a constant size while `zoom` is off, 700x933 on its
+//    1080x1440 stage, with `planeSize` reading directly as the card's WIDTH in
+//    px. Halving that for this project's canvas and dividing back out by the 3:4
+//    ratio cancels exactly, so `cardSize` here equals the reference planeSize.
+//  · Pitch is card + gap on both axes (700+80, 933+80).
+//  · The clip loops exactly, and the wall returns to its home cell six times
+//    across it — a 2.93s cycle on a 17.6s clip.
+//
+//  The motion, tracked by following one identified cell across a cycle rather
+//  than by reading residues (which wrap and mislead):
+//
+//      t=0.00  (540, -293)      t=1.47  (-74,  505)
+//      t=0.24  (540, -293)      t=2.20  (-202, 671)
+//      t=0.73  (430, -151)      t=3.18  (-241, 719)
+//
+//  That is a displacement of (-781, +1012), which is exactly (-1 pitchX,
+//  +1 pitchY). So the wall advances ONE CELL DIAGONALLY per cycle — left one
+//  column, down one row — six times over the clip. Its progress within a step
+//  runs 0, 0, 0.015, 0.14, 0.46, 0.79, 0.95, 0.99: a distinct hold at the start
+//  and then a long deceleration, which is a stepped advance, not a glide.
+//
+//  So Grid is a stepped diagonal conveyor with aligned columns, and Frames is a
+//  woven one with offset rows. An earlier version of this file had it drifting a
+//  few percent of a cell in place, which was wrong by an order of magnitude —
+//  that reading came from residues sampled while the playhead was running.
+// ============================================================
+
+const grid: Template = {
+  meta: {
+    id: 'grid-01',
+    name: 'Grid 01',
+    group: 'Grid',
+    isNew: true,
+    defaultEasing: { id: 'glide' },
+    cardAspect: 3 / 4,
+    repeatAssets: true,
+  },
+
+  controls: [
+    // The lattice has to hold at least as many distinct cells along each axis as
+    // the wall takes steps, or the whole composition repeats inside one clip:
+    // a 3x3 returns to itself every 3 steps, so six steps played the same three
+    // frames twice. Six columns and six rows give six distinct steps. Most of
+    // those cells sit off-canvas at any moment — that is the overscan doing its
+    // job, and it is what the reference gets for free by virtualizing.
+    { key: 'count',        label: 'Count',         type: 'slider', min: 2, max: 60, step: 1,   default: 36 },
+    { key: 'columns',      label: 'Columns',       type: 'slider', min: 1, max: 10, step: 1,   default: 6, section: 'Layout', description: 'Snaps to a divisor of Count so the wall has no half-filled row.' },
+    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 60, max: 1000, step: 1, default: 700 },
+    { key: 'gap',          label: 'Gap',           type: 'slider', min: 0, max: 400, step: 1,  default: 60 },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,  default: 0 },
+    { key: 'direction',    label: 'Direction',     type: 'pills',  options: ['forward','reverse'], default: 'forward', section: 'Motion' },
+    { key: 'cycles',       label: 'Steps',         type: 'slider', min: 0, max: 24, step: 1,   default: 6, section: 'Motion', description: 'Cells advanced diagonally over the clip. 0 pins the wall still.' },
+    { key: 'hold',         label: 'Hold',          type: 'slider', min: 0, max: 90, step: 1,   default: 12, section: 'Motion', unit: '%', description: 'Share of each cell step spent stopped before it moves.' },
+    { key: 'zoom',         label: 'Zoom',          type: 'pills',  options: ['off','on'],      default: 'off', section: 'Motion' },
+    { key: 'zoomAmount',   label: 'Zoom Amount',   type: 'slider', min: 0, max: 60, step: 1,   default: 20, unit: '%', visibleWhen: { key: 'zoom', equals: 'on' } },
+    { key: 'breath',       label: 'Breath',        type: 'pills',  options: ['off','on'],      default: 'off', section: 'Motion', description: 'A cyclic swell on top of the zoom.' },
+    { key: 'pulseAmt',     label: 'Breath Amount', type: 'slider', min: 0, max: 60, step: 1,   default: 20, unit: '%', visibleWhen: { key: 'breath', equals: 'on' } },
+    { key: 'pulseCycles',  label: 'Breath Cycles', type: 'slider', min: 1, max: 12, step: 1,   default: 6, visibleWhen: { key: 'breath', equals: 'on' } },
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                              default: { x: 0, y: 0 } },
+  ],
+
+  transform: (frame, index, count, v, ctx) => {
+    // Same no-half-row rule as Frames: an incomplete last row would read as a
+    // hole punched in the wall, and here it never scrolls away.
+    const cols = divisorNear(count, clamp(Math.round(v.columns), 1, 10));
+    const rows = Math.max(1, Math.round(count / cols));
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+
+    // The renderer normalizes a sprite's LONG edge, so cardSize is that edge and
+    // the short one follows the card's RESOLVED aspect — which the scene's card
+    // shape can override away from this family's declared 3:4. Spacing off the
+    // declared value instead leaves one gutter right and the other wrong: at the
+    // 4:5 shape a nominal 60px gap comes out 60 vertically and 25 across.
+    // `gap` is a true edge gap in canvas px, so pitch reads as "card plus gutter".
+    const aspect = ctx.cardAspect ?? 3 / 4;
+    const sizeFactor = v.cardSize / BASE;
+    const cardW = aspect < 1 ? v.cardSize * aspect : v.cardSize;
+    const cardH = aspect < 1 ? v.cardSize : v.cardSize / aspect;
+    const pitchX = cardW + v.gap;
+    const pitchY = cardH + v.gap;
+
+    const spanX = cols * pitchX;
+    const spanY = rows * pitchY;
+
+    // The wall steps a whole cell per cycle on BOTH axes, so travel is snapped
+    // to a multiple of the lattice period on each — a wall that stops a third of
+    // the way across would put different pictures in the same cells at the loop
+    // point. With the measured 6 steps on a 3x3 that snap is already exact.
+    const want = Math.max(0, Math.round(v.cycles));
+    const stepsX = want === 0 ? 0 : cols * Math.max(1, Math.round(want / cols));
+    const stepsY = want === 0 ? 0 : rows * Math.max(1, Math.round(want / rows));
+
+    const dir = v.direction === 'reverse' ? -1 : 1;
+    const u = frame / ctx.totalFrames;
+
+    // One phase unit = one cell, so the hold parks the wall on whole cells.
+    // `stepHold` is loop-safe (f(n) = n) and takes the scene curve, which is
+    // what produces the measured shape: a beat of stillness, then a long settle.
+    const hold = clamp(v.hold / 100, 0, 0.95);
+    const step = (total: number) => total === 0 ? 0
+      : hold > 0 ? stepHold(u * total, hold, ctx.ease) : ctx.easedPhase(u * total);
+
+    // Measured: left one column and down one row per cycle.
+    const panX = -step(stepsX) * pitchX * dir;
+    const panY = step(stepsY) * pitchY * dir;
+
+    const wrapCentred = (q: number, span: number) => (((q % span) + span) % span) - span / 2;
+    const baseX = wrapCentred(col * pitchX - panX, spanX);
+    const baseY = wrapCentred(row * pitchY - panY, spanY);
+
+    const turn = TAU * u;
+
+    // Zoom swells once and returns; breath rides a whole number of cycles on top,
+    // which is why Breath Cycles is an integer slider.
+    const z = v.zoom === 'on'
+      ? 1 + (v.zoomAmount / 100) * (0.5 - 0.5 * Math.cos(turn))
+      : 1;
+    const b = v.breath === 'on'
+      ? 1 + (v.pulseAmt / 100) * 0.5 * Math.sin(turn * Math.round(v.pulseCycles))
+      : 1;
+    const swell = z * b;
+
+    // Scaling the lattice with the cards keeps the zoom centred on the frame
+    // instead of sliding the wall off one corner.
+    return {
+      x: baseX * swell + v.offset.x,
+      y: baseY * swell + v.offset.y,
+      scale: sizeFactor * swell,
+      rotation: 0,
+      alpha: 1,
+      depth: row + col * 0.01,
+    };
+  },
+};
+
+// `variant` only patches control defaults; a preset with its own curve needs
+// `meta` patched too.
+function preset(id: string, name: string, patch: Record<string, any>, easing: EasingSpec): Template {
+  const t = variant(grid, id, name, patch);
+  return { ...t, meta: { ...t.meta, defaultEasing: easing } };
+}
+
+const SMOOTH: EasingSpec = { id: 'smooth' };
+
+export const gridVariants: Template[] = [
+  grid,
+  // A dense 7x7 of smaller tiles.
+  preset('grid-02', 'Grid 02', { count: 49, columns: 7, cardSize: 537, gap: 59 }, { id: 'glide' }),
+  preset('grid-03', 'Grid 03', { gap: 89 }, SMOOTH),
+  // Wide gutters and a real zoom — the tiles read as separate prints on a wall.
+  preset('grid-04', 'Grid 04', { cardSize: 637, gap: 375, zoom: 'on', zoomAmount: 30 }, SMOOTH),
+  preset('grid-05', 'Grid 05', { gap: 89, zoom: 'on' }, SMOOTH),
+];

--- a/templates/helix3d.ts
+++ b/templates/helix3d.ts
@@ -1,0 +1,251 @@
+import type { Template } from '@/lib/types';
+import { TAU, clamp, lerp, loopCycles } from '@/lib/motion';
+import {
+  DEG, backfaceFade, quaternionFromEuler, tiltNormalCanvas, tiltPointCanvas, wrapEnvelope,
+} from '@/lib/tilt3d';
+import { variant } from './variant';
+
+const BASE = 340;
+
+// ============================================================
+//  HELIX 3D — a corkscrew of cards climbing a tilted axis
+//
+//  A separate family from the existing pixi Helix, not a replacement: that one
+//  stays exactly as it is. The old one fakes depth — x = sin(a)·radius with no z
+//  at all, and cos(a) reused as a sort key — so the cards slide past each other
+//  on a flat plane. Here the helix is an actual curve in space, seen through the
+//  perspective camera, with the axis itself tiltable.
+//
+//  Axis runs VERTICALLY. A helix around the z axis would corkscrew toward the
+//  camera, which is territory Card Tunnel already occupies; keeping the axis
+//  upright is what makes this a staircase rather than a second tunnel, and it is
+//  what `Card Gap` reads against — the rise per card, i.e. the helix pitch.
+//
+//  Cards face OUTWARD from the axis, like the risers on a spiral stair. The
+//  normal is aimed with the same construction globe.ts uses (rotationY =
+//  atan2(n.x, n.z), rotationX = -asin(n.y)) rather than by assuming the angle,
+//  because once the axis is tilted the radial direction is no longer the flat
+//  circle's radial direction.
+//
+//  ONE CAMERA. `camera()` is mandatory: without it renderer3d maps
+//  `values.perspective` over 0..200, and this family's Perspective range is
+//  0..40 — the default mapping would read every value as a long lens.
+// ============================================================
+
+// ---- The one assumption in this file ----------------------------------------
+// `Taper` could not be measured: the reference editor suspends its render loop
+// whenever its tab is not compositing, so its canvas stayed frozen and sweeping
+// the slider produced no observable change. Read from the name and its symmetric
+// -90..90 range: the radius varies along the spiral, negative closing it toward
+// the far end and positive opening it out, 0 leaving a plain cylinder.
+//
+// Kept as one function so that if the reference becomes measurable, only this
+// changes. The 0.45 ceiling keeps the radius strictly positive at both extremes.
+const taperFactor = (taper: number, u: number) => {
+  const t = clamp(taper, -90, 90) / 200; // ±0.45
+  return lerp(1 - t, 1 + t, clamp(u, 0, 1));
+};
+
+// Long lens to moderately wide, matching the reference's deliberately low
+// ceiling. A helix blows out into a funnel long before a 95-degree fov.
+const helixFov = (perspective: number) => lerp(19, 48, clamp(perspective, 0, 40) / 40);
+
+// Shared geometry + a size clamp, so the 3D pose and the 2D fallback can never
+// disagree and so the card can never render bigger than the spiral lets it.
+//
+// A flat ring (Orbit 3D) only ever needs to protect against ITS OWN neighbour —
+// one step around the circle. A multi-turn spiral has a second, easy-to-miss
+// collision: card i and card i+k, where k ≈ count/turns is "one lap later",
+// land at nearly the SAME angle, separated mostly by one turn's rise. When that
+// rise is small relative to the card, laps stack on top of each other and read
+// as flickering vertical stripes — measured on the shipped defaults, the
+// closest pair (6 apart, not 1) sat at 0.78x the card's own size, i.e. already
+// overlapping, and the reference-inspired "funnel" variant reached 1.46x.
+//
+// Both distances are estimated analytically (not by scanning all pairs from
+// inside a per-card pure function) and the smaller one bounds the card.
+function helixMetrics(v: Record<string, any>, count: number, ctx: { width: number; height: number }) {
+  const stage = Math.min(ctx.width, ctx.height);
+  const radius = (stage * (v.spiralSize / 100)) / 2;
+  const risePerTurn = stage * (v.cardGap / 100) * 0.9;
+  const totalRise = v.turns * risePerTurn;
+  const requested = stage * (v.cardSizePct / 100);
+
+  // Worst-case radius for the spacing estimate: Taper can shrink the spiral
+  // down to (1 - |taper|/200) of its nominal radius at one end (see
+  // taperFactor below), and that end is where laps sit closest together.
+  const radiusSafe = radius * (1 - Math.min(1, Math.abs(clamp(v.taper, -90, 90)) / 200));
+
+  // 1. Same-lap neighbour — one index step along the coil.
+  const angleStep1 = (v.turns * TAU) / count;
+  const yStep1 = totalRise / count;
+  const spacing1 = Math.hypot(radiusSafe * angleStep1, yStep1);
+
+  // 2. Adjacent-lap neighbour, k ≈ count/turns steps away. Skipped when the
+  // spiral never completes a second lap across its own card count (turns too
+  // small relative to count), and when the rise is negligible — Card Gap = 0
+  // is a deliberate flat multi-layer ring (see its own control description),
+  // not a defect to clamp away.
+  let spacing2 = Infinity;
+  if (totalRise > 1) {
+    const k = Math.round(count / Math.max(0.001, v.turns));
+    if (k >= 1 && k < count) {
+      const raw = ((v.turns * TAU * k) / count) % TAU;
+      const angleStep2 = Math.min(raw, TAU - raw);
+      const yStep2 = (totalRise * k) / count;
+      spacing2 = Math.hypot(radiusSafe * angleStep2, yStep2);
+    }
+  }
+
+  // The card is portrait (default crop 4:5), so its own diagonal is ~0.8x its
+  // width — bigger than the width alone. A factor tuned only against width, as
+  // a ring's would be, still let portrait corners graze: two near-opaque cards
+  // that overlap even slightly can z-fight, because depthWrite turns on above
+  // alpha 0.995 (renderer3d) and two nearly-coincident depth writes resolve
+  // per-pixel, which is what reads as interleaved stripes rather than a soft
+  // double-exposure. 0.52 leaves real clearance for that diagonal.
+  const bound = Math.min(spacing1, spacing2);
+  const cardPx = Number.isFinite(bound) ? Math.min(requested, bound * 0.28) : requested;
+  return { radius, risePerTurn, totalRise, cardPx };
+}
+
+const helix3d: Template = {
+  meta: {
+    id: 'helix3d-01', name: 'Spiral Stream', group: 'Helix',
+    catalog3d: true, isNew: true, engine: 'webgl', repeatAssets: true,
+    defaultEasing: { id: 'linear' },
+  },
+
+  controls: [
+    { key: 'direction',    label: 'Direction',     type: 'toggle', options: ['forward','reverse'], default: 'forward', section: 'Motion' },
+    { key: 'count',        label: 'Card Count',    type: 'slider', min: 8, max: 48, step: 1,      default: 24, section: 'Layout' },
+    { key: 'turns',        label: 'Spiral Turns',  type: 'slider', min: 1, max: 6, step: 0.25,    default: 3.75, section: 'Layout', precision: 2 },
+    { key: 'spiralSize',   label: 'Spiral Size',   type: 'slider', min: 35, max: 90, step: 1,     default: 62, section: 'Layout', unit: '%' },
+    { key: 'cardSizePct',  label: 'Card Size',     type: 'slider', min: 12, max: 36, step: 1,     default: 33, section: 'Layout', unit: '%' },
+    { key: 'cardGap',      label: 'Card Gap',      type: 'slider', min: 0, max: 50, step: 2,      default: 28, section: 'Layout', unit: '%',
+      description: 'Rise per turn — the helix pitch. 0 collapses the spiral into a flat ring.' },
+    { key: 'taper',        label: 'Taper',         type: 'slider', min: -90, max: 90, step: 5,    default: 0, section: 'Depth', unit: '%',
+      description: 'Varies the radius along the spiral. Negative closes it toward the far end, positive opens it out.' },
+    { key: 'ringTilt',     label: 'Ring Tilt',     type: 'slider', min: -45, max: 45, step: 1,    default: 0, section: 'Depth', unit: '°',
+      description: 'Tips the whole helix axis. The cards stay attached to the curve.' },
+    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 40, step: 2,      default: 20, section: 'Depth', unit: '%' },
+    { key: 'facing',       label: 'Card Facing',   type: 'pills',  options: ['surface','camera'], default: 'surface', section: 'Depth' },
+    { key: 'scalePulse',   label: 'Scale Pulse',   type: 'slider', min: 0, max: 60, step: 5,      default: 0, section: 'Motion', unit: '%',
+      description: 'Breathes the card size once per lap. Period is exactly one lap, so the loop stays seamless.' },
+    { key: 'backFade',     label: 'Back Fade',     type: 'slider', min: 10, max: 95, step: 5,     default: 55, section: 'Finish', unit: '%' },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 12, step: 0.5,    default: 3, section: 'Finish', unit: '%', precision: 1 },
+    { key: 'thickness',    label: 'Thickness',     type: 'slider', min: 0, max: 24, step: 1,      default: 8, section: 'Finish', unit: 'px',
+      description: 'Gives the cards a physical edge. Also what lets depth shading register at all.' },
+    { key: 'shadow',       label: 'Shadow',        type: 'toggle', options: ['on','off'],         default: 'on', section: 'Finish' },
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 2, step: 0.1,     default: 0.35, section: 'Motion', unit: '×', precision: 1 },
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                                 default: { x: 0, y: 0 }, section: 'Layout' },
+  ],
+
+  camera: (v) => ({ fov: helixFov(v.perspective) }),
+
+  transform3d: (frame, index, count, v, ctx) => {
+    const dir = v.direction === 'reverse' ? -1 : 1;
+    // Period is `count`: each card advances exactly one slot per cycle, so frame
+    // totalFrames poses like frame 0.
+    // Raw phase: a helix advances continuously, so easedPhase would make it
+    // accelerate and settle once per card. Seam holds — loopCycles returns a
+    // whole multiple of `count`.
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir;
+    // u wraps in [0,1) along the whole spiral. Every term below is a function of
+    // u with integer period, which is what keeps the seam closed.
+    const u = (((index - phase) % count + count) % count) / count;
+
+    const m = helixMetrics(v, count, ctx);
+    const radius = m.radius * taperFactor(v.taper, u);
+    const a = v.turns * TAU * u;
+
+    const rig = { pitch: v.ringTilt };
+    const p = tiltPointCanvas({
+      x: Math.sin(a) * radius,
+      y: (0.5 - u) * m.totalRise,
+      z: Math.cos(a) * radius,
+    }, rig);
+
+    // Radial normal — a riser on a spiral stair faces away from the axis. Tilted
+    // by the same rig so the facing cannot drift off the curve.
+    const n = tiltNormalCanvas({ x: Math.sin(a), y: 0, z: Math.cos(a) }, rig);
+
+    const surface = v.facing === 'surface';
+    const quaternion = surface
+      // Aim +Z (a plane's own normal) along n. Same construction as globe.ts:
+      // solving for the angles rather than reusing `a` is what stays correct
+      // once the axis is tilted.
+      ? quaternionFromEuler(-Math.asin(clamp(n.y, -1, 1)), Math.atan2(n.x, n.z), 0)
+      // 'camera' facing keeps every card square to the frame: identity, so the
+      // helix reads purely as position and the images stay flat to the viewer.
+      : quaternionFromEuler(0, 0, 0);
+
+    // One breath per lap. sin(TAU·u) has period exactly 1 in u, so it returns to
+    // its starting value at the seam by construction.
+    const pulse = 1 + (v.scalePulse / 100) * 0.5 * Math.sin(TAU * u);
+    const cardPx = m.cardPx * pulse;
+
+    const nearness = clamp((p.z / Math.max(1, radius) + 1) / 2, 0, 1);
+
+    return {
+      x: p.x + v.offset.x,
+      y: p.y + v.offset.y,
+      z: p.z,
+      quaternion,
+      scale: cardPx / BASE,
+      // Two separate things: the card turning away from the camera, and the
+      // hand-off at the ends of the spiral.
+      alpha: backfaceFade(n.z, v.backFade) * wrapEnvelope(u, 0.06),
+      thickness: v.thickness,
+      shadowStrength: v.shadow === 'on' ? 1 : 0,
+      materialExposure: lerp(0.6, 1.08, nearness),
+    };
+  },
+
+  // ---- 2D fallback, for thumbnails and the non-webgl path ----
+  transform: (frame, index, count, v, ctx) => {
+    const dir = v.direction === 'reverse' ? -1 : 1;
+    // Raw phase: a helix advances continuously, so easedPhase would make it
+    // accelerate and settle once per card. Seam holds — loopCycles returns a
+    // whole multiple of `count`.
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir;
+    const u = (((index - phase) % count + count) % count) / count;
+
+    const m = helixMetrics(v, count, ctx);
+    const radius = m.radius * taperFactor(v.taper, u);
+    const a = v.turns * TAU * u;
+
+    const p = tiltPointCanvas({
+      x: Math.sin(a) * radius,
+      y: (0.5 - u) * m.totalRise,
+      z: Math.cos(a) * radius,
+    }, { pitch: v.ringTilt });
+
+    const nearness = clamp((p.z / Math.max(1, radius) + 1) / 2, 0, 1);
+    const pulse = 1 + (v.scalePulse / 100) * 0.5 * Math.sin(TAU * u);
+    const cardPx = m.cardPx * pulse;
+
+    return {
+      x: p.x + v.offset.x,
+      y: p.y + v.offset.y,
+      scale: (cardPx / BASE) * lerp(0.62, 1.14, nearness),
+      rotation: 0,
+      alpha: lerp(1 - clamp(v.backFade, 0, 95) / 100, 1, nearness) * wrapEnvelope(u, 0.06),
+      depth: nearness,
+    };
+  },
+};
+
+export const helix3dVariants: Template[] = [
+  helix3d,
+  // Tight and tall: many laps, small cards, a DNA column.
+  variant(helix3d, 'helix3d-02', 'Spiral Column', {
+    turns: 5.5, count: 40, spiralSize: 44, cardSizePct: 17, cardGap: 34,
+    perspective: 26, backFade: 65, thickness: 5, speed: 0.5,
+  }),
+  // A closing funnel seen from a tilted axis — the shot that shows Taper.
+  variant(helix3d, 'helix3d-03', 'Spiral Funnel', {
+    turns: 2.5, count: 18, spiralSize: 86, cardSizePct: 28, cardGap: 16,
+    taper: -70, ringTilt: 24, perspective: 30, backFade: 70, speed: 0.3,
+  }),
+];

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -25,6 +25,10 @@ import { revealVariants } from './reveal';
 import { blankVariants } from './blank';
 import { galleryVariants } from './gallery';
 import { tickerVariants } from './ticker';
+import { isometricVariants } from './isometric';
+import { coverflowVariants } from './coverflow';
+import { flipVariants } from './flipgrid';
+import { boxVariants } from './box';
 
 const carouselVariants: Template[] = [
   { ...carousel, meta: { ...carousel.meta, name: 'Runway 01' } },
@@ -68,6 +72,10 @@ export const templateList: Template[] = [
   ...blankVariants,
   ...galleryVariants,
   ...tickerVariants,
+  ...isometricVariants,
+  ...coverflowVariants,
+  ...flipVariants,
+  ...boxVariants,
 ];
 
 export const templates: Record<string, Template> = Object.fromEntries(

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -20,15 +20,23 @@ import { scaleVariants } from './scale';
 import { proximityVariants } from './proximity';
 import { storiesFocusVariants } from './storiesFocus';
 import { zoomVariants } from './zoom';
+import { bloomVariants } from './bloom';
 import { scatterVariants } from './scatter';
 import { revealVariants } from './reveal';
+import { framesVariants } from './frames';
+import { gridVariants } from './grid';
 import { blankVariants } from './blank';
 import { galleryVariants } from './gallery';
 import { tickerVariants } from './ticker';
 import { isometricVariants } from './isometric';
 import { coverflowVariants } from './coverflow';
+import { deckVariants } from './deck';
 import { flipVariants } from './flipgrid';
 import { boxVariants } from './box';
+import { surfaceVariants } from './surface';
+import { premium3dTemplates } from './premium3d';
+import { showcaseVariants } from './showcase';
+import { helix3dVariants } from './helix3d';
 
 const carouselVariants: Template[] = [
   { ...carousel, meta: { ...carousel.meta, name: 'Runway 01' } },
@@ -51,6 +59,8 @@ export const templateList: Template[] = [
   ...carouselVariants,
   ...orbitVariants,
   ...orbit3dVariants,
+  ...premium3dTemplates,
+  ...showcaseVariants,
   ...spinVariants,
   ...stackVariants,
   ...wheelVariants,
@@ -60,20 +70,26 @@ export const templateList: Template[] = [
   ...storiesFocusVariants,
   ...flickerVariants,
   ...globeVariants,
+  ...surfaceVariants,
   ...spiralVariants,
+  ...helix3dVariants,
   ...tourVariants,
   ...gravityVariants,
   ...parallaxVariants,
   ...scatterVariants,
   ...scaleVariants,
   ...zoomVariants,
+  ...bloomVariants,
   ...proximityVariants,
   ...revealVariants,
+  ...framesVariants,
+  ...gridVariants,
   ...blankVariants,
   ...galleryVariants,
   ...tickerVariants,
   ...isometricVariants,
   ...coverflowVariants,
+  ...deckVariants,
   ...flipVariants,
   ...boxVariants,
 ];
@@ -82,13 +98,21 @@ export const templates: Record<string, Template> = Object.fromEntries(
   templateList.map((t) => [t.meta.id, t])
 );
 
+// Templates can remain addressable for persisted scenes while being withheld
+// from every picker until their visual quality is ready for the catalogue.
+export const catalogTemplateList = templateList.filter((t) => !t.meta.catalogHidden);
+
 // Group order follows the reference catalogue.
 export const templateGroups: { group: string; items: Template[] }[] = (() => {
   const order: string[] = [];
   const map = new Map<string, Template[]>();
-  for (const t of templateList) {
-    if (!map.has(t.meta.group)) { map.set(t.meta.group, []); order.push(t.meta.group); }
-    map.get(t.meta.group)!.push(t);
+  // A renderer is an implementation detail, not a catalogue category. Runway
+  // may use WebGL for perspective and Ticker Tilt may use it for a rigid plane,
+  // but neither belongs to the same family as Box, Globe or Surface.
+  for (const t of catalogTemplateList) {
+    const group = t.meta.catalog3d ? `${t.meta.group} 3D` : t.meta.group;
+    if (!map.has(group)) { map.set(group, []); order.push(group); }
+    map.get(group)!.push(t);
   }
   return order.map((group) => ({ group, items: map.get(group)! }));
 })();

--- a/templates/isometric.ts
+++ b/templates/isometric.ts
@@ -1,0 +1,100 @@
+import type { Template } from '@/lib/types';
+import { clamp, loopCycles, wave } from '@/lib/motion';
+import { variant } from './variant';
+
+// Reference size (px) shared with the renderer's sprite normalization, so that
+// `cardSize` reads directly in on-screen pixels.
+const BASE = 340;
+
+// ============================================================
+//  ISOMETRIC — tiles on a 2:1 projected grid
+//
+//  The family's identity is the LAYOUT, not the motion: a grid mapped through an
+//  isometric projection, where a step along a grid column moves the tile right
+//  and down while a step along a row moves it left and down. `squash` is the
+//  vertical ratio — 0.5 is the classic 2:1 game-art isometric, 1.0 collapses to
+//  a plain 45° diamond.
+//
+//  On top of that sits a lift wave travelling along the grid diagonal, which is
+//  what reads as depth on an isometric plane: tiles rise off the surface in
+//  sequence. The wave is a function of frac(), so it repeats every unit and the
+//  clip loops seamlessly.
+// ============================================================
+
+const isometric: Template = {
+  meta: { id: 'iso-01', name: 'Isometric 01', group: 'Isometric', isNew: true, defaultEasing: { id: 'smooth' }, repeatAssets: true },
+
+  controls: [
+    { key: 'count',        label: 'Count',         type: 'slider', min: 2, max: 60, step: 1,     default: 16 },
+    { key: 'cols',         label: 'Columns',       type: 'slider', min: 1, max: 10, step: 1,     default: 4 },
+    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 40, max: 400, step: 1,   default: 150 },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,    default: 8 },
+    { key: 'tileGap',      label: 'Tile Gap',      type: 'slider', min: 40, max: 400, step: 1,   default: 130 },
+    { key: 'squash',       label: 'Iso Squash',    type: 'slider', min: 0.2, max: 1, step: 0.05, default: 0.5 }, // 0.5 = classic 2:1
+    { key: 'lift',         label: 'Lift',          type: 'slider', min: 0, max: 300, step: 1,    default: 90 },  // px a tile rises at the wave peak
+    { key: 'spread',       label: 'Wave Spread',   type: 'slider', min: 0, max: 3, step: 0.05,   default: 1 },   // how far the wave stretches across the diagonal
+    { key: 'growth',       label: 'Peak Growth',   type: 'slider', min: 0, max: 60, step: 1,     default: 14 },  // % scale gain at the peak
+    { key: 'rock',         label: 'Rock',          type: 'slider', min: 0, max: 20, step: 1,     default: 0 },   // degrees, per-tile rotation at the peak
+    { key: 'fade',         label: 'Trough Fade',   type: 'slider', min: 0, max: 100, step: 1,    default: 0 },   // dim tiles resting on the plane
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                                default: { x: 0, y: 0 } },
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.1,    default: 0.5 }, // wave cycles/sec
+  ],
+
+  transform: (frame, index, count, v, ctx) => {
+    const cols = Math.max(1, Math.round(v.cols));
+    const rows = Math.max(1, Math.ceil(count / cols));
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+
+    // Centre the grid on the canvas.
+    const dc = col - (cols - 1) / 2;
+    const dr = row - (rows - 1) / 2;
+
+    const sizeFactor = v.cardSize / BASE;
+    const stepX = v.tileGap * sizeFactor;
+    const stepY = stepX * v.squash;
+
+    // The isometric projection: columns go right-and-down, rows go left-and-down.
+    const baseX = (dc - dr) * stepX;
+    const baseY = (dc + dr) * stepY;
+
+    // Period 1: the wave repeats every cycle, so a whole number of cycles per
+    // clip puts frame totalFrames back on frame 0.
+    const phase = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, 1));
+
+    // Position along the diagonal, normalized 0..1. The wave is delayed by it,
+    // so the lift travels from the back corner to the front.
+    const span = Math.max(1, (cols - 1) + (rows - 1));
+    const u = (col + row) / span;
+    const peak = wave(phase - u * v.spread); // 0 → 1 → 0, one pulse per cycle
+
+    const lift = peak * v.lift;
+    const scale = sizeFactor * (1 + (v.growth / 100) * peak);
+    const alpha = 1 - (v.fade / 100) * (1 - peak);
+
+    return {
+      x: baseX + v.offset.x,
+      // Lift moves the tile UP off the plane, so it subtracts from y.
+      y: baseY - lift + v.offset.y,
+      scale,
+      rotation: (v.rock * Math.PI) / 180 * peak,
+      alpha: clamp(alpha, 0, 1),
+      // Front of the plane draws over the back. The lift is converted into
+      // diagonal steps rather than added as a flat bonus: a tile raised higher
+      // than one row's spacing is physically above the tiles in front of it, so
+      // it must draw over them. A fixed bonus left a tile lifted 300px still
+      // painted behind its neighbour, which read as broken.
+      depth: (col + row) + lift / Math.max(1, stepY),
+    };
+  },
+};
+
+export const isometricVariants: Template[] = [
+  isometric,
+  variant(isometric, 'iso-02', 'Isometric 02', {
+    cols: 6, count: 30, cardSize: 110, tileGap: 100, squash: 0.42, lift: 140, spread: 1.6, growth: 22, fade: 35, speed: 0.4,
+  }),
+  variant(isometric, 'iso-03', 'Isometric 03', {
+    cols: 3, count: 9, cardSize: 210, tileGap: 190, squash: 0.6, lift: 60, spread: 0.5, growth: 8, rock: 6, speed: 0.7,
+  }),
+];

--- a/templates/orbit3d.ts
+++ b/templates/orbit3d.ts
@@ -1,86 +1,158 @@
 import type { Template } from '@/lib/types';
-import { TAU, lerp, loopCycles } from '@/lib/motion';
-import { cardPath } from '@/lib/cardPath';
+import { TAU, clamp, loopCycles, smooth } from '@/lib/motion';
+import {
+  backfaceFade,
+  multiplyQuaternion,
+  quaternionFromEuler,
+  tiltNormalCanvas,
+  tiltPointCanvas,
+  velocityLean,
+} from '@/lib/tilt3d';
 import { variant } from './variant';
 
 const BASE = 340;
 
-// Orbit 3D — real WebGL orbit: cards ride a circle in actual 3D space, seen
-// through a perspective camera (the `perspective` control maps to camera FOV
-// in the 3D renderer). `facing` chooses billboarded cards (screen) or cards
-// lying on the ring like a carousel drum (ring). The 2D transform below is a
-// cheap projection of the same motion for thumbnails.
-const orbit3d: Template = {
-  meta: {
-    id: 'orbit-3d-01', name: 'Orbit 3D 01', group: 'Orbit',
-    defaultEasing: { id: 'flow' }, engine: 'webgl',
-  },
+function ringMetrics(v: Record<string, any>, count: number, ctx: { width: number; height: number }) {
+  const minDim = Math.min(ctx.width, ctx.height);
+  const padding = clamp(v.padding / 100, 0, 0.2);
+  const usable = minDim * (1 - padding * 2);
+  // Opening is relative to the ring's own outer diameter. Previously it was
+  // measured against the canvas, so opening and ring size fought each other.
+  const outer = usable * clamp(v.ringSizePct / 100, 0.4, 0.98);
+  const inner = outer * clamp(v.opening / 100, 0.15, 0.85);
+  const radius = (outer + inner) / 4;
 
+  // A card must never consume more arc than its slot owns. This keeps every
+  // count airy instead of collapsing the cards into a closed black drum.
+  const requested = usable * clamp(v.cardSizePct / 100, 0.08, 0.36);
+  const arcPerCard = (TAU * radius) / Math.max(4, count);
+  return {
+    radius,
+    // Use the full long edge for the safety bound. Assets may be landscape or
+    // square when Card shape is Auto; assuming 4:5 here made wide images touch.
+    cardPx: Math.min(requested, arcPerCard * 0.72),
+  };
+}
+
+// A continuously turning ring must NOT route its angle through ctx.easedPhase.
+//
+// easedPhase is floor(p) + ease(frac(p)): it shapes every UNIT STEP of the
+// phase. That is exactly right for a conveyor that advances one slot at a time —
+// a ticker, a deck — where each step should accelerate and settle. A ring is the
+// opposite case: its period is `count`, so an ease-in-out curve makes it
+// accelerate and decelerate once PER CARD, twelve times per revolution at the
+// default count. Measured with the shipped `flow` curve, the instantaneous
+// angular velocity swung 23.5x between its slowest and fastest frame; with a
+// linear phase the same ring holds a flat rate. That lurch is what reads as
+// stiff next to a smoothly spinning reference.
+//
+// It also made `velocity` lie. That vector is derived from cycles/duration —
+// the AVERAGE rate — and is handed to the finish pass for motion blur, so under
+// an eased phase the blur was being told a speed up to 23x off from the truth.
+// On a linear phase the average IS the instantaneous rate, and it becomes exact.
+//
+// The seam is unaffected either way: loopCycles returns a whole multiple of
+// `count`, so at frame totalFrames the angle has advanced by a multiple of TAU.
+function ringPhase(frame: number, v: Record<string, any>, count: number, ctx: { duration: number; totalFrames: number }) {
+  const dir = v.direction === 'reverse' ? -1 : 1;
+  const cycles = loopCycles(v.speed, ctx.duration, count);
+  return { dir, cycles, phase: (frame / ctx.totalFrames) * cycles * dir };
+}
+
+const ringStream: Template = {
+  meta: {
+    id: 'orbit-3d-01', name: 'Ring Stream', group: 'Orbit',
+    // Linear on purpose — see ringPhase above. The curve picker still works for
+    // anyone who wants the stepped feel back.
+    defaultEasing: { id: 'linear' }, engine: 'webgl', catalog3d: true, repeatAssets: true,
+  },
   controls: [
-    { key: 'direction',   label: 'Direction',   type: 'toggle', options: ['forward','reverse'], default: 'forward' },
-    { key: 'count',       label: 'Count',       type: 'slider', min: 2, max: 16, step: 1,   default: 8 },
-    { key: 'cardSize',    label: 'Plane Size',  type: 'slider', min: 50, max: 800, step: 1, default: 300 },
-    { key: 'radius',      label: 'Orbit Radius',type: 'slider', min: 100, max: 700, step: 1, default: 380 },
-    { key: 'perspective', label: 'Perspective', type: 'slider', min: 0, max: 200, step: 1,  default: 120 },
-    { key: 'tiltX',       label: 'Tilt',        type: 'slider', min: -45, max: 45, step: 1, default: 10 },
-    { key: 'facing',      label: 'Facing',      type: 'pills', options: ['screen','ring'],  default: 'screen' },
-    { key: 'fade',        label: 'Depth Fade',  type: 'slider', min: 0, max: 100, step: 1,  default: 25 },
-    { key: 'speed',       label: 'Speed',       type: 'slider', min: 0, max: 2, step: 0.1,  default: 0.3 },
-    { key: 'offset',      label: 'Offset',      type: 'xypad',                              default: { x: 0, y: 0 } },
+    { key: 'style', label: 'Style', type: 'pills', options: ['stream','showcase','bloom'], default: 'stream', section: 'Layout', advanced: true },
+    { key: 'direction', label: 'Direction', type: 'toggle', options: ['forward','reverse'], default: 'forward', section: 'Motion' },
+    { key: 'count', label: 'Count', type: 'slider', min: 4, max: 24, step: 1, default: 12, section: 'Layout' },
+    { key: 'padding', label: 'Padding', type: 'slider', min: 0, max: 20, step: 1, default: 6, section: 'Layout', unit: '%' },
+    { key: 'ringSizePct', label: 'Ring Size', type: 'slider', min: 45, max: 95, step: 1, default: 94, section: 'Layout', unit: '%' },
+    { key: 'opening', label: 'Ring Opening', type: 'slider', min: 15, max: 85, step: 1, default: 70, section: 'Layout', unit: '%', description: 'Controls the inner diameter while keeping the ring complete.' },
+    { key: 'cardSizePct', label: 'Card Size', type: 'slider', min: 8, max: 36, step: 1, default: 18, section: 'Layout', unit: '%' },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 20, step: 0.5, default: 3, section: 'Finish', unit: '%', precision: 1 },
+    { key: 'cardBend', label: 'Card Bend', type: 'slider', min: 0, max: 12, step: 0.5, default: 4, section: 'Depth', unit: '%', precision: 1, description: 'Curves each image surface gently around the ring.' },
+    { key: 'tiltX', label: 'Ring Tilt', type: 'slider', min: -60, max: 60, step: 1, default: -8, section: 'Depth', unit: '°', description: 'Rotates the complete physical ring without changing its radius.' },
+    { key: 'perspective', label: 'Perspective', type: 'slider', min: 0, max: 40, step: 1, default: 18, section: 'Depth', unit: '%' },
+    { key: 'facing', label: 'Facing', type: 'pills', options: ['camera','ring'], default: 'ring', section: 'Depth' },
+    { key: 'fade', label: 'Back Fade', type: 'slider', min: 0, max: 100, step: 1, default: 15, section: 'Finish', unit: '%' },
+    { key: 'shadow', label: 'Shadow', type: 'toggle', options: ['on','off'], default: 'on', section: 'Finish' },
+    { key: 'spread', label: 'Ring Width', type: 'slider', min: 55, max: 135, step: 1, default: 100, section: 'Layout', unit: '%', visibleWhen: { key: 'style', equals: 'showcase' } },
+    { key: 'pulse', label: 'Bloom', type: 'slider', min: 0, max: 35, step: 1, default: 15, section: 'Motion', unit: '%', visibleWhen: { key: 'style', equals: 'bloom' } },
+    { key: 'curve', label: 'Curve', type: 'slider', min: -100, max: 100, step: 1, default: 0, section: 'Depth', unit: '%', visibleWhen: { key: 'style', equals: 'bloom' } },
+    { key: 'speed', label: 'Speed', type: 'slider', min: 0, max: 2, step: 0.1, default: 0.3, section: 'Motion', unit: '×', precision: 1 },
+    { key: 'offset', label: 'Offset', type: 'xypad', default: { x: 0, y: 0 }, section: 'Layout' },
   ],
 
-  // Real 3D pose (renderer3d). y is canvas-down; the renderer flips it.
+  camera: (v) => ({ fov: 15 + clamp(v.perspective / 40, 0, 1) * 14 }),
+
   transform3d: (frame, index, count, v, ctx) => {
-    const dir = v.direction === 'reverse' ? -1 : 1;
-    const phase = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir);
+    const { dir, cycles, phase } = ringPhase(frame, v, count, ctx);
     const a = TAU * ((index - phase) / count);
-
-    // ring in the XZ plane, tilted around the X axis
-    const tilt = (v.tiltX * Math.PI) / 180;
-    const x0 = Math.sin(a) * v.radius;
-    const z0 = Math.cos(a) * v.radius;
-    const y = -z0 * Math.sin(tilt) + v.offset.y; // tilt lifts the far side
-    const z = z0 * Math.cos(tilt);
-
-    const depthN = (z0 / v.radius + 1) / 2; // 1 = front, 0 = back
-    const alpha = 1 - (v.fade / 100) * (1 - depthN);
-
+    const metrics = ringMetrics(v, count, ctx);
+    const pulse = v.style === 'bloom' ? 1 + (v.pulse / 100) * Math.sin((phase / count) * TAU) : 1;
+    const width = metrics.radius * (v.style === 'showcase' ? v.spread / 100 : 1) * pulse;
+    const depth = metrics.radius * pulse;
+    const curveY = v.style === 'bloom' ? (1 - Math.cos(a)) * metrics.radius * (v.curve / 100) * 0.28 : 0;
+    const base = { x: Math.sin(a) * width, y: curveY, z: Math.cos(a) * depth };
+    const point = tiltPointCanvas(base, { pitch: v.tiltX });
+    const normal = tiltNormalCanvas({ x: Math.sin(a), y: 0, z: Math.cos(a) }, { pitch: v.tiltX });
+    const depthN = clamp((normal.z + 1) / 2, 0, 1);
+    const lean = velocityLean(dir * v.speed, 1, 3) * Math.PI / 180;
+    const qTilt = quaternionFromEuler(v.tiltX * Math.PI / 180, 0, 0);
+    const qRadial = quaternionFromEuler(0, v.facing === 'ring' ? a : 0, 0);
+    const qLean = quaternionFromEuler(0, 0, lean);
+    const quaternion = multiplyQuaternion(multiplyQuaternion(qTilt, qRadial), qLean);
+    const angularRate = (cycles / Math.max(0.001, ctx.duration)) * TAU / count * dir;
     return {
-      x: x0 + v.offset.x,
-      y,
-      z,
-      rotationX: v.facing === 'ring' ? tilt : 0,
-      rotationY: v.facing === 'ring' ? a : 0,
-      rotationZ: 0,
-      scale: v.cardSize / BASE,
-      alpha,
+      x: point.x + v.offset.x,
+      y: point.y + v.offset.y,
+      z: point.z,
+      quaternion,
+      scale: (metrics.cardPx / BASE) * (1 + smooth(depthN) * 0.035),
+      alpha: backfaceFade(normal.z, v.fade),
+      bend: v.cardBend / 100,
+      thickness: 0,
+      shadowStrength: v.shadow === 'on' ? 1 : 0,
+      materialExposure: 0.78 + depthN * 0.28,
+      velocity: {
+        x: Math.cos(a) * width * angularRate,
+        y: Math.sin(a) * depth * angularRate * Math.sin(v.tiltX * Math.PI / 180),
+        z: -Math.sin(a) * depth * angularRate,
+      },
     };
   },
 
-  // 2D projection of the same orbit (thumbnails + non-webgl fallback).
   transform: (frame, index, count, v, ctx) => {
-    const dir = v.direction === 'reverse' ? -1 : 1;
-    const phase = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir);
-    const p = cardPath({ kind: 'ring', index, count, phase, radius: v.radius });
-    const tiltSquash = Math.abs(Math.sin((v.tiltX * Math.PI) / 180)) * 0.8 + 0.1;
-    const scale = (v.cardSize / BASE) * lerp(0.55, 1.1, p.depthNorm);
+    // Same linear phase as the 3D path, so the thumbnail matches the stage.
+    const { phase } = ringPhase(frame, v, count, ctx);
+    const a = TAU * ((index - phase) / count);
+    const metrics = ringMetrics(v, count, ctx);
+    const base = { x: Math.sin(a) * metrics.radius, y: 0, z: Math.cos(a) * metrics.radius };
+    const p = tiltPointCanvas(base, { pitch: v.tiltX });
+    const normal = tiltNormalCanvas({ x: Math.sin(a), y: 0, z: Math.cos(a) }, { pitch: v.tiltX });
+    const depthN = clamp((normal.z + 1) / 2, 0, 1);
     return {
       x: p.x + v.offset.x,
-      y: -p.y * tiltSquash + v.offset.y,
-      scale,
+      y: p.y + v.offset.y,
+      scale: (metrics.cardPx / BASE) * (0.84 + depthN * 0.19),
       rotation: 0,
-      alpha: 1 - (v.fade / 100) * (1 - p.depthNorm),
-      depth: p.depthNorm,
+      alpha: backfaceFade(normal.z, v.fade),
+      depth: p.z,
     };
   },
 };
 
 export const orbit3dVariants: Template[] = [
-  orbit3d,
-  variant(orbit3d, 'orbit-3d-02', 'Orbit 3D 02', {
-    facing: 'ring', count: 10, radius: 460, tiltX: 0, perspective: 160, speed: 0.25,
+  ringStream,
+  variant(ringStream, 'orbit-3d-02', 'Orbit Showcase', {
+    style: 'showcase', count: 10, ringSizePct: 86, opening: 48, tiltX: 0, perspective: 28, spread: 92, speed: 0.25,
   }),
-  variant(orbit3d, 'orbit-3d-03', 'Orbit 3D 03', {
-    count: 6, radius: 300, tiltX: 28, perspective: 80, cardSize: 380, fade: 45,
+  variant(ringStream, 'orbit-3d-03', 'Orbit Bloom', {
+    style: 'bloom', count: 8, ringSizePct: 72, opening: 42, tiltX: -29, perspective: 26, cardSizePct: 25, fade: 45, pulse: 16,
   }),
 ];

--- a/templates/parallax.ts
+++ b/templates/parallax.ts
@@ -10,7 +10,7 @@ const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
 const h = (k: number) => { const s = Math.sin(k * 127.1 + 1.7) * 43758.5453; return s - Math.floor(s); };
 
 const parallax: Template = {
-  meta: { id: 'parallax-01', name: 'Drift 01', group: 'Drift', defaultEasing: { id: 'smooth' } },
+  meta: { id: 'parallax-01', name: 'Drift 01', group: 'Drift', repeatAssets: true, defaultEasing: { id: 'smooth' } },
 
   controls: [
     { key: 'count',        label: 'Count',         type: 'slider', min: 3, max: 16, step: 1,    default: 9 },

--- a/templates/premium3d.ts
+++ b/templates/premium3d.ts
@@ -1,0 +1,183 @@
+import type { Template } from '@/lib/types';
+import { TAU, clamp, frac, hash2, lerp, loopCycles, smooth } from '@/lib/motion';
+import { quaternionFromEuler, springOvershoot, wrapEnvelope } from '@/lib/tilt3d';
+
+const BASE = 340;
+
+const sharedFinish = [
+  { key: 'cornerRadius', label: 'Corner Radius', type: 'slider' as const, min: 0, max: 20, step: 0.5, default: 3, section: 'Finish' as const, unit: '%' as const, precision: 1 },
+  { key: 'thickness', label: 'Thickness', type: 'slider' as const, min: 0, max: 24, step: 1, default: 10, section: 'Finish' as const, unit: 'px' as const },
+  { key: 'shadow', label: 'Shadow', type: 'toggle' as const, options: ['on','off'], default: 'on', section: 'Finish' as const },
+];
+
+export const cardTunnel: Template = {
+  meta: { id: 'tunnel-01', name: 'Card Tunnel', group: 'Depth', isNew: true, engine: 'webgl', catalog3d: true, catalogHidden: true, repeatAssets: true, defaultEasing: { id: 'linear' } },
+  controls: [
+    { key: 'direction', label: 'Direction', type: 'toggle', options: ['forward','backward'], default: 'forward', section: 'Motion' },
+    { key: 'count', label: 'Card Count', type: 'slider', min: 8, max: 48, step: 4, default: 24, section: 'Layout' },
+    { key: 'tunnelSize', label: 'Tunnel Size', type: 'slider', min: 45, max: 110, step: 1, default: 90, section: 'Layout', unit: '%' },
+    { key: 'cardLength', label: 'Card Length', type: 'slider', min: 25, max: 75, step: 1, default: 55, section: 'Layout', unit: '%' },
+    { key: 'gap', label: 'Gap', type: 'slider', min: 0, max: 30, step: 1, default: 10, section: 'Layout', unit: '%' },
+    { key: 'depth', label: 'Tunnel Depth', type: 'slider', min: 500, max: 2400, step: 25, default: 1500, section: 'Depth', unit: 'px' },
+    { key: 'perspective', label: 'Perspective', type: 'slider', min: 0, max: 100, step: 1, default: 58, section: 'Depth', unit: '%' },
+    { key: 'depthFade', label: 'Depth Fade', type: 'slider', min: 0, max: 100, step: 1, default: 45, section: 'Finish', unit: '%' },
+    { key: 'speed', label: 'Speed', type: 'slider', min: 0, max: 2, step: 0.1, default: 0.35, section: 'Motion', unit: '×', precision: 1 },
+    ...sharedFinish,
+  ],
+  camera: (v) => ({ fov: 34 + clamp(v.perspective / 100, 0, 1) * 38, near: 1, far: 6000 }),
+  transform3d: (frame, index, count, v, ctx) => {
+    const dir = v.direction === 'backward' ? -1 : 1;
+    const laneCount = Math.max(1, Math.ceil(count / 4));
+    const lane = Math.floor(index / 4);
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, laneCount) * dir;
+    const u = frac(lane / laneCount - phase / laneCount);
+    const side = index % 4;
+    const half = Math.min(ctx.width, ctx.height) * (v.tunnelSize / 100) * 0.42;
+    const z = lerp(-v.depth * 0.62, v.depth * 0.42, u);
+    const edge = wrapEnvelope(u, 0.08);
+    const farFade = 1 - (v.depthFade / 100) * smooth(clamp((0.28 - u) / 0.28, 0, 1));
+    const cardPx = Math.min(ctx.width, ctx.height) * (v.cardLength / 100) * (1 - v.gap / 120);
+    let x = 0, y = 0, rx = 0, ry = 0;
+    if (side === 0) { x = -half; ry = Math.PI / 2; }
+    if (side === 1) { x = half; ry = -Math.PI / 2; }
+    if (side === 2) { y = -half; rx = Math.PI / 2; }
+    if (side === 3) { y = half; rx = -Math.PI / 2; }
+    const speedZ = -(loopCycles(v.speed, ctx.duration, laneCount) / laneCount) * v.depth / Math.max(0.001, ctx.duration) * dir;
+    return {
+      x, y, z,
+      quaternion: quaternionFromEuler(rx, ry, 0),
+      scale: cardPx / BASE,
+      alpha: edge * farFade,
+      thickness: v.thickness,
+      shadowStrength: v.shadow === 'on' ? 1 : 0,
+      materialExposure: 0.62 + u * 0.48,
+      velocity: { x: 0, y: 0, z: speedZ },
+    };
+  },
+  transform: (frame, index, count, v, ctx) => {
+    const dir = v.direction === 'backward' ? -1 : 1;
+    const laneCount = Math.max(1, Math.ceil(count / 4));
+    const lane = Math.floor(index / 4);
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, laneCount) * dir;
+    const u = frac(lane / laneCount - phase / laneCount);
+    const side = index % 4;
+    const half = Math.min(ctx.width, ctx.height) * (v.tunnelSize / 100) * 0.32;
+    const zN = smooth(u);
+    return {
+      x: side === 0 ? -half : side === 1 ? half : 0,
+      y: side === 2 ? -half : side === 3 ? half : 0,
+      scale: (Math.min(ctx.width, ctx.height) * v.cardLength / 100 / BASE) * lerp(0.2, 1, zN),
+      rotation: side < 2 ? Math.PI / 2 : 0,
+      alpha: wrapEnvelope(u, 0.08),
+      depth: u,
+    };
+  },
+};
+
+export const depthStackScroll: Template = {
+  meta: { id: 'depth-stack-01', name: 'Depth Stack Scroll', group: 'Depth', isNew: true, engine: 'webgl', catalog3d: true, catalogHidden: true, repeatAssets: true, defaultEasing: { id: 'smooth' } },
+  controls: [
+    { key: 'direction', label: 'Direction', type: 'toggle', options: ['forward','backward'], default: 'forward', section: 'Motion' },
+    { key: 'count', label: 'Count', type: 'slider', min: 3, max: 16, step: 1, default: 7, section: 'Layout' },
+    { key: 'cardSizePct', label: 'Card Size', type: 'slider', min: 25, max: 80, step: 1, default: 48, section: 'Layout', unit: '%' },
+    { key: 'depth', label: 'Stack Depth', type: 'slider', min: 200, max: 1400, step: 20, default: 720, section: 'Depth', unit: 'px' },
+    { key: 'spread', label: 'Stack Spread', type: 'slider', min: 0, max: 40, step: 1, default: 14, section: 'Layout', unit: '%' },
+    { key: 'tilt', label: 'Resting Tilt', type: 'slider', min: -20, max: 20, step: 0.5, default: -4, section: 'Depth', unit: '°', precision: 1 },
+    { key: 'perspective', label: 'Perspective', type: 'slider', min: 0, max: 100, step: 1, default: 42, section: 'Depth', unit: '%' },
+    { key: 'fade', label: 'Depth Fade', type: 'slider', min: 0, max: 100, step: 1, default: 58, section: 'Finish', unit: '%' },
+    { key: 'speed', label: 'Speed', type: 'slider', min: 0, max: 2, step: 0.1, default: 0.3, section: 'Motion', unit: '×', precision: 1 },
+    ...sharedFinish,
+  ],
+  camera: (v) => ({ fov: 20 + clamp(v.perspective / 100, 0, 1) * 42 }),
+  transform3d: (frame, index, count, v, ctx) => {
+    const dir = v.direction === 'backward' ? -1 : 1;
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir;
+    const u = frac(index / count - phase / count);
+    const arrival = smooth(clamp((u - 0.66) / 0.34, 0, 1));
+    const settle = springOvershoot(arrival, 8.5, 12);
+    const edge = wrapEnvelope(u, 0.075);
+    const spreadPx = Math.min(ctx.width, ctx.height) * v.spread / 100;
+    const cardPx = Math.min(ctx.width, ctx.height) * v.cardSizePct / 100;
+    const z = lerp(-v.depth * 0.62, v.depth * 0.38, u) + settle * 42;
+    const drift = (hash2(index, 4.1) - 0.5) * spreadPx;
+    const lean = (v.tilt + dir * settle * 2.4) * Math.PI / 180;
+    return {
+      x: drift * 0.24 * (1 - settle * 0.65),
+      y: lerp(-spreadPx, spreadPx * 0.72, smooth(u)) - drift * 0.12,
+      z,
+      quaternion: quaternionFromEuler(lean, -lean * 0.35, lean * 0.3),
+      scale: (cardPx / BASE) * (0.9 + settle * 0.1),
+      alpha: edge * (1 - (v.fade / 100) * (1 - smooth(u))),
+      thickness: v.thickness,
+      shadowStrength: v.shadow === 'on' ? 1 : 0,
+      materialExposure: 0.68 + smooth(u) * 0.4,
+      velocity: { x: 0, y: 0, z: -v.depth * v.speed * dir },
+    };
+  },
+  transform: (frame, index, count, v, ctx) => {
+    const dir = v.direction === 'backward' ? -1 : 1;
+    const u = frac(index / count - ((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir) / count);
+    const cardPx = Math.min(ctx.width, ctx.height) * v.cardSizePct / 100;
+    const spreadPx = Math.min(ctx.width, ctx.height) * v.spread / 100;
+    return { x: 0, y: lerp(-spreadPx, spreadPx * 0.72, smooth(u)), scale: cardPx / BASE * lerp(0.72, 1, u), rotation: v.tilt * Math.PI / 180, alpha: wrapEnvelope(u, 0.075), depth: u };
+  },
+};
+
+export const parallaxTotem: Template = {
+  meta: { id: 'parallax-totem-01', name: 'Parallax Totem', group: 'Depth', isNew: true, engine: 'webgl', catalog3d: true, catalogHidden: true, repeatAssets: true, defaultEasing: { id: 'flow' } },
+  controls: [
+    { key: 'count', label: 'Count', type: 'slider', min: 6, max: 24, step: 1, default: 12, section: 'Layout' },
+    { key: 'planes', label: 'Depth Planes', type: 'slider', min: 2, max: 5, step: 1, default: 3, section: 'Depth' },
+    { key: 'cardSizePct', label: 'Card Size', type: 'slider', min: 12, max: 42, step: 1, default: 22, section: 'Layout', unit: '%' },
+    { key: 'spreadX', label: 'Horizontal Spread', type: 'slider', min: 30, max: 110, step: 1, default: 52, section: 'Layout', unit: '%' },
+    { key: 'spreadY', label: 'Vertical Spread', type: 'slider', min: 30, max: 110, step: 1, default: 58, section: 'Layout', unit: '%' },
+    { key: 'depth', label: 'Depth', type: 'slider', min: 120, max: 900, step: 10, default: 520, section: 'Depth', unit: 'px' },
+    { key: 'parallax', label: 'Parallax', type: 'slider', min: 0, max: 100, step: 1, default: 58, section: 'Motion', unit: '%' },
+    { key: 'tilt', label: 'Card Tilt', type: 'slider', min: 0, max: 20, step: 0.5, default: 5, section: 'Depth', unit: '°', precision: 1 },
+    { key: 'perspective', label: 'Perspective', type: 'slider', min: 0, max: 100, step: 1, default: 50, section: 'Depth', unit: '%' },
+    { key: 'speed', label: 'Speed', type: 'slider', min: 0, max: 2, step: 0.1, default: 0.22, section: 'Motion', unit: '×', precision: 1 },
+    ...sharedFinish,
+  ],
+  camera: (v) => ({ fov: 24 + clamp(v.perspective / 100, 0, 1) * 38 }),
+  transform3d: (frame, index, count, v, ctx) => {
+    const planes = Math.max(2, Math.round(v.planes));
+    const plane = index % planes;
+    const row = Math.floor(index / planes);
+    const rows = Math.max(1, Math.ceil(count / planes));
+    const depthN = planes <= 1 ? 1 : plane / (planes - 1);
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration);
+    const a = TAU * phase + (plane / planes) * TAU;
+    const amp = v.parallax / 100 * (0.35 + depthN * 0.65);
+    const baseX = (plane - (planes - 1) / 2) * (ctx.width * v.spreadX / 100) / Math.max(1, planes - 1);
+    const baseY = (row - (rows - 1) / 2) * (ctx.height * v.spreadY / 100) / Math.max(1, rows - 1);
+    const x = baseX + Math.sin(a) * ctx.width * 0.035 * amp;
+    const y = baseY + Math.cos(a * 2) * ctx.height * 0.025 * amp;
+    const z = lerp(-v.depth * 0.62, v.depth * 0.38, depthN);
+    const tilt = (hash2(index, 12.4) - 0.5) * 2 * v.tilt * Math.PI / 180;
+    const cardPx = Math.min(ctx.width, ctx.height) * v.cardSizePct / 100;
+    return {
+      x, y, z,
+      quaternion: quaternionFromEuler(tilt * 0.55, -tilt, tilt * 0.8),
+      scale: (cardPx / BASE) * lerp(0.78, 1.08, depthN),
+      alpha: lerp(0.52, 1, depthN),
+      thickness: v.thickness,
+      shadowStrength: v.shadow === 'on' ? 1 : 0,
+      materialExposure: lerp(0.68, 1.08, depthN),
+      velocity: { x: Math.cos(a) * ctx.width * 0.035 * amp, y: -Math.sin(a * 2) * ctx.height * 0.05 * amp, z: 0 },
+    };
+  },
+  transform: (frame, index, count, v, ctx) => {
+    const planes = Math.max(2, Math.round(v.planes));
+    const plane = index % planes;
+    const row = Math.floor(index / planes);
+    const rows = Math.max(1, Math.ceil(count / planes));
+    const depthN = plane / (planes - 1);
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration);
+    const a = TAU * phase + (plane / planes) * TAU;
+    const x = (plane - (planes - 1) / 2) * (ctx.width * v.spreadX / 100) / Math.max(1, planes - 1) + Math.sin(a) * ctx.width * 0.025;
+    const y = (row - (rows - 1) / 2) * (ctx.height * v.spreadY / 100) / Math.max(1, rows - 1) + Math.cos(a * 2) * ctx.height * 0.018;
+    return { x, y, scale: Math.min(ctx.width, ctx.height) * v.cardSizePct / 100 / BASE * lerp(0.78, 1.08, depthN), rotation: 0, alpha: lerp(0.52, 1, depthN), depth: depthN };
+  },
+};
+
+export const premium3dTemplates = [cardTunnel, depthStackScroll, parallaxTotem];

--- a/templates/proximity.ts
+++ b/templates/proximity.ts
@@ -1,5 +1,5 @@
 import type { Template } from '@/lib/types';
-import { TAU, frac, wave, clamp, lerp, hash2, loopCycles } from '@/lib/motion';
+import { TAU, frac, wave, clamp, lerp, hash2, loopCycles, smooth } from '@/lib/motion';
 import { variant } from './variant';
 
 const BASE = 340;
@@ -57,11 +57,12 @@ const proximity: Template = {
 
     const dist = Math.hypot(baseX - fx, baseY - fy);
     const r = v.focusRadius;
-    const mag = 1 + v.magnify * Math.max(0, 1 - dist / r);
+    const influence = smooth(clamp(1 - dist / r, 0, 1));
+    const mag = 1 + v.magnify * influence;
 
     // per-tile variety: deterministic size mix and rotation wobble
     const mix = 1 - (v.sizeMix / 100) * 0.6 * hash2(index, 13.7);
-    const rotation = ((hash2(index, 71.3) - 0.5) * 2 * v.tilt * Math.PI) / 180;
+    const rotation = ((hash2(index, 71.3) - 0.5) * 2 * v.tilt * Math.PI) / 180 * influence;
 
     // whole-field build in/out envelope (0 at both ends → loop-safe)
     const env = v.buildInOut === 'on' ? Math.pow(wave(frame / ctx.totalFrames), 0.75) : 1;

--- a/templates/reveal.ts
+++ b/templates/reveal.ts
@@ -1,6 +1,7 @@
 import type { Template } from '@/lib/types';
 import { smooth, clamp } from '@/lib/motion';
 import { variant } from './variant';
+import { tiltPointCanvas } from '@/lib/tilt3d';
 
 const BASE = 340;
 const TEX_RATIO = 480 / 600; // house placeholder/texture proportion
@@ -96,9 +97,13 @@ const reveal: Template = {
     const scale = ph / BASE;
     const scaleX = (pw / ph) / TEX_RATIO;
 
+    const layoutPoint = tiltPointCanvas(
+      { x: panel.x * ctx.width, y: panel.y * ctx.height, z: 0 },
+      { roll: v.tilt },
+    );
     return {
-      x: panel.x * ctx.width + v.offset.x,
-      y: panel.y * ctx.height + v.offset.y,
+      x: layoutPoint.x + v.offset.x,
+      y: layoutPoint.y + v.offset.y,
       scale: scale * (0.94 + 0.06 * vis),             // slight settle as it lands
       scaleX,
       rotation: (v.tilt * Math.PI) / 180,

--- a/templates/showcase.ts
+++ b/templates/showcase.ts
@@ -1,0 +1,196 @@
+import type { Template } from '@/lib/types';
+import { TAU, clamp, lerp, loopCycles } from '@/lib/motion';
+import {
+  DEG, backfaceFade, quaternionFromEuler, tiltNormalCanvas, tiltPointCanvas,
+} from '@/lib/tilt3d';
+import { variant } from './variant';
+
+const BASE = 340;
+
+// ============================================================
+//  SHOWCASE — a ring of cards lying on a plane tipped into depth
+//
+//  Ferris already puts cards on a ring, but that ring sits IN the screen plane:
+//  seen face on, every card the same size, and it stays a circle. Here the ring
+//  is laid down on a tipped plane, so it reads as an ellipse, the far side is
+//  genuinely further from the camera, and each card is turned with the surface
+//  it sits on.
+//
+//  This is a `webgl` template because that is the only way to get it honestly.
+//  The 2D seam's LayerTransform is entirely affine, and affine maps send
+//  parallel lines to parallel lines — a card turning away needs a keystone,
+//  which is projective. Three.js supplies a real perspective camera, so the
+//  keystone comes from the projection rather than from faking it with skew.
+//
+//  ONE CAMERA. `camera()` is not optional for this family. Without it the
+//  renderer maps `values.perspective` over 0..200 (renderer3d's
+//  updateTrackCamera), and this template's Perspective range is 0..40 — the
+//  default mapping would read 18 as a very long lens and the tilt would barely
+//  register. The fov mapping has to belong to the template.
+// ============================================================
+
+// ---- The one assumption in this file ----------------------------------------
+// `Ring Opening` could not be measured directly: the reference editor's render
+// loop is suspended whenever its tab is not compositing, so its canvas was
+// frozen on an old frame and sweeping the slider changed nothing measurable.
+//
+// One real data point survived, from the default state (tilt -28, opening 55,
+// size 80): the drawn ring's bounding box was 906x766, a ratio of 0.845. A plain
+// circle tipped 28 degrees would give cos(28) = 0.883, and the cards' own extent
+// inflates the box's height, pushing the measured ratio UP toward 1. So the ring
+// underneath is flatter than 0.845 — flatter than the tilt alone explains.
+//
+// Hence: opening is a squash of the ellipse's minor axis that is ADDITIONAL to
+// the tilt. 85 leaves the ring nearly as open as the tilt alone would; 15
+// collapses it toward a line. Isolated here on purpose — if the reference can be
+// measured later, only this function changes.
+const openingFactor = (opening: number) => lerp(0.18, 1, clamp(opening, 0, 100) / 100);
+
+// Long lens to moderately wide. The ceiling is deliberately low: the reference
+// caps Perspective at 40 and ships 18, keeping the lens long enough that the
+// ring reads as a ring rather than a funnel.
+const showcaseFov = (perspective: number) => lerp(17, 46, clamp(perspective, 0, 40) / 40);
+
+const showcase: Template = {
+  meta: {
+    id: 'showcase-01', name: 'Showcase Stream', group: 'Showcase',
+    isNew: true, engine: 'webgl', repeatAssets: true, catalogHidden: true,
+    defaultEasing: { id: 'linear' },
+  },
+
+  controls: [
+    { key: 'direction',    label: 'Direction',     type: 'toggle', options: ['forward','reverse'], default: 'forward', section: 'Motion' },
+    { key: 'count',        label: 'Count',         type: 'slider', min: 6, max: 32, step: 1,      default: 12, section: 'Layout' },
+    { key: 'ringSize',     label: 'Ring Size',     type: 'slider', min: 50, max: 95, step: 1,     default: 80, section: 'Layout', unit: '%' },
+    { key: 'cardSizePct',  label: 'Card Size',     type: 'slider', min: 12, max: 32, step: 1,     default: 21, section: 'Layout', unit: '%' },
+    { key: 'ringTilt',     label: 'Ring Tilt',     type: 'slider', min: -60, max: 60, step: 1,    default: -28, section: 'Depth', unit: '°',
+      description: 'Tips the whole ring plane into depth. Every card turns with the surface it sits on.' },
+    { key: 'ringOpening',  label: 'Ring Opening',  type: 'slider', min: 15, max: 85, step: 1,     default: 55, section: 'Depth', unit: '%',
+      description: 'Squashes the ellipse further than the tilt alone does. Low collapses the ring toward a line.' },
+    { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 40, step: 2,      default: 18, section: 'Depth', unit: '%',
+      description: 'Camera field of view. Kept deliberately long — past this the ring reads as a funnel.' },
+    { key: 'facing',       label: 'Card Facing',   type: 'pills',  options: ['surface','camera'], default: 'surface', section: 'Depth' },
+    { key: 'backFade',     label: 'Back Fade',     type: 'slider', min: 10, max: 95, step: 5,     default: 70, section: 'Finish', unit: '%' },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 12, step: 0.5,    default: 3, section: 'Finish', unit: '%', precision: 1 },
+    { key: 'thickness',    label: 'Thickness',     type: 'slider', min: 0, max: 24, step: 1,      default: 8, section: 'Finish', unit: 'px',
+      description: 'Gives the cards a physical edge. Also what lets depth shading register at all.' },
+    { key: 'shadow',       label: 'Shadow',        type: 'toggle', options: ['on','off'],         default: 'on', section: 'Finish' },
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 2, step: 0.1,     default: 0.35, section: 'Motion', unit: '×', precision: 1 },
+    { key: 'offset',       label: 'Offset',        type: 'xypad',                                 default: { x: 0, y: 0 }, section: 'Layout' },
+  ],
+
+  camera: (v) => ({ fov: showcaseFov(v.perspective) }),
+
+  transform3d: (frame, index, count, v, ctx) => {
+    const dir = v.direction === 'reverse' ? -1 : 1;
+    // Period is `count`: one full turn of the ring is count slots, so frame
+    // totalFrames poses exactly like frame 0.
+    //
+    // RAW phase, not ctx.easedPhase. easedPhase is floor(p) + ease(frac(p)) — it
+    // shapes every unit step, which is right for a conveyor advancing one slot at
+    // a time and wrong for a ring turning continuously: with period `count` an
+    // ease-in-out curve makes the ring accelerate and settle once PER CARD.
+    // Measured on Orbit 3D, that swung the instantaneous angular rate 23.5x
+    // between frames. The seam is unaffected — loopCycles returns a whole
+    // multiple of `count`, so the angle advances by a multiple of TAU.
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir;
+    const phi = (((index - phase) % count + count) % count) / count * TAU;
+
+    const stage = Math.min(ctx.width, ctx.height);
+    const radius = (stage * (v.ringSize / 100)) / 2;
+    const k = openingFactor(v.ringOpening);
+
+    // The ring in its own plane, before the plane is tipped. phi = 0 sits at the
+    // front (canvas y is down, so +y is the near side once tilted).
+    const rx = Math.sin(phi) * radius;
+    const ry = Math.cos(phi) * radius * k;
+
+    const rig = { pitch: v.ringTilt };
+    const p = tiltPointCanvas({ x: rx, y: ry, z: 0 }, rig);
+    // The plane's own normal, tipped the same way. One function for the point and
+    // the normal is what keeps card centres and card facings on the same plane.
+    const n = tiltNormalCanvas({ x: 0, y: 0, z: 1 }, rig);
+
+    // Lay the card along the ring: it takes the plane's tilt plus the roll that
+    // points it around the curve. Quaternion rather than Euler because the
+    // renderer prefers it and because composing tilt with roll in Euler order
+    // introduces gimbal drift at steep tilts.
+    //
+    // The roll is the tangent of the ELLIPSE, not of a circle. `opening` squashes
+    // the ring inside its own plane before the plane is tipped, so the curve the
+    // cards sit on is already an ellipse — and an ellipse's tangent is not the
+    // circle's. Using -phi looked right only at opening 100; at the default 55
+    // (k ≈ 0.63) it left every card visibly off its own path. Reduces to -phi
+    // exactly when k = 1.
+    const surface = v.facing === 'surface';
+    const roll = surface ? Math.atan2(-Math.sin(phi) * k, Math.cos(phi)) : 0;
+    const quaternion = quaternionFromEuler(
+      surface ? v.ringTilt * DEG : 0,
+      0,
+      roll,
+    );
+
+    const cardPx = stage * (v.cardSizePct / 100);
+    // Depth shading needs thickness to register: without it renderer3d makes the
+    // material emissive and ignores materialExposure entirely.
+    const nearness = clamp((p.z / Math.max(1, radius) + 1) / 2, 0, 1);
+
+    return {
+      x: p.x + v.offset.x,
+      y: p.y + v.offset.y,
+      z: p.z,
+      quaternion,
+      scale: cardPx / BASE,
+      alpha: backfaceFade(n.z, v.backFade * (1 - nearness)),
+      thickness: v.thickness,
+      shadowStrength: v.shadow === 'on' ? 1 : 0,
+      materialExposure: lerp(0.62, 1.06, nearness),
+    };
+  },
+
+  // ---- 2D fallback, for thumbnails and the non-webgl path ----
+  // Orthographic on purpose: it cannot express a keystone, so it does not
+  // pretend to. Size falloff stands in for the perspective.
+  transform: (frame, index, count, v, ctx) => {
+    const dir = v.direction === 'reverse' ? -1 : 1;
+    // Raw phase, matching the 3D path — see the note there.
+    const phase = (frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir;
+    const phi = (((index - phase) % count + count) % count) / count * TAU;
+
+    const stage = Math.min(ctx.width, ctx.height);
+    const radius = (stage * (v.ringSize / 100)) / 2;
+    const k = openingFactor(v.ringOpening);
+    const rx = Math.sin(phi) * radius;
+    const ry = Math.cos(phi) * radius * k;
+    const p = tiltPointCanvas({ x: rx, y: ry, z: 0 }, { pitch: v.ringTilt });
+
+    const nearness = clamp((p.z / Math.max(1, radius) + 1) / 2, 0, 1);
+    const cardPx = stage * (v.cardSizePct / 100);
+
+    return {
+      x: p.x + v.offset.x,
+      y: p.y + v.offset.y,
+      scale: (cardPx / BASE) * lerp(0.72, 1.12, nearness),
+      // Same ellipse tangent as the 3D path, so the thumbnail agrees with the stage.
+      rotation: v.facing === 'surface' ? Math.atan2(-Math.sin(phi) * k, Math.cos(phi)) : 0,
+      alpha: lerp(1 - clamp(v.backFade, 0, 95) / 100, 1, nearness),
+      depth: nearness,
+    };
+  },
+};
+
+export const showcaseVariants: Template[] = [
+  showcase,
+  // Steeper and flatter: looking down into the ring, the shot where the tipped
+  // plane is most obvious.
+  variant(showcase, 'showcase-02', 'Showcase Deep', {
+    ringTilt: -46, ringOpening: 34, ringSize: 88, cardSizePct: 24,
+    perspective: 26, backFade: 80, speed: 0.28,
+  }),
+  // Near-upright ring, long lens, cards square to the frame — a calm band
+  // rather than a drum.
+  variant(showcase, 'showcase-03', 'Showcase Flat', {
+    ringTilt: -12, ringOpening: 78, ringSize: 72, cardSizePct: 18,
+    perspective: 8, facing: 'camera', backFade: 45, thickness: 4, speed: 0.45, count: 16,
+  }),
+];

--- a/templates/spiral.ts
+++ b/templates/spiral.ts
@@ -8,15 +8,15 @@ const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
 // Spiral — the camera corkscrews through a helix of cards (DNA / spiral
 // staircase): continuous rotation around the axis plus looping vertical travel.
 const spiral: Template = {
-  meta: { id: 'spiral-01', name: 'Helix 01', group: 'Helix', defaultEasing: { id: 'linear' } },
+  meta: { id: 'spiral-01', name: 'Helix 01', group: 'Helix', repeatAssets: true, defaultEasing: { id: 'linear' } },
 
   controls: [
     { key: 'direction',    label: 'Direction',     type: 'toggle', options: ['forward','reverse'], default: 'forward' },
-    { key: 'count',        label: 'Count',         type: 'slider', min: 8, max: 70, step: 1,   default: 40 },
-    { key: 'radius',       label: 'Radius',        type: 'slider', min: 80, max: 600, step: 1, default: 300 },
-    { key: 'turns',        label: 'Turns',         type: 'slider', min: 1, max: 6, step: 1,    default: 3 },
-    { key: 'pitch',        label: 'Pitch',         type: 'slider', min: 10, max: 120, step: 1, default: 40 },
-    { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 20, max: 300, step: 1, default: 110 },
+    { key: 'count',        label: 'Count',          type: 'slider', min: 8, max: 70, step: 1,   default: 40 },
+    { key: 'radius',       label: 'Radius',         type: 'slider', min: 80, max: 600, step: 1, default: 300 },
+    { key: 'turns',        label: 'Turns',          type: 'slider', min: 1, max: 6, step: 1,    default: 3 },
+    { key: 'pitch',        label: 'Pitch',          type: 'slider', min: 10, max: 120, step: 1, default: 40 },
+    { key: 'cardSize',     label: 'Plane Size',     type: 'slider', min: 20, max: 300, step: 1, default: 110 },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,  default: 12 },
     { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 3, step: 0.1,  default: 0.5 },
     { key: 'offset',       label: 'Offset',        type: 'xypad',                              default: { x: 0, y: 0 } },

--- a/templates/surface.ts
+++ b/templates/surface.ts
@@ -1,0 +1,96 @@
+import type { Template } from '@/lib/types';
+import { clamp, loopCycles, smooth } from '@/lib/motion';
+import { backfaceFade, tiltNormalCanvas, tiltPointCanvas, wrapEnvelope } from '@/lib/tilt3d';
+import { variant } from './variant';
+
+const BASE = 340;
+
+function geometry(frame: number, index: number, count: number, v: Record<string, any>, ctx: Parameters<Template['transform']>[4]) {
+  const columns = Math.max(2, Math.round(v.columns));
+  const rows = Math.max(1, Math.ceil(count / columns));
+  const col = index % columns;
+  const row = Math.floor(index / columns);
+  const phase = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, rows));
+  const gap = 1 + v.gap / 100;
+  const stepX = v.cardSize * gap;
+  const stepY = v.cardSize * 0.72 * gap;
+  const width = Math.max(stepX, (columns - 1) * stepX);
+  const u = columns <= 1 ? 0 : col / (columns - 1);
+  const centred = u * 2 - 1;
+  const bend = clamp(v.curvature / 150, -1, 1) * 1.35;
+  const angle = centred * Math.abs(bend);
+  const radius = Math.abs(bend) < 0.001 ? 1e8 : width / (2 * Math.abs(bend));
+  const sign = Math.sign(bend) || 1;
+  const x = Math.abs(bend) < 0.001 ? centred * width / 2 : Math.sin(angle) * radius;
+  const z = Math.abs(bend) < 0.001 ? 0 : (1 - Math.cos(angle)) * radius * sign;
+
+  let row01 = rows <= 1 ? 0.5 : row / rows;
+  let seam = 1;
+  if (v.mode !== 'wall') {
+    const alternate = v.flow === 'alternate' && col % 2 ? -1 : 1;
+    const columnPhase = v.mode === 'cascade' ? col * v.phaseOffset / 100 : col * 0.11;
+    row01 = ((row01 - phase / rows * alternate + columnPhase) % 1 + 1) % 1;
+    seam = wrapEnvelope(row01, 0.09);
+  }
+  const y = (row01 - (v.mode === 'wall' ? (rows - 1) / Math.max(1, rows) / 2 : 0.5)) * rows * stepY;
+  const edge = 1 - (v.edgeFade / 100) * smooth(clamp((Math.abs(centred) - 0.55) / 0.45, 0, 1));
+  const normal = tiltNormalCanvas({ x: -Math.sin(angle) * sign, y: 0, z: Math.cos(angle) }, { pitch: v.tilt });
+  const point = tiltPointCanvas({ x, y, z }, { pitch: v.tilt });
+  return { point, normal, angle: angle * sign, alpha: seam * edge * backfaceFade(normal.z, v.backFade) };
+}
+
+const surface: Template = {
+  meta: { id: 'surface-wall-01', name: 'Curved Wall', group: 'Surface', isNew: true, engine: 'webgl', catalog3d: true, repeatAssets: true, defaultEasing: { id: 'linear' } },
+  controls: [
+    { key: 'mode', label: 'Mode', type: 'pills', options: ['wall','cascade','totem'], default: 'wall', section: 'Layout', advanced: true },
+    { key: 'count', label: 'Count', type: 'slider', min: 6, max: 60, step: 1, default: 25, section: 'Layout' },
+    { key: 'columns', label: 'Columns', type: 'slider', min: 2, max: 5, step: 1, default: 5, section: 'Layout' },
+    { key: 'cardSize', label: 'Card Size', type: 'slider', min: 70, max: 320, step: 1, default: 170, section: 'Layout', unit: 'px' },
+    { key: 'gap', label: 'Gap', type: 'slider', min: 0.5, max: 20, step: 0.5, default: 5, section: 'Layout', unit: '%', precision: 1 },
+    { key: 'curvature', label: 'Curvature', type: 'slider', min: -150, max: 150, step: 1, default: -100, section: 'Depth', unit: '%', description: 'Bends the shared surface while every card remains attached to it.' },
+    { key: 'tilt', label: 'Tilt', type: 'slider', min: -45, max: 45, step: 1, default: 0, section: 'Depth', unit: '°', description: 'Rotates the complete curved surface, not the individual cards.' },
+    { key: 'perspective', label: 'Perspective', type: 'slider', min: 0, max: 100, step: 1, default: 48, section: 'Depth', unit: '%' },
+    { key: 'flow', label: 'Column Flow', type: 'pills', options: ['same','alternate'], default: 'same', section: 'Motion', visibleWhen: { key: 'mode', not: 'wall' } },
+    { key: 'phaseOffset', label: 'Phase Offset', type: 'slider', min: 0, max: 100, step: 1, default: 15, section: 'Motion', unit: '%', visibleWhen: { key: 'mode', equals: 'cascade' } },
+    { key: 'speed', label: 'Speed', type: 'slider', min: 0, max: 2, step: 0.1, default: 0, section: 'Motion', unit: '×', precision: 1 },
+    { key: 'edgeFade', label: 'Edge Fade', type: 'slider', min: 0, max: 100, step: 1, default: 18, section: 'Finish', unit: '%' },
+    { key: 'backFade', label: 'Back Fade', type: 'slider', min: 0, max: 100, step: 1, default: 55, section: 'Finish', unit: '%' },
+    { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1, default: 10, section: 'Finish', unit: '%' },
+    { key: 'offset', label: 'Offset', type: 'xypad', default: { x: 0, y: 0 }, section: 'Layout' },
+  ],
+  transform3d: (frame, index, count, v, ctx) => {
+    const g = geometry(frame, index, count, v, ctx);
+    return {
+      x: g.point.x + v.offset.x,
+      y: g.point.y + v.offset.y,
+      z: g.point.z,
+      rotationX: -v.tilt * Math.PI / 180,
+      rotationY: g.angle,
+      rotationZ: 0,
+      scale: v.cardSize / BASE,
+      alpha: g.alpha,
+    };
+  },
+  transform: (frame, index, count, v, ctx) => {
+    const g = geometry(frame, index, count, v, ctx);
+    const depthScale = 1 + clamp(g.point.z / 1500, -0.35, 0.35);
+    return {
+      x: g.point.x + v.offset.x,
+      y: g.point.y + v.offset.y,
+      scale: (v.cardSize / BASE) * depthScale,
+      rotation: 0,
+      alpha: g.alpha,
+      depth: g.point.z,
+    };
+  },
+};
+
+export const surfaceVariants: Template[] = [
+  surface,
+  variant(surface, 'surface-cascade-01', 'Curved Cascade', {
+    mode: 'cascade', count: 30, columns: 5, speed: 0.55, phaseOffset: 15, curvature: -85, edgeFade: 25,
+  }),
+  variant(surface, 'surface-totem-01', 'Totem Wall', {
+    mode: 'totem', count: 18, columns: 3, cardSize: 205, speed: 0.4, flow: 'alternate', curvature: -70, edgeFade: 30,
+  }),
+];

--- a/templates/ticker.ts
+++ b/templates/ticker.ts
@@ -1,7 +1,9 @@
 import type { Template } from '@/lib/types';
-import { loopCycles, stepHold } from '@/lib/motion';
+import type { EasingSpec } from '@/lib/easing';
+import { clamp, loopCycles, stepHold } from '@/lib/motion';
 import { cardPath } from '@/lib/cardPath';
 import { variant } from './variant';
+import { tiltPointCanvas } from '@/lib/tilt3d';
 
 // Reference size (px) shared with the renderer's sprite normalization, so that
 // `cardSize` reads directly in on-screen pixels.
@@ -28,19 +30,20 @@ const BASE = 340;
 // ============================================================
 
 const ticker: Template = {
-  meta: { id: 'ticker-01', name: 'Ticker 01', group: 'Ticker', defaultEasing: { id: 'linear' }, repeatAssets: true },
+  meta: { id: 'ticker-01', name: 'Ticker 01', group: 'Ticker', isNew: true, defaultEasing: { id: 'linear' }, repeatAssets: true },
 
   controls: [
     { key: 'direction',    label: 'Direction',     type: 'pills',  options: ['left','right','up','down'], default: 'left' },
     { key: 'count',        label: 'Count',         type: 'slider', min: 2, max: 60, step: 1,    default: 12 },
-    { key: 'rows',         label: 'Rows',          type: 'slider', min: 1, max: 5, step: 1,     default: 1 },
-    { key: 'weave',        label: 'Weave Rows',    type: 'toggle', options: ['off','on'],       default: 'off' }, // alternate rows run the other way
+    { key: 'rows',         label: 'Rows',          type: 'slider', min: 1, max: 6, step: 1,     default: 1 },
+    { key: 'flow',         label: 'Flow',          type: 'pills', options: ['same','opposed','staggered'], default: 'opposed', section: 'Motion' },
+    { key: 'laneOffset',   label: 'Lane Offset',   type: 'slider', min: -100, max: 100, step: 1, default: 0, section: 'Motion', unit: '%', description: 'Phase shift added per row, in cells. Keeps rows from starting aligned.' },
     { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 40, max: 600, step: 1,  default: 220 },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,   default: 8 },
     { key: 'gap',          label: 'Gap',           type: 'slider', min: 0, max: 600, step: 1,   default: 250 }, // px between card centres (at base size)
     { key: 'rowGap',       label: 'Row Gap',       type: 'slider', min: 0, max: 600, step: 1,   default: 260 },
+    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -30, max: 30, step: 1, default: -6, section: 'Depth', unit: '°', description: 'Rotates the complete ticker plane.' },
     { key: 'hold',         label: 'Step Hold',     type: 'slider', min: 0, max: 90, step: 1,    default: 0 },  // % of each step spent stopped
-    { key: 'tilt',         label: 'Tilt',          type: 'slider', min: -30, max: 30, step: 1,  default: 0 },  // degrees, uniform
     { key: 'offset',       label: 'Offset',        type: 'xypad',                               default: { x: 0, y: 0 } },
     { key: 'outerFade',    label: 'Outer Fade',    type: 'slider', min: 0, max: 100, step: 1,   default: 100 }, // fade while leaving the frame %
     { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 4, step: 0.1,   default: 0.8 }, // cards/sec
@@ -58,12 +61,19 @@ const ticker: Template = {
     const perRow = Math.max(1, Math.ceil(count / rows));
 
     // Weave: odd rows travel the other way.
-    const dir = v.weave === 'on' && row % 2 === 1 ? -baseDir : baseDir;
+    const dir = v.flow === 'opposed' && row % 2 === 1 ? -baseDir : baseDir;
 
     // Period is the row length, so every card lands back on its own slot at the
     // loop point — the same guarantee the other conveyors make.
     const cycles = loopCycles(v.speed, ctx.duration, perRow);
-    const raw = (frame / ctx.totalFrames) * cycles * dir;
+    // Lane phase. `staggered` is the fixed half-cell weave the family shipped
+    // with; `laneOffset` is the free version, and the reason a multi-lane band
+    // reads as woven rather than as a rigid grid sliding sideways — with every
+    // lane in phase, the rows line up into columns and the eye reads a table.
+    // A whole-cell offset is a no-op by construction, so the loop is unaffected.
+    const stagger = (v.flow === 'staggered' ? row * 0.5 : 0)
+      + row * ((v.laneOffset ?? 0) / 100);
+    const raw = (frame / ctx.totalFrames) * cycles * dir + stagger;
 
     // Hold > 0 turns the glide into discrete steps. `stepHold` is loop-safe
     // (f(n) = n at integers), and handing it ctx.ease means the scene's easing
@@ -81,8 +91,11 @@ const ticker: Template = {
     const along = offset * v.gap * sizeFactor;
     const across = (row - (rows - 1) / 2) * v.rowGap * sizeFactor;
 
-    const x = (horiz ? along : across) + v.offset.x;
-    const y = (horiz ? across : along) + v.offset.y;
+    const px = horiz ? along : across;
+    const py = horiz ? across : along;
+    const roll = (Number(v.tilt ?? 0) * Math.PI) / 180;
+    const x = px * Math.cos(roll) - py * Math.sin(roll) + v.offset.x;
+    const y = px * Math.sin(roll) + py * Math.cos(roll) + v.offset.y;
 
     // Constant scale — a ticker has no hero card.
     const scale = sizeFactor;
@@ -103,7 +116,7 @@ const ticker: Template = {
       x,
       y,
       scale,
-      rotation: (v.tilt * Math.PI) / 180,
+      rotation: roll,
       alpha,
       // Rows nearer the bottom of the stack draw on top, and within a row the
       // card closest to centre wins — stable, and never flickers mid-travel.
@@ -112,12 +125,256 @@ const ticker: Template = {
   },
 };
 
+// Ticker Tilt is not a collection of individually rotated cards. It is one
+// rigid, flat sheet. The sheet first tips away around X, then yaws around Y.
+// That compound rotation is important: horizontal rows stay aligned while the
+// columns lean toward an off-centre vanishing point and distant rows compress.
+// A single Y rotation only makes a side-facing trapezoid, which is the wrong
+// visual language for this effect.
+const tickerTilt: Template = {
+  ...ticker,
+  meta: {
+    ...ticker.meta,
+    id: 'ticker-02',
+    name: 'Ticker Tilt',
+    engine: 'webgl',
+    defaultEasing: { id: 'smooth' },
+  },
+  controls: ticker.controls.flatMap((control) => {
+    if (control.key === 'tilt') return [];
+    const patched =
+      control.key === 'count' ? { ...control, default: 24 } :
+      control.key === 'rows' ? { ...control, default: 4 } :
+      control.key === 'flow' ? { ...control, default: 'same' } :
+      control.key === 'cardSize' ? { ...control, default: 180 } :
+      control.key === 'gap' ? { ...control, default: 200 } :
+      control.key === 'rowGap' ? { ...control, default: 210 } :
+      control.key === 'outerFade' ? { ...control, default: 0 } :
+      control.key === 'speed' ? { ...control, default: 0.6 } :
+      control;
+    if (control.key !== 'rowGap') return [patched];
+    return [
+      patched,
+      { key: 'zoom',        label: 'Zoom',        type: 'slider' as const, min: 0, max: 100, step: 1, default: 32 },
+      { key: 'tilt',        label: 'Tilt',        type: 'slider' as const, min: -55, max: 55, step: 1, default: 30 },
+      { key: 'perspective', label: 'Perspective', type: 'slider' as const, min: 0, max: 100, step: 1, default: 60 },
+    ];
+  }),
+  transform: (frame, index, count, v, ctx) => {
+    // The base ticker's `tilt` is a 2D roll. Here the same public key means
+    // WebGL yaw, so explicitly neutralize the base roll before projecting the
+    // rigid sheet. Letting both interpretations stack was the source of the
+    // crooked, individually scattered look in the old preset.
+    const flat = ticker.transform(frame, index, count, { ...v, tilt: 0 }, ctx);
+    const pitch = -(4 + clamp(v.perspective / 100, 0, 1) * 38) * Math.PI / 180;
+    const yaw = -(clamp(v.tilt, -55, 55) / 55) * 22 * Math.PI / 180;
+    const cp = Math.cos(pitch);
+    const shear = -Math.sin(pitch) * Math.sin(yaw);
+    // At the reference default (32%) the sheet deliberately overscans the
+    // frame, so its clipped edges read as a continuous surface rather than a
+    // small floating grid.
+    const zoom = 1.45 + clamp(v.zoom / 100, 0, 1) * 1.8;
+    return {
+      ...flat,
+      x: (flat.x + flat.y * shear) * zoom,
+      y: flat.y * cp * zoom,
+      scale: flat.scale * zoom,
+      rotation: 0,
+      // Multi-layer scenes use Pixi. This affine projection preserves the
+      // plane's dominant lean; the single-layer preview/export uses WebGL.
+      skewX: Math.atan(shear),
+      scaleY: cp,
+    };
+  },
+  transform3d: (frame, index, count, v, ctx) => {
+    const flat = ticker.transform(frame, index, count, { ...v, tilt: 0 }, ctx);
+    const pitchDeg = -(4 + clamp(v.perspective / 100, 0, 1) * 38);
+    const yawDeg = -(clamp(v.tilt, -55, 55) / 55) * 22;
+    const pitch = pitchDeg * Math.PI / 180;
+    const yaw = yawDeg * Math.PI / 180;
+    const cp = Math.cos(pitch);
+    const sp = Math.sin(pitch);
+    const cy = Math.cos(yaw);
+    const sy = Math.sin(yaw);
+    const zoom = 1.45 + clamp(v.zoom / 100, 0, 1) * 1.8;
+    const localX = flat.x * zoom;
+    const localY = flat.y * zoom;
+    const point = tiltPointCanvas({ x: localX, y: localY, z: 0 }, { pitch: pitchDeg, yaw: yawDeg });
+
+    // Renderer world Y points up while template Y points down. These equations
+    // are Ry(yaw) * Rx(pitch) applied to (localX, -localY, 0), then converted
+    // back to the template's canvas-down convention.
+    return {
+      x: point.x,
+      y: point.y,
+      z: point.z,
+      rotationX: pitch,
+      rotationY: yaw,
+      rotationZ: 0,
+      scale: flat.scale * zoom,
+      alpha: flat.alpha,
+    };
+  },
+};
+
+// ============================================================
+//  Reference-catalogue presets (Marquee 01–22)
+//
+//  The reference tool authors a marquee from `planeSize` and `gap` in its own
+//  units. Measured live across four of its presets (planeSize 55 / 115 / 160 /
+//  180), a card is 3:4 portrait with
+//        height  = 2 * planeSize * REF_UNIT
+//        pitch   = height + REF_UNIT * gap
+//  and REF_UNIT held to within 0.1% across all four, so this is the tool's real
+//  sizing rule rather than a curve fit. The reference canvas is 1080x1440 where
+//  this project normalizes the long edge to 1080 — hence the 0.75.
+//
+//  Ticker's own `gap`/`rowGap` are centre distances AT BASE SIZE, so dividing
+//  the measured pitches by the card's size factor cancels REF_UNIT out entirely
+//  and leaves an exact form with no fitted constant in it:
+//        gap    = BASE * (1    + gap / (2 * planeSize))
+//        rowGap = BASE * (0.75 + gap / (2 * planeSize))
+//  REF_UNIT survives only to set `cardSize` itself.
+// ============================================================
+const REF_UNIT = 2.155 * 0.75;
+
+interface RefMarquee {
+  axis: 'vertical' | 'horizontal';
+  reverse?: boolean;
+  lanes: number;
+  planeSize: number;
+  gap: number;
+  weave?: boolean;   // reference `alternate` — lanes run against each other
+  hold?: number;     // % of each step spent stopped
+  angle?: number;    // whole-plane rotation, degrees
+  lane?: number;     // per-lane phase offset, % of one cell
+  cycles?: number;   // times the whole asset set passes per reference clip
+  assets?: number;   // the reference preset's `count` — its asset set size
+  seconds?: number;  // the reference clip length those cycles were authored for
+}
+
+function refMarquee(r: RefMarquee): Record<string, any> {
+  const cardSize = Math.round(2 * r.planeSize * REF_UNIT);
+  const ratio = r.gap / (2 * r.planeSize);
+
+  // `cardSize` is the card's LONG edge (3:4 portrait ⇒ its height), so which
+  // dimension faces the travel axis depends on the axis: a horizontal band is
+  // spaced by card WIDTH, a vertical one by card HEIGHT. Using height for both
+  // is what left a quarter-card hole between every pair in the horizontal
+  // presets — the edge gap has to come out as cardSize*ratio either way.
+  const alongUnit = r.axis === 'vertical' ? 1 : 3 / 4;
+  const acrossUnit = r.axis === 'vertical' ? 3 / 4 : 1;
+  const gap = Math.round(BASE * (alongUnit + ratio));
+  const rowGap = Math.round(BASE * (acrossUnit + ratio));
+
+  // Enough cards per lane to overscan the travel axis, so a band never shows its
+  // own end. Two things stretch what has to be covered: a tilted plane presents
+  // the canvas diagonal to the travel axis rather than one side, and a lane
+  // pushed by `lane` starts up to a full cell short. Both cost real cards.
+  const alongPitch = gap * (cardSize / BASE);
+  const cardAlong = cardSize * alongUnit;
+  const roll = Math.abs(((r.angle ?? 0) * Math.PI) / 180);
+  const along = r.axis === 'vertical'
+    ? 810 * Math.sin(roll) + 1080 * Math.cos(roll)
+    : 810 * Math.cos(roll) + 1080 * Math.sin(roll);
+  const perLane = Math.max(2, Math.ceil((along + 2 * cardAlong) / alongPitch) + 1);
+
+  return {
+    // Reference `forward` moves content along +y (measured: a lane's cards ran
+    // -547 -> -472 -> -398 over 4s), which is this family's `down`.
+    direction: r.axis === 'vertical' ? (r.reverse ? 'up' : 'down')
+                                     : (r.reverse ? 'left' : 'right'),
+    rows: r.lanes,
+    count: r.lanes * perLane,
+    cardSize,
+    gap,
+    rowGap,
+    cornerRadius: 0,
+    flow: r.weave === false ? 'same' : 'opposed',
+    laneOffset: r.lane ?? 0,
+    hold: r.hold ?? 0,
+    tilt: r.angle ?? 0,
+    // The reference band clips at the canvas edge instead of dissolving
+    // (depthFade was 0 on all 22 of its presets).
+    outerFade: 0,
+    // Cells per second. The reference tool's `cycles` counts how many times the
+    // whole asset set passes, not how many cells move, so the rate is
+    // cycles * assets / seconds. Measured on Marquee 01 to confirm: it travels
+    // 8201px over its authored 20s clip at a dead-constant 410 reference px/s,
+    // which is 11 cells — exactly its `count` of 11, and why its loop closes.
+    // Reading `cycles` as cells put every preset at a third of its real pace.
+    //
+    // `loopCycles` then snaps the clip to a whole number of lane lengths so
+    // every texture lands back on its own slot. That is a different repeat unit
+    // than the reference's (which advances one asset set), but it is the same
+    // idea and it holds the authored rate across clip lengths.
+    speed: ((r.cycles ?? 1) * (r.assets ?? 11)) / (r.seconds ?? 20),
+  };
+}
+
+// `variant` only patches control defaults, so a preset that also ships its own
+// curve — or its own card shape — needs `meta` patched alongside.
+function preset(
+  id: string,
+  name: string,
+  ref: RefMarquee,
+  easing: EasingSpec = { id: 'linear' }
+): Template {
+  const t = variant(ticker, id, name, refMarquee(ref));
+  return { ...t, meta: { ...t.meta, defaultEasing: easing, cardAspect: 3 / 4 } };
+}
+
+const LINEAR: EasingSpec = { id: 'linear' };
+const FLOW: EasingSpec = { id: 'flow' };
+const SMOOTH: EasingSpec = { id: 'smooth' };
+const EASE: EasingSpec = { id: 'ease' };
+
 export const tickerVariants: Template[] = [
   ticker,
-  variant(ticker, 'ticker-02', 'Ticker Tilt', {
-    rows: 3, weave: 'on', tilt: -12, cardSize: 180, gap: 200, rowGap: 210, speed: 0.6, count: 24,
-  }),
+  tickerTilt,
   variant(ticker, 'ticker-03', 'Ticker Step', {
     hold: 62, speed: 1.2, cardSize: 260, gap: 290, count: 10,
   }),
+
+  // Three lanes weaving against each other — the family's home base.
+  preset('ticker-04', 'Ticker 04', { axis: 'vertical',   lanes: 3, planeSize: 160, gap: 25, lane: -15 }, LINEAR),
+  preset('ticker-05', 'Ticker 05', { axis: 'horizontal', lanes: 3, planeSize: 160, gap: 25, lane: -15, reverse: true }, LINEAR),
+
+  // Lanes locked in the same direction, faster, one lane pushed half a cell.
+  preset('ticker-06', 'Ticker 06', { axis: 'vertical',   lanes: 3, planeSize: 115, gap: 42, lane: 50, weave: false, reverse: true, seconds: 5 }, FLOW),
+  preset('ticker-07', 'Ticker 07', { axis: 'horizontal', lanes: 3, planeSize: 115, gap: 42, lane: 50, weave: false, reverse: true, seconds: 5 }, FLOW),
+
+  // Stepped: a steep curve per cell reads as stop-and-go with no pause at all.
+  preset('ticker-08', 'Ticker 08', { axis: 'vertical',   lanes: 3, planeSize: 160, gap: 40 }, FLOW),
+  preset('ticker-09', 'Ticker 09', { axis: 'horizontal', lanes: 3, planeSize: 160, gap: 40 }, FLOW),
+
+  preset('ticker-10', 'Ticker 10', { axis: 'vertical',   lanes: 3, planeSize: 115, gap: 42, weave: false, reverse: true, cycles: 2, seconds: 6 }, SMOOTH),
+  preset('ticker-11', 'Ticker 11', { axis: 'horizontal', lanes: 3, planeSize: 115, gap: 42, weave: false, cycles: 2, seconds: 6 }, SMOOTH),
+
+  // The whole plane leans.
+  preset('ticker-12', 'Ticker 12', { axis: 'vertical',   lanes: 3, planeSize: 160, gap: 25, lane: -15, angle: 20 }, LINEAR),
+  preset('ticker-13', 'Ticker 13', { axis: 'horizontal', lanes: 3, planeSize: 160, gap: 25, lane: -15, angle: -20, reverse: true }, LINEAR),
+
+  // Four tighter lanes.
+  preset('ticker-14', 'Ticker 14', { axis: 'vertical',   lanes: 4, planeSize: 100, gap: 13, lane: -15, reverse: true }, LINEAR),
+  preset('ticker-15', 'Ticker 15', { axis: 'horizontal', lanes: 4, planeSize: 100, gap: 13, lane: -15, reverse: true }, LINEAR),
+
+  // Six lanes of small cards — the densest weave in the family.
+  preset('ticker-16', 'Ticker 16', { axis: 'vertical',   lanes: 6, planeSize: 55, gap: 20, weave: false, reverse: true, cycles: 2, seconds: 5 }, SMOOTH),
+  preset('ticker-17', 'Ticker 17', { axis: 'horizontal', lanes: 4, planeSize: 100, gap: 13, lane: -15, angle: -15, reverse: true }, LINEAR),
+  preset('ticker-18', 'Ticker 18', { axis: 'horizontal', lanes: 5, planeSize: 75,  gap: 20, weave: false, reverse: true, angle: 10, cycles: 2, seconds: 7 }, EASE),
+
+  // Two wide lanes.
+  preset('ticker-19', 'Ticker 19', { axis: 'vertical',   lanes: 2, planeSize: 140, gap: 25, lane: -15 }, LINEAR),
+  preset('ticker-20', 'Ticker 20', { axis: 'horizontal', lanes: 2, planeSize: 150, gap: 25, lane: -15 }, LINEAR),
+  preset('ticker-21', 'Ticker 21', { axis: 'horizontal', lanes: 2, planeSize: 152, gap: 20, lane: 50, reverse: true, seconds: 15 }, FLOW),
+  preset('ticker-22', 'Ticker 22', { axis: 'vertical',   lanes: 2, planeSize: 145, gap: 20, lane: 50, reverse: true, seconds: 15 }, FLOW),
+
+  // Gapless, very slow — the band reads as one continuous ribbon.
+  preset('ticker-23', 'Ticker 23', { axis: 'vertical',   lanes: 3, planeSize: 112, gap: 0, lane: 35, seconds: 30 }, LINEAR),
+  preset('ticker-24', 'Ticker 24', { axis: 'vertical',   lanes: 3, planeSize: 112, gap: 5, lane: 35, weave: false, reverse: true, seconds: 30 }, LINEAR),
+
+  // A single lane of large cards — the plain vertical marquee.
+  // The reference preset behind this one carries 5 assets, not the usual 11.
+  preset('ticker-25', 'Ticker 25', { axis: 'vertical',   lanes: 1, planeSize: 180, gap: 40, weave: false, reverse: true, assets: 5, seconds: 10 }, LINEAR),
 ];

--- a/templates/tour.ts
+++ b/templates/tour.ts
@@ -10,7 +10,7 @@ const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
 const h = (k: number) => { const s = Math.sin(k * 127.1 + 1.7) * 43758.5453; return s - Math.floor(s); };
 
 const tour: Template = {
-  meta: { id: 'tour-01', name: 'Voyage 01', group: 'Voyage', defaultEasing: { id: 'smooth' } },
+  meta: { id: 'tour-01', name: 'Voyage 01', group: 'Voyage', repeatAssets: true, defaultEasing: { id: 'smooth' } },
 
   controls: [
     { key: 'count',        label: 'Count',         type: 'slider', min: 4, max: 24, step: 1,    default: 14 },

--- a/templates/variant.ts
+++ b/templates/variant.ts
@@ -15,5 +15,11 @@ export function variant(
       patch[c.key] !== undefined ? { ...c, default: patch[c.key] } : c
     ),
     transform: base.transform,
+    // `transform3d` has to come along too. `meta` is spread wholesale, so a
+    // variant of a webgl template inherits engine: 'webgl' — but without the 3D
+    // pose the renderer silently falls back to projecting the 2D transform, and
+    // the variant renders flat while its base renders in 3D. That is what was
+    // happening to Orbit 3D 02 and 03.
+    transform3d: base.transform3d,
   };
 }

--- a/templates/variant.ts
+++ b/templates/variant.ts
@@ -21,5 +21,6 @@ export function variant(
     // the variant renders flat while its base renders in 3D. That is what was
     // happening to Orbit 3D 02 and 03.
     transform3d: base.transform3d,
+    camera: base.camera,
   };
 }

--- a/templates/wheel.ts
+++ b/templates/wheel.ts
@@ -8,7 +8,7 @@ const BASE = 340;
 // Wheel — cards on a rotating ring (or a fan arc). Featured card is the one
 // nearest the top of the wheel; Spin Thumbs tilts cards along the tangent.
 const wheel: Template = {
-  meta: { id: 'wheel-01', name: 'Ferris 01', group: 'Ferris', defaultEasing: { id: 'flow' } },
+  meta: { id: 'wheel-01', name: 'Ferris 01', group: 'Ferris', repeatAssets: true, defaultEasing: { id: 'flow' } },
 
   controls: [
     { key: 'direction',    label: 'Direction',     type: 'toggle', options: ['forward','reverse'], default: 'forward' },

--- a/templates/wipe.ts
+++ b/templates/wipe.ts
@@ -1,10 +1,16 @@
 import type { Template } from '@/lib/types';
-import { loopCycles } from '@/lib/motion';
+import type { EasingSpec } from '@/lib/easing';
+import { clamp, loopCycles } from '@/lib/motion';
 import { variant } from './variant';
 
 // Wipe — full-frame images revealed by a directional push. The incoming
 // full-bleed image slides in from an edge, hard-covering the previous one;
 // the just-arrived image holds at centre until the next one pushes over it.
+//
+// The reference catalogue's Wipe family splits into two looks. Its 01/02 are
+// this full-bleed push. Its 03/04 push a CARD instead — the image fitted inside
+// the frame at 68% and parked at centre for a beat between pushes — which needs
+// two things this family did not have: a hold, and a non-full-bleed fit.
 const BASE = 340;
 
 const wipe: Template = {
@@ -13,15 +19,27 @@ const wipe: Template = {
   controls: [
     { key: 'count',        label: 'Count',         type: 'slider', min: 2, max: 8, step: 1,     default: 4 },
     { key: 'direction',    label: 'Direction',     type: 'pills',  options: ['left','right','up','down'], default: 'left' },
-    { key: 'zoom',         label: 'Zoom',          type: 'slider', min: 80, max: 160, step: 1,  default: 110 },
+    { key: 'fit',          label: 'Fit',           type: 'pills',  options: ['fill','fit'],     default: 'fill', section: 'Layout', description: 'fill covers the frame; fit pushes a card sized by Plane Size.' },
+    { key: 'zoom',         label: 'Zoom',          type: 'slider', min: 80, max: 160, step: 1,  default: 110, visibleWhen: { key: 'fit', equals: 'fill' } },
+    { key: 'planeSize',    label: 'Plane Size',    type: 'slider', min: 20, max: 120, step: 1,  default: 68, unit: '%', visibleWhen: { key: 'fit', equals: 'fit' }, description: 'Card height as a share of the frame.' },
+    { key: 'hold',         label: 'Hold',          type: 'slider', min: 0, max: 80, step: 1,    default: 0, section: 'Motion', unit: '%', description: 'Share of each image’s turn spent parked at centre before the next push.' },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,   default: 0 },
     { key: 'speed',        label: 'Speed',         type: 'slider', min: 0.2, max: 3, step: 0.1, default: 0.7 },
     { key: 'offset',       label: 'Offset',        type: 'xypad',                               default: { x: 0, y: 0 } },
   ],
 
   transform: (frame, index, count, v, ctx) => {
-    // full-bleed cover scale so the image fills the frame
-    const scale = (ctx.height / BASE) * 1.15 * (v.zoom / 100);
+    // `fill` is the original full-bleed cover scale, kept as the literal same
+    // expression so the shipped Takeover presets cannot drift. `fit` sizes the
+    // card by its height as a share of the frame, which is what Plane Size means
+    // once the image is fitted rather than cropped to the canvas.
+    // `fit` cards are 3:4 portrait, so their long edge IS the height. `fill`
+    // cards are cropped to the canvas, so covering the frame means matching the
+    // canvas's long edge — on a landscape canvas that is the width, and reading
+    // the height instead left a band down the sides (55px on 4:3, 311px on 16:9).
+    const scale = v.fit === 'fit'
+      ? (ctx.height / BASE) * (v.planeSize / 100)
+      : (Math.max(ctx.width, ctx.height) / BASE) * 1.15 * (v.zoom / 100);
 
     const phase = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count));
     // lifecycle w ∈ [0, count): 0 = this image just fully arrived at centre
@@ -31,9 +49,14 @@ const wipe: Template = {
     let oy = 0;
     let depth = -w; // most-recent (small w) drawn on top
 
+    // A hold shortens the slide window inside the same turn, so the image lands
+    // early and parks. At hold 0 `push` is 1 and `e` collapses to `arriving` —
+    // the original expression exactly, which is why the shipped presets are
+    // untouched.
+    const push = 1 - clamp(v.hold / 100, 0, 0.8);
     const arriving = count - w; // small positive → arriving soon
-    if (arriving < 1) {
-      const e = arriving; // 1 (off-screen) → 0 (centred)
+    if (arriving < push) {
+      const e = arriving / push; // 1 (off-screen) → 0 (centred)
       const horizontal = v.direction === 'left' || v.direction === 'right';
       const span = horizontal ? ctx.width : ctx.height;
       const sgn = v.direction === 'left' || v.direction === 'up' ? 1 : -1;
@@ -53,6 +76,26 @@ const wipe: Template = {
   },
 };
 
+// A preset that also ships its own curve — or its own card shape — needs `meta`
+// patched, which `variant` deliberately does not do.
+function preset(
+  id: string,
+  name: string,
+  patch: Record<string, any>,
+  easing: EasingSpec,
+  cardAspect?: number
+): Template {
+  const t = variant(wipe, id, name, patch);
+  return {
+    ...t,
+    meta: {
+      ...t.meta,
+      defaultEasing: easing,
+      ...(cardAspect === undefined ? {} : { cardAspect }),
+    },
+  };
+}
+
 export const wipeVariants: Template[] = [
   wipe, // Wipe 01 — push from the left
   variant(wipe, 'wipe-02', 'Takeover 02', {
@@ -61,4 +104,21 @@ export const wipeVariants: Template[] = [
   variant(wipe, 'wipe-03', 'Takeover 03', {
     count: 6, direction: 'right', zoom: 100, speed: 0.5,
   }),
+
+  // Reference Wipe 01/02 — full-bleed push, one image every 1.67s (0.6/s).
+  // Their `scale: 4` had no unit I could pin down, so Zoom stays at this
+  // family's own default rather than being invented from it.
+  preset('wipe-04', 'Takeover 04', { count: 5, direction: 'up', speed: 0.6 }, { id: 'flow' }),
+  preset('wipe-05', 'Takeover 05', { count: 5, direction: 'right', speed: 0.6 }, { id: 'flow' }),
+
+  // Reference Wipe 03/04 — a fitted card at 68% that parks between pushes.
+  // Its clip arithmetic pins the timing exactly: 401 frames at 30fps for
+  // count 5 with duration 1.67 and delay 1 is 5 * (1.67 + 1), so a turn is
+  // 2.67s of which 1s is the park — 37% hold, 0.375 turns/sec.
+  preset('wipe-06', 'Takeover 06', {
+    count: 5, direction: 'down', fit: 'fit', planeSize: 68, hold: 37, speed: 0.375,
+  }, { id: 'glide' }, 3 / 4),
+  preset('wipe-07', 'Takeover 07', {
+    count: 5, direction: 'left', fit: 'fit', planeSize: 68, hold: 37, speed: 0.375,
+  }, { id: 'glide' }, 3 / 4),
 ];


### PR DESCRIPTION
# Motion Studio — Effects, 3D and Mobile Update

Hey @appariciojunior! I’ve been working on a larger Motion Studio update focused on expanding the effects catalog, improving the WebGL/3D foundation, and creating a proper mobile editing experience.

> **Live preview:** [motion-jitter-clone.vercel.app](https://motion-jitter-clone.vercel.app/)
>
> The live version can be used to test the new effects, mobile interface, responsive controls, and export flow.

---

## ✨ Overview

The visible catalog has grown from **89 to 140 effects**, with new template families and significant refinements to existing effects.

The goal was not only to add more presets, but also to improve:

- Visual quality
- Motion behavior
- Image distribution
- 3D depth and perspective
- Template controls
- Preview and export consistency
- Desktop and mobile usability

---

## 🎞️ New effects and families

The update introduces several new families and spatial compositions:

| Family | Description |
| --- | --- |
| **Frames** | Structured frame-based layouts and animated compositions |
| **Grid** | Grid motion, directional movement, and modular arrangements |
| **Bloom** | Expanding and radial motion compositions |
| **Showcase** | Presentation-focused card and image animations |
| **Deck** | Layered card stacks, transitions, and depth movement |
| **Surface** | Curved walls and surface-based arrangements |
| **Helix 3D** | Cards distributed along a real three-dimensional helix |
| **Premium 3D** | Additional spatial compositions using WebGL |
| **Ticker** | New flow, perspective, direction, and wrapping variations |
| **Wipe** | Additional transition and reveal behaviors |

Recently introduced effects now display a **`NEW`** badge in the catalog.

Existing template IDs remain stable to preserve compatibility with previously saved scenes.

---

## 🧊 WebGL and 3D improvements

The WebGL foundation was expanded to produce more consistent spatial effects.

### Shared 3D foundation

- Shared utilities for **tilt**, **orientation**, **perspective**, and **3D positioning**
- Improved camera behavior and depth handling
- Better card orientation and opacity
- Improved material and renderer lifecycle management
- Deterministic transforms for consistent preview and export frames
- Improved handling of WebGL template variants
- Fixed variants that could previously fall back to flat transforms

### Refined 3D effects

The following families received important spatial and rendering improvements:

- **Box**
- **Orbit**
- **Globe**
- **Helix**
- **Carousel**
- **Coverflow**
- **Showcase**
- **Surface**

Curved surfaces and additional premium 3D compositions were also introduced.

---

## 🖼️ Image distribution improvements

Image assignment and card recycling were adjusted across multiple templates.

These changes reduce:

- Unexpected repeated images
- Empty cards
- Incorrect card recycling
- Visible image swaps during animation
- Inconsistent image distribution
- Glitches caused by missing asset slots

The templates now use more consistent rules when distributing uploaded and demo images.

---

## 🔄 Existing effect refinements

Several existing effect families were also refined:

- **Ticker**
- **Wipe**
- **Box**
- **Carousel**
- **Globe**
- **Gravity**
- **Orbit**
- **Proximity**
- **Reveal**
- **Spiral**
- **Tour**
- **Wheel**
- **Coverflow**

The refinements include better defaults, improved controls, smoother wrapping, more consistent positioning, and more useful first-load previews.

---

## 📱 Mobile editor

The editor now has dedicated **desktop** and **mobile** structures.

Instead of compressing the desktop interface into a smaller viewport, the mobile version provides a touch-first editing workflow.

### Mobile features

- Touch-first top and bottom navigation
- Mobile timeline transport
- Template browser
- Media management
- Effect adjustments
- Canvas settings
- Project management
- Undo and redo history
- Export controls
- Larger touch targets
- Responsive spacing
- Mobile sheets for opening editor sections
- Light and dark theme switching

---

## ▶️ Automatic mobile previews

When a template group is expanded on mobile, its visible template previews now start playing automatically.

### Performance behavior

- Only templates currently visible on screen animate
- Off-screen thumbnails remain paused
- Closing a group removes its animation loops
- Desktop hover previews remain unchanged
- Keyboard-focus previews remain available
- `prefers-reduced-motion` is respected

This provides animated previews without running every thumbnail continuously.

---

## 🎨 Mobile theme controls

The mobile top bar now includes the missing interface theme control.

Users can switch directly between:

- **Light theme**
- **Dark theme**

The control includes an accessible label describing the available action.

---

## 🎛️ Canvas and FPS controls

The editor now supports:

- **15 FPS**
- **25 FPS**
- **30 FPS**
- **60 FPS**

Changing the FPS preserves the current timeline time instead of moving the playhead to an unrelated position.

Compact option groups also use the available mobile width more effectively, avoiding unnecessary horizontal scrolling.

---

## 📤 Mobile export experience

The mobile export flow was redesigned as a dedicated review screen.

### Export features

- Large live canvas preview
- Play and pause controls
- Current playback time
- Total project duration
- Touch-friendly output controls
- Touch-friendly resolution controls
- Simplified export action
- Responsive landscape layout

The export preview mirrors the active renderer instead of creating another Pixi or Three.js instance.

The canvas mirroring process only runs under the mobile breakpoint, avoiding unnecessary work on desktop.

---

## ♿ Accessibility and performance

- Descriptive labels for mobile controls
- Accessible selected state for FPS controls
- Reduced-motion support for template previews
- Off-screen preview animations remain paused
- Desktop export does not run the mobile canvas-copy loop
- Responsive controls use shared design tokens
- Preview loops are removed when template groups close

---

## ✅ Validation

The update was validated with:

- **TypeScript type checking**
- **Next.js production build**
- **Static page generation**
- **18,752 motion assertions**
- **146 registered templates**
- **140 visible catalog effects**
- Mobile testing at **390 × 844**
- Automatic preview visibility checks
- Preview cleanup checks
- Light and dark theme switching
- Responsive control testing
- Mobile export verification

---

## 📸 Interface screenshots

These changes make the current README screenshots outdated because the following areas changed substantially:

- Effect catalog size
- Template groups
- Mobile editor structure
- Navigation
- Canvas controls
- Export interface
- Theme controls
- Animated template previews

The screenshots can be refreshed after the changes are merged.

---
