### PR TITLE
Fix/orbit3d far arc

### DIFF
--- a/app/(editor)/3d/page.tsx
+++ b/app/(editor)/3d/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '3D',
+  description: 'The experimental 3D effects stage.',
+};
+
+export default function ThreeDPage() {
+  return null;
+}

--- a/app/(editor)/board/page.tsx
+++ b/app/(editor)/board/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Boards',
+  description: 'Arrange cards on a board and export the React component.',
+};
+
+export default function BoardPage() {
+  return null;
+}

--- a/app/(editor)/layout.tsx
+++ b/app/(editor)/layout.tsx
@@ -1,0 +1,10 @@
+import EditorShell from '@/components/EditorShell';
+
+// Every section route — /, /library, /mockup, /projects, /3d, /web, /board —
+// lives in this group, so they all share one EditorShell instance. That is the
+// whole point of the group: Next keeps a layout mounted across sibling routes,
+// so switching sections swaps panels instead of tearing down the WebGL context
+// and rebuilding the stage.
+export default function EditorLayout({ children }: { children: React.ReactNode }) {
+  return <EditorShell>{children}</EditorShell>;
+}

--- a/app/(editor)/library/page.tsx
+++ b/app/(editor)/library/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Library',
+  description: 'Browse and tweak the motion templates, then save your own.',
+};
+
+// Renders nothing on purpose — EditorShell (the group layout) reads the URL and
+// shows the matching panels. The file exists so the section has a real route,
+// a shareable link and its own <title>.
+export default function LibraryPage() {
+  return null;
+}

--- a/app/(editor)/mockup/page.tsx
+++ b/app/(editor)/mockup/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Mockup',
+  description: 'Put your screen content on a 3D device and animate it.',
+};
+
+export default function MockupPage() {
+  return null;
+}

--- a/app/(editor)/page.tsx
+++ b/app/(editor)/page.tsx
@@ -1,0 +1,6 @@
+// `/` is an alias for the library, not a redirect: a server redirect can't run
+// in the static export used for GitHub Pages. /library is the canonical URL and
+// the rail links there; landing on `/` opens the same section.
+export default function IndexPage() {
+  return null;
+}

--- a/app/(editor)/projects/page.tsx
+++ b/app/(editor)/projects/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Projects',
+  description: 'Your saved projects.',
+};
+
+export default function ProjectsPage() {
+  return null;
+}

--- a/app/(editor)/web/page.tsx
+++ b/app/(editor)/web/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Web',
+  description: 'The experimental web-source stage.',
+};
+
+export default function WebPage() {
+  return null;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -112,10 +112,13 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
   background: var(--inverse-bg); color: var(--inverse-fg);
   display: grid; place-items: center;
 }
+/* Section items are <a> now (one route per section), so the underline and the
+   UA link colour have to go — the rest of the rule already worked for buttons. */
 .rail-item {
   position: relative;
   display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
   height: 52px; border-radius: var(--r-nav); color: var(--fg-faint);
+  text-decoration: none; cursor: pointer;
   transition: color var(--t-fast), background var(--t-fast);
   margin-bottom: 4px;
 }
@@ -1799,6 +1802,16 @@ select.field { padding-right: 26px; }
 }
 
 @keyframes editor-loading-spin { to { transform: rotate(360deg); } }
