### PR TITLE
Remove Vercel Web Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import { Analytics } from '@vercel/analytics/next';
 import '../styles/tokens.css';
 import './globals.css';
 
@@ -33,7 +32,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className={inter.variable}>
         {children}
-        <Analytics />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@react-three/fiber": "^9.0.0",
         "@tailwindcss/browser": "^4.3.3",
-        "@vercel/analytics": "^2.0.1",
         "jszip": "^3.10.1",
         "mp4-muxer": "^5.2.2",
         "next": "^16.2.10",
@@ -952,48 +951,6 @@
       "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
       "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
       "license": "MIT"
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
-      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.71",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@react-three/fiber": "^9.0.0",
     "@tailwindcss/browser": "^4.3.3",
-    "@vercel/analytics": "^2.0.1",
     "jszip": "^3.10.1",
     "mp4-muxer": "^5.2.2",
     "next": "^16.2.10",


### PR DESCRIPTION
## Summary
- Removes `@vercel/analytics` (import + `<Analytics />` in `app/layout.tsx`, dependency in `package.json`/`package-lock.json`). It was pulled into `main` unintentionally via a fork PR; the app doesn't need it.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)