+
+/* 404 — borrows the loading screen's centring, stacked instead of inline. */
+.route-404 { flex-direction: column; gap: 8px; text-align: center; }
+.route-404-title { margin: 0; font-size: 18px; font-weight: 600; color: var(--fg); }
+.route-404-link {
+  margin-top: 6px; padding: 8px 14px; border-radius: var(--r-nav);
+  background: var(--card-inset); color: var(--fg); text-decoration: none;
+  font-size: var(--fs-ui); font-weight: 600;
+}
+.route-404-link:hover { background: var(--line); }
 
 @media (prefers-reduced-motion: reduce) {
   .editor-loading-mark { animation: none; border-right-color: currentColor; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
+import { Analytics } from '@vercel/analytics/next';
 import '../styles/tokens.css';
 import './globals.css';
 
@@ -25,7 +26,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet" />
       </head>
-      <body className={inter.variable}>{children}</body>
+      <body className={inter.variable}>
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,12 @@ import './globals.css';
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
 export const metadata: Metadata = {
-  title: 'motion-studio-open',
+  // Section routes set their own short title ('Mockup', 'Library'…) and the
+  // template gives them the product name.
+  title: {
+    default: 'motion-studio-open',
+    template: '%s · motion-studio-open',
+  },
   description: 'motion-studio-open — an open-source factory for quick videos and GIFs.',
 };
 

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+// Now that the sections have real URLs, a mistyped one has to land somewhere.
+// Sits outside the (editor) group on purpose: no stage, no stores, just a way
+// back. The static export writes it to 404.html, which is what GitHub Pages
+// serves for unknown paths.
+export default function NotFound() {
+  return (
+    <main className="editor-loading route-404">
+      <span className="eyebrow">404</span>
+      <h1 className="route-404-title">This section doesn&apos;t exist</h1>
+      <Link className="route-404-link" href="/library">Back to the library</Link>
+    </main>
+  );
+}

--- a/components/EditorShell.tsx
+++ b/components/EditorShell.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { usePathname } from 'next/navigation';
 import WelcomeDialog from '@/components/WelcomeDialog';
+import { sectionFromPathname } from '@/lib/navSections';
 import { startSceneAutosave } from '@/lib/scenePersist';
 import { useHistoryStore } from '@/store/useHistoryStore';
 import { useProjectStore } from '@/store/useProjectStore';
@@ -51,8 +53,35 @@ function EditorLoading() {
   );
 }
 
-export default function Home() {
+/**
+ * Mounted by app/(editor)/layout.tsx, so it survives every section navigation:
+ * the Pixi and Three canvases, the autosave loop and the whole store graph stay
+ * alive while the URL changes from /library to /mockup. The section pages under
+ * that layout render nothing — they only declare the route and its <title>.
+ *
+ * The URL is the source of truth for which section is open; useUIStore.nav is
+ * the read path the panels already use, mirrored from it here.
+ */
+export default function EditorShell({ children }: { children?: React.ReactNode }) {
   const mode = useViewportMode();
+  const pathname = usePathname();
+  const section = sectionFromPathname(pathname);
+  const seeded = useRef(false);
+
+  // Seed the store during the first render rather than in the effect below:
+  // an effect lands after the editor's first paint, so a deep link to /mockup
+  // would flash the library first. Safe to write mid-render only because no
+  // subscriber is mounted yet — DesktopEditor is rendered by this component.
+  if (!seeded.current) {
+    seeded.current = true;
+    if (useUIStore.getState().nav !== section) useUIStore.setState({ nav: section });
+  }
+
+  // Later changes — rail clicks, back/forward, a pasted URL. Rail clicks also
+  // set the store optimistically, so this mostly matters for history moves.
+  useEffect(() => {
+    if (useUIStore.getState().nav !== section) useUIStore.setState({ nav: section });
+  }, [section]);
 
   useEffect(() => {
     useUIStore.getState().hydratePreferences();
@@ -81,12 +110,20 @@ export default function Home() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  if (mode === 'pending') return <EditorLoading />;
+  if (mode === 'pending') {
+    return (
+      <>
+        <EditorLoading />
+        {children}
+      </>
+    );
+  }
 
   return (
     <>
       {mode === 'mobile' ? <MobileEditor /> : <DesktopEditor />}
       <WelcomeDialog />
+      {children}
     </>
   );
 }

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -1,42 +1,33 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { NAV_SECTIONS, sectionFromPathname, type NavSectionId } from '@/lib/navSections';
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
 import { AddIcon, BoardIcon, ChevronDownIcon, ExperimentalsIcon, LibraryIcon, MockupIcon, MoonIcon, ProjectsIcon, SunIcon, ThreeDIcon, WebIcon } from './EditorIcons';
 
-const NAV = [
-  { id: 'projects', label: 'Projects', icon: (
-    <ProjectsIcon />
-  ) },
-  { id: 'library', label: 'Library', icon: (
-    <LibraryIcon />
-  ) },
-  { id: 'mockup', label: 'Mockup', icon: (
-    <MockupIcon />
-  ) },
-];
+const ICONS: Record<NavSectionId, React.ReactNode> = {
+  projects: <ProjectsIcon />,
+  library: <LibraryIcon />,
+  mockup: <MockupIcon />,
+  '3d': <ThreeDIcon />,
+  web: <WebIcon />,
+  board: <BoardIcon />,
+};
 
-const EXPERIMENTAL_NAV = [
-  { id: '3d', label: '3D', icon: (
-    <ThreeDIcon />
-  ) },
-  { id: 'web', label: 'Web', icon: (
-    <WebIcon />
-  ) },
-  // Board mode — a DOM playground of arranged cards with hover interactions,
-  // and the entry point for the drop-in React component export. Its nav id is
-  // 'board' rather than the original 'new': the + button at the top of the rail
-  // now creates a project, so the two ids would collide. Kept last in the list.
-  { id: 'board', label: 'Boards', icon: (
-    <BoardIcon />
-  ) },
-];
+const NAV = NAV_SECTIONS.filter((section) => !section.experimental);
+const EXPERIMENTAL_NAV = NAV_SECTIONS.filter((section) => section.experimental);
 
 export default function IconRail() {
-  const active = useUIStore((s) => s.nav);
+  // The URL owns the active section (EditorShell mirrors it into the store for
+  // the panels). Reading the pathname here means back/forward and pasted links
+  // light up the right rail item without a second source of truth.
+  const active = sectionFromPathname(usePathname());
+  const router = useRouter();
   const theme = useUIStore((s) => s.theme);
-  const setActive = useUIStore((s) => s.setNav);
+  const setNav = useUIStore((s) => s.setNav);
   const toggleTheme = useUIStore((s) => s.toggleTheme);
   const createProject = useProjectStore((s) => s.create);
   const projectCount = useProjectStore((s) => s.projects.length);
@@ -47,7 +38,8 @@ export default function IconRail() {
   // icon at the top of the rail now creates what it looks like it creates.
   const newProject = () => {
     createProject(`Project ${projectCount + 1}`);
-    setActive('projects');
+    setNav('projects');
+    router.push('/projects');
   };
 
   return (
@@ -67,10 +59,19 @@ export default function IconRail() {
           <span className="rail-label">New</span>
         </button>
         {NAV.map((n) => (
-          <button key={n.id} className={`rail-item ${active === n.id ? 'active' : ''}`} onClick={() => setActive(n.id)}>
-            <span className="rail-ico">{n.icon}</span>
+          <Link
+            key={n.id}
+            href={n.href}
+            // Setting the store on click as well as on the URL change keeps the
+            // panel swap on the same frame as the click: the mirror in
+            // EditorShell is an effect, which lands a frame later.
+            onClick={() => setNav(n.id)}
+            aria-current={active === n.id ? 'page' : undefined}
+            className={`rail-item ${active === n.id ? 'active' : ''}`}
+          >
+            <span className="rail-ico">{ICONS[n.id]}</span>
             <span className="rail-label">{n.label}</span>
-          </button>
+          </Link>
         ))}
         <button
           className={`rail-item rail-experimentals ${experimentalActive ? 'active' : ''}`}
@@ -89,10 +90,17 @@ export default function IconRail() {
         >
           <div className="rail-experimental-inner">
             {EXPERIMENTAL_NAV.map((n) => (
-              <button key={n.id} tabIndex={experimentalsOpen ? 0 : -1} className={`rail-item rail-subitem ${active === n.id ? 'active' : ''}`} onClick={() => setActive(n.id)}>
-                <span className="rail-ico">{n.icon}</span>
+              <Link
+                key={n.id}
+                href={n.href}
+                tabIndex={experimentalsOpen ? 0 : -1}
+                onClick={() => setNav(n.id)}
+                aria-current={active === n.id ? 'page' : undefined}
+                className={`rail-item rail-subitem ${active === n.id ? 'active' : ''}`}
+              >
+                <span className="rail-ico">{ICONS[n.id]}</span>
                 <span className="rail-label">{n.label}</span>
-              </button>
+              </Link>
             ))}
           </div>
         </div>

--- a/components/WelcomeDialog.tsx
+++ b/components/WelcomeDialog.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useProjectStore } from '@/store/useProjectStore';
-import { useUIStore } from '@/store/useUIStore';
 
 const SEEN_KEY = 'motion-welcome-seen';
 
@@ -16,15 +15,18 @@ export default function WelcomeDialog() {
   }, []);
 
   // Accepting hands the user a real, named project to work in rather than an
-  // unsaved scratch scene. bootstrap() (page mount) has already created the
+  // unsaved scratch scene. bootstrap() (shell mount) has already created the
   // default project, so this only has to make sure one is open — it never
   // overwrites an existing project.
+  //
+  // It no longer forces the library section: the URL owns that now, and `/`
+  // already lands there. Yanking a first-time visitor who opened /mockup back
+  // to the library would break the link they followed.
   const enter = () => {
     try { localStorage.setItem(SEEN_KEY, '1'); } catch { /* storage blocked */ }
     const projects = useProjectStore.getState();
     projects.bootstrap();               // no-op when already booted
     if (!projects.activeId) projects.create('Default project');
-    useUIStore.getState().setNav('library');
     setOpen(false);
   };
 

--- a/lib/navSections.ts
+++ b/lib/navSections.ts
@@ -1,0 +1,45 @@
+// The editor's sections in one place: the IconRail renders its buttons from
+// this list, the route folders under app/(editor) are named after the slugs,
+// and EditorShell maps the current URL back to the nav id every panel reads
+// off useUIStore. Add a section here and it still needs its own page.tsx —
+// the route has to exist for the URL to resolve.
+export type NavSectionId = 'projects' | 'library' | 'mockup' | '3d' | 'web' | 'board';
+
+export interface NavSection {
+  id: NavSectionId;
+  label: string;
+  href: string;
+  /** Lives under the collapsible "Experiments" group in the rail. */
+  experimental?: boolean;
+}
+
+export const NAV_SECTIONS: NavSection[] = [
+  { id: 'projects', label: 'Projects', href: '/projects' },
+  { id: 'library', label: 'Library', href: '/library' },
+  { id: 'mockup', label: 'Mockup', href: '/mockup' },
+  { id: '3d', label: '3D', href: '/3d', experimental: true },
+  { id: 'web', label: 'Web', href: '/web', experimental: true },
+  // Board mode — a DOM playground of arranged cards with hover interactions,
+  // and the entry point for the drop-in React component export. Its nav id is
+  // 'board' rather than the original 'new': the + button at the top of the rail
+  // now creates a project, so the two ids would collide. Kept last in the list.
+  { id: 'board', label: 'Boards', href: '/board', experimental: true },
+];
+
+/** What `/` renders, and the fallback for any path we don't recognise. */
+export const DEFAULT_SECTION: NavSectionId = 'library';
+
+const SECTION_IDS = new Set<string>(NAV_SECTIONS.map((section) => section.id));
+
+/**
+ * `/mockup` → 'mockup'. `/` → the default section, because the index route is
+ * an alias for the library rather than a redirect: a redirect would have to run
+ * on a server, and the GitHub Pages build (STATIC_EXPORT=1) has none.
+ *
+ * usePathname() already strips basePath, so the subpath deploy needs no special
+ * casing here.
+ */
+export function sectionFromPathname(pathname: string | null | undefined): NavSectionId {
+  const segment = (pathname ?? '').split('?')[0].split('/').filter(Boolean)[0];
+  return segment && SECTION_IDS.has(segment) ? (segment as NavSectionId) : DEFAULT_SECTION;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@react-three/fiber": "^9.0.0",
         "@tailwindcss/browser": "^4.3.3",
+        "@vercel/analytics": "^2.0.1",
         "jszip": "^3.10.1",
         "mp4-muxer": "^5.2.2",
         "next": "^16.2.10",
@@ -951,6 +952,48 @@
       "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
       "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
       "license": "MIT"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.71",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@react-three/fiber": "^9.0.0",
     "@tailwindcss/browser": "^4.3.3",
+    "@vercel/analytics": "^2.0.1",
     "jszip": "^3.10.1",
     "mp4-muxer": "^5.2.2",
     "next": "^16.2.10",

--- a/templates/orbit3d.ts
+++ b/templates/orbit3d.ts
@@ -1,7 +1,7 @@
 import type { Template } from '@/lib/types';
 import { TAU, clamp, loopCycles, smooth } from '@/lib/motion';
 import {
-  backfaceFade,
+  depthDim,
   multiplyQuaternion,
   quaternionFromEuler,
   tiltNormalCanvas,
@@ -116,7 +116,12 @@ const ringStream: Template = {
       z: point.z,
       quaternion,
       scale: (metrics.cardPx / BASE) * (1 + smooth(depthN) * 0.035),
-      alpha: backfaceFade(normal.z, v.fade),
+      // depthDim, not backfaceFade: this is a RING, and lib/tilt3d says it in
+      // as many words — a ring's far arc has to stay present or the whole thing
+      // reads as a front-only fan. backfaceFade multiplies in a hard cut to
+      // zero near edge-on (added so sphere tiles never expose their DoubleSide
+      // back), and applying it here deleted every card on the far side.
+      alpha: depthDim(normal.z, v.fade),
       bend: v.cardBend / 100,
       thickness: 0,
       shadowStrength: v.shadow === 'on' ? 1 : 0,
@@ -143,7 +148,9 @@ const ringStream: Template = {
       y: p.y + v.offset.y,
       scale: (metrics.cardPx / BASE) * (0.84 + depthN * 0.19),
       rotation: 0,
-      alpha: backfaceFade(normal.z, v.fade),
+      // Same reasoning as transform3d above, and it matters more here: the 2D
+      // fallback has no depth at all, so losing the far arc leaves a bare row.
+      alpha: depthDim(normal.z, v.fade),
       depth: p.z,
     };
   },


### PR DESCRIPTION
Orbit 3D lost every card on the far side of the ring and rendered as a front-only fan. This restores it — one file, both call sites.

## What broke it

`696840e` ("Finalize 3D catalog and camera controls") split one fade helper in `lib/tilt3d.ts` into two:

| | behaviour | intended for |
|---|---|---|
| `depthDim` | dims a card that turns away, **never hides it** | a ring of cards, where none is ever genuinely reversed |
| `backfaceFade` | dims **and cuts to zero** near edge-on | a sphere tile, which would otherwise expose its `DoubleSide` back — the same texture, mirrored, which no amount of dimming makes readable |

That commit moved `showcase.ts` onto `depthDim`. **`orbit3d.ts` was not moved** and kept calling `backfaceFade`, so the new hard cut deleted the ring's whole far arc.

`lib/tilt3d.ts` names this exact failure in `depthDim`'s own docstring:

> a ring of cards lying flat ON a plane … the far arc must stay present or the ring reads as a front-only fan

So this is the migration that commit missed, not a new idea.

## How it was found

Photographed the template through `scripts/shoot.cjs` (real Chrome, deterministic frames) with the 3D pipeline — `lib/renderer3d.ts`, `lib/tilt3d.ts`, `lib/types.ts`, `templates/orbit3d.ts` — reverted to `696840e~1`, then again at `HEAD`:

- **parent:** cards visible around the back of the ring
- **HEAD:** front arc only

**Orbit Bloom** is the clearest case: it now closes the ring again, near arc large, far arc smaller and set behind it.

Two things were ruled out on the way, by measurement rather than by reading:

- **Not the camera.** `camera()`, `perspective` (18), `ringSizePct` (94) and `cardSizePct` (18) are byte-identical between `0d1807f` and `HEAD`. The only camera change in `696840e` was adding `distance: v.camDistance`, whose default of `1` multiplies to exactly the previous `z = D`.
- **Not the flat Pixi fallback.** The 960-index draw calls looked like Pixi `PerspectiveMesh` at first, but `carousel` also declares `engine: 'webgl'`, so both go through three.js — the 960 indices are `cardBend` subdividing the plane.

## Both call sites move

`transform3d` and the 2D fallback `transform`. It matters more in the fallback: that path has no depth at all, so losing the far arc leaves a bare row.

## Known follow-up, deliberately not changed here

The far cards come back **translucent rather than merely darker**, because alpha is the only channel available to them. Measured: Ring Stream and Orbit Showcase reach alpha 0.85 at `fade: 15`; **Orbit Bloom reaches 0.55 at `fade: 45`**, which is visibly see-through.

Routing the fade into the luminance channel instead would be a no-op: `renderer3d` gates `materialExposure` on `physical = thickness > 0.05 && !bent`, and a ring card is `thickness: 0` and bent, so it takes the branch that zeroes `color` and pins `emissiveIntensity` to 1 to keep the image colour-accurate.

Lowering `Back Fade` gives a solid ring, and the slider already allows it per project. Changing the preset defaults would alter the look of scenes already saved, so that call is left to the owner rather than bundled in a bug fix.

Also unchanged: the far arc shows **mirrored lettering** on cards turned past edge-on. That is inherent to `Facing: ring` with the back visible, and was the behaviour before the regression too. `Facing: camera` avoids it but flattens the cards into billboards.

Worth a look separately: `globe.ts`, `helix3d.ts`, `surface.ts` and `interactiveCards.ts` are still on `backfaceFade`. Those have genuine per-card normals, so the cut is probably correct for them — but any that also read as front-only has the same diagnosis.
