### PR TITLE
Add Parallax and Wipe families, rebuilt from measurement — with `dim` and `clip` on LayerTransform

### DIFF
--- a/components/TemplateThumb.tsx
+++ b/components/TemplateThumb.tsx
@@ -17,7 +17,7 @@ const SPRITE_BASE = 340;
 
 interface CardPose {
   x: number; y: number; w: number; h: number;
-  rotation: number; skewX: number; alpha: number; z: number; r: number;
+  rotation: number; skewX: number; alpha: number; dim: number; z: number; r: number;
 }
 
 export default function TemplateThumb({
@@ -154,6 +154,7 @@ export default function TemplateThumb({
         rotation: t.rotation,
         skewX: t.skewX ?? 0,
         alpha: t.alpha,
+        dim: Math.max(0, Math.min(1, t.dim ?? 0)),
         z: Math.round(t.depth * 1000 + i),
         r: (Math.min(w, h) / 2) * Math.max(0, Math.min(1, (v.cornerRadius ?? 0) / 100)),
       });
@@ -161,15 +162,19 @@ export default function TemplateThumb({
 
     // Draw budget. A thumbnail is a few hundred px across and the catalogue runs
     // to 140 cards, so keep the DOM bounded — but drop whole cards rather than
-    // move them. Off-canvas ones go first, then the furthest from centre, so what
-    // survives is what a viewer would actually have seen.
+    // move them. Invisible ones go first (a scattered flicker field like
+    // Parallax has most of its cards at alpha 0 at any instant, and picking
+    // purely by distance from centre could fill the whole budget with
+    // currently-invisible cards while every actually-visible one gets cut for
+    // sitting farther out), then off-canvas ones, then the furthest from
+    // centre — so what survives is what a viewer would actually have seen.
     if (out.length <= DRAW_BUDGET) return out;
     const halfW = CTX_BASE.width / 2, halfH = CTX_BASE.height / 2;
     const offCanvas = (p: CardPose) =>
       Math.abs(p.x) - p.w / 2 > halfW || Math.abs(p.y) - p.h / 2 > halfH;
     return out
-      .map((p, i) => ({ p, i, off: offCanvas(p) ? 1 : 0, d: Math.hypot(p.x, p.y) }))
-      .sort((a, b) => a.off - b.off || a.d - b.d)
+      .map((p, i) => ({ p, i, invisible: p.alpha < 0.02 ? 1 : 0, off: offCanvas(p) ? 1 : 0, d: Math.hypot(p.x, p.y) }))
+      .sort((a, b) => a.invisible - b.invisible || a.off - b.off || a.d - b.d)
       .slice(0, DRAW_BUDGET)
       .sort((a, b) => a.i - b.i)
       .map((e) => e.p);
@@ -189,6 +194,9 @@ export default function TemplateThumb({
             top: `${50 + (p.y / CTX_BASE.height) * 100}%`,
             transform: `translate(-50%, -50%) rotate(${p.rotation}rad) skewX(${p.skewX}rad)`,
             opacity: p.alpha,
+            // Mirrors the renderer: a receding card darkens, it does not
+            // go see-through.
+            filter: p.dim > 0 ? `brightness(${(1 - p.dim).toFixed(3)})` : undefined,
             zIndex: p.z,
             borderRadius: `${Math.max(1, (p.r / p.w) * 100)}%`,
           }}

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -26,6 +26,10 @@ interface Slot {
   texH: number;
   cornerR: number; // last-applied corner radius fraction, for mask caching
   bindKey: string; // guards async image/video loads from overwriting a newer slot
+  // The slot's undimmed tint (white for a real image, grey for a placeholder).
+  // Kept because the per-frame loop multiplies it by the pose's `dim`, and
+  // would otherwise erase the placeholder's own tint.
+  baseTint: number;
 }
 
 // The GPU-side realization of one motion track. Each track owns its own sprite
@@ -36,6 +40,14 @@ interface TrackRT {
   slots: Slot[];
   assetSig: string;
   countSig: number;
+}
+
+// Multiply every channel of a packed 0xRRGGBB tint, for `dim`.
+function scaleTint(tint: number, k: number): number {
+  const r = Math.round(((tint >> 16) & 0xff) * k);
+  const g = Math.round(((tint >> 8) & 0xff) * k);
+  const b = Math.round((tint & 0xff) * k);
+  return (r << 16) | (g << 8) | b;
 }
 
 // A single white rounded texture, tinted per placeholder card.
@@ -238,7 +250,7 @@ export class SceneRenderer {
       label.anchor.set(0.5);
       sprite.addChild(label);
       rt.container.addChild(sprite);
-      rt.slots.push({ sprite, mask, label, texW: 480, texH: 600, cornerR: -1, bindKey: '' });
+      rt.slots.push({ sprite, mask, label, texW: 480, texH: 600, cornerR: -1, bindKey: '', baseTint: 0xffffff });
     }
     while (rt.slots.length > count) {
       const slot = rt.slots.pop()!;
@@ -257,6 +269,7 @@ export class SceneRenderer {
       slot.bindKey = binding;
       if (!asset || !asset.visible) {
         slot.sprite.texture = this.placeholder;
+        slot.baseTint = PLACEHOLDER_FILL;
         slot.sprite.tint = PLACEHOLDER_FILL;
         slot.label.text = String(i + 1);
         slot.label.visible = true;
@@ -266,10 +279,12 @@ export class SceneRenderer {
           // Never leave the previous template's image visible while a new crop
           // is decoding. Local/demo files replace this again in the same tick.
           slot.sprite.texture = this.placeholder;
+          slot.baseTint = PLACEHOLDER_FILL;
           slot.sprite.tint = PLACEHOLDER_FILL;
           slot.label.text = String(i + 1);
           slot.label.visible = true;
         }
+        slot.baseTint = 0xffffff;
         slot.sprite.tint = 0xffffff;
         const { url, crop, kind } = asset;
         this.loadTexture(url, kind).then((base) => {
@@ -485,6 +500,10 @@ export class SceneRenderer {
         slot.sprite.scale.set(norm * t.scale * (t.scaleX ?? 1), norm * t.scale * (t.scaleY ?? 1));
         slot.sprite.rotation = t.rotation;
         slot.sprite.alpha = t.alpha;
+        // `dim` darkens toward black rather than going see-through, so a
+        // receding card occludes what is behind it instead of ghosting it.
+        const dim = clamp(t.dim ?? 0, 0, 1);
+        slot.sprite.tint = dim > 0 ? scaleTint(slot.baseTint, 1 - dim) : slot.baseTint;
         slot.sprite.skew.set(t.skewX ?? 0, t.skewY ?? 0);
         slot.sprite.zIndex = t.depth * 1000 + i; // stable tiebreak
         this.applyMask(slot, track.values.cornerRadius ?? 0);

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -47,8 +47,18 @@ function makeBentPlaneGeometry(sag: number): THREE.PlaneGeometry {
   const ac = new THREE.Vector2().subVectors(a, c);
   const radius = (ab.length() * bc.length() * ac.length()) / (2 * Math.abs(ab.cross(ac)));
   const centre = new THREE.Vector2(0, bend - Math.sign(bend) * radius);
-  const baseAngle = new THREE.Vector2().subVectors(a, centre).angle() - Math.PI / 2;
-  const arc = baseAngle * 2;
+  // The arc from c to a around the centre, taken the SHORT way. This used to be
+  // `(a - centre).angle() * 2 - PI`, which relies on the centre sitting BELOW
+  // the chord and so only held for a positive bend. Vector2.angle() returns
+  // [0, 2*PI), so a negative bend — centre above the chord — picked the reflex
+  // angle and swept the card nearly all the way round its own circle: at
+  // bend -0.04 the centre vertex landed 6.25 units out instead of 0.04, about
+  // 150x too far. Measuring the signed difference works for either side.
+  const angleA = new THREE.Vector2().subVectors(a, centre).angle();
+  const angleC = new THREE.Vector2().subVectors(c, centre).angle();
+  let arc = angleA - angleC;
+  if (arc > Math.PI) arc -= Math.PI * 2;
+  if (arc < -Math.PI) arc += Math.PI * 2;
   const uv = geometry.attributes.uv;
   const position = geometry.attributes.position;
   const point = new THREE.Vector2();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,6 +38,12 @@ export interface LayerTransform {
   skewY?: number;
   scaleX?: number;   // optional non-uniform squash (default 1) — flips/page turns
   scaleY?: number;   // optional non-uniform squash (default 1) — split-flap
+  // Darken the card toward black, 0 = untouched .. 1 = fully black. This is
+  // how a card RECEDES: dropping its alpha instead makes it see-through, so
+  // whatever it overlaps ghosts through it and the field reads as broken
+  // glass rather than as depth. Reach for `alpha` when a card is genuinely
+  // appearing or leaving, and `dim` when it is merely far away.
+  dim?: number;
   depth: number;     // sort order; higher = drawn on top / nearer
 }
 

--- a/lib/webKeyframes.ts
+++ b/lib/webKeyframes.ts
@@ -72,9 +72,13 @@ export function bakeCss(o: BakeOpts): string {
       const pct = (s / samples) * 100;
       const frame = (s / samples) * totalFrames;
       const t = poseFor(o.template, o.mode, frame, i, count, { ...o.values, count }, ctx);
+      const dim = Math.max(0, Math.min(1, t.dim ?? 0));
       const decls = [
         `transform: ${transformCss(t, o.mode)}`,
         `opacity: ${num(t.alpha)}`,
+        // A receding card darkens instead of going see-through — same rule as
+        // the sprite renderer, so exported CSS matches the stage.
+        `filter: brightness(${num(1 - dim)})`,
         `z-index: ${Math.round(t.depth * 1000 + i)}`,
       ];
       steps.push(`  ${num(pct)}% { ${decls.join('; ')}; }`);

--- a/lib/webPose.ts
+++ b/lib/webPose.ts
@@ -53,6 +53,7 @@ export function poseFor(
     skewX: (t.skewX ?? 0) - (rest.skewX ?? 0),
     skewY: (t.skewY ?? 0) - (rest.skewY ?? 0),
     alpha: t.alpha,
+    dim: t.dim,
     depth: t.depth,
   };
 }
@@ -77,6 +78,11 @@ export function transformCss(t: LayerTransform, mode: LayoutMode): string {
 export function applyPose(el: HTMLElement, t: LayerTransform, mode: LayoutMode, i: number) {
   el.style.transform = transformCss(t, mode);
   el.style.opacity = String(t.alpha);
+  // A receding card darkens rather than going see-through — same rule as the
+  // sprite renderer, so an exported board matches the stage.
+  const dim = Math.max(0, Math.min(1, t.dim ?? 0));
+  if (dim > 0) el.style.filter = `brightness(${(1 - dim).toFixed(3)})`;
+  else el.style.removeProperty('filter');
   el.style.zIndex = String(Math.round(t.depth * 1000 + i)); // stable tiebreak
   if (mode === 'own') {
     el.style.position = 'absolute';
@@ -88,7 +94,7 @@ export function applyPose(el: HTMLElement, t: LayerTransform, mode: LayoutMode, 
 
 /** Undo everything applyPose set, so switching modes doesn't leave residue. */
 export function clearPose(el: HTMLElement) {
-  for (const p of ['transform', 'opacity', 'z-index', 'position', 'left', 'top', 'margin', 'transform-origin']) {
+  for (const p of ['transform', 'opacity', 'filter', 'z-index', 'position', 'left', 'top', 'margin', 'transform-origin']) {
     el.style.removeProperty(p);
   }
 }

--- a/scripts/verify-contexts.cjs
+++ b/scripts/verify-contexts.cjs
@@ -109,9 +109,14 @@ function thumbnailPoses(template, frame) {
 
   const halfW = CTX_W / 2, halfH = CTX_H / 2;
   const offCanvas = (p) => Math.abs(p.x) - p.w / 2 > halfW || Math.abs(p.y) - p.h / 2 > halfH;
+  // Invisible cards go first (see TemplateThumb.tsx): a scattered flicker
+  // field like Parallax has most cards at alpha 0 at any instant, and a pure
+  // distance-from-centre sort could fill the whole budget with currently-
+  // invisible ones while every actually-visible card gets cut for sitting
+  // farther out.
   const drawn = all
-    .map((p) => ({ p, off: offCanvas(p) ? 1 : 0, d: Math.hypot(p.x, p.y) }))
-    .sort((a, b) => a.off - b.off || a.d - b.d)
+    .map((p) => ({ p, invisible: p.alpha < 0.02 ? 1 : 0, off: offCanvas(p) ? 1 : 0, d: Math.hypot(p.x, p.y) }))
+    .sort((a, b) => a.invisible - b.invisible || a.off - b.off || a.d - b.d)
     .slice(0, DRAW_BUDGET)
     .sort((a, b) => a.p.i - b.p.i)
     .map((e) => e.p);

--- a/scripts/verify-reference.cjs
+++ b/scripts/verify-reference.cjs
@@ -191,9 +191,13 @@ for (const [name, { ages, widths }] of Object.entries(BLOOM)) {
 //  not assert an exact value for it.
 // ============================================================
 const PARALLAX = {
-  'Parallax 01': { count: 133, spread: 300, depth: 60, fade: 0 },
-  'Parallax 02': { count: 200, spread: 300, depth: 100, fade: 78 },
-  'Parallax 03': { count: 140, spread: 180, depth: 60, fade: 80 },
+  // sdx/sdy are the reference's own lit-pixel standard deviations on its
+  // 1080x1440 stage, read off its canvas with golden-ratio time sampling
+  // (plain k/8 sampling can alias onto a single phase and read a healthy
+  // field as collapsed — it did, on our side, during this port).
+  'Parallax 01': { count: 133, depth: 60, fade: 0, sdx: 312, sdy: 351, coverMin: 12, coverMax: 32 },
+  'Parallax 02': { count: 200, depth: 100, fade: 78, sdx: 281, sdy: 440, coverMin: 15, coverMax: 35 },
+  'Parallax 03': { count: 140, depth: 60, fade: 80, sdx: 293, sdy: 408, coverMin: 19, coverMax: 30 },
 };
 for (const [name, ref] of Object.entries(PARALLAX)) {
   const t = byName(name);
@@ -202,55 +206,176 @@ for (const [name, ref] of Object.entries(PARALLAX)) {
   near(v.minSize, REF_SCALE * 238, 1, name, 'min size');
   near(v.maxSize, REF_SCALE * 442, 1, name, 'max size');
   near(v.count, ref.count, 0, name, 'count');
-  near(v.spread, REF_SCALE * ref.spread, 1, name, 'spread');
   near(v.depth, ref.depth, 0, name, 'depth');
   near(v.fade, ref.fade, 0, name, 'fade');
+  // All three reference presets measure as a scatter over the WHOLE frame,
+  // whatever their own `spread` says (180 and 300 both fill it) — so ours
+  // carry 100%. This is the assertion the visible fix rests on: an earlier
+  // pass read `spread` as a px radius and clumped every card into the middle.
+  near(v.spread, 100, 0, name, 'spread (% of frame)');
 
   const ctx = makeCtx(t.meta.id, { width: 810, height: 1080, duration: 8, cardAspect: 3 / 4 });
   check(loopDrift(t, v, ctx) < 1e-6, name, 'does not return to frame 0 at the loop point');
 
-  // Every card holds a FIXED position and size — position/size must not
-  // depend on frame at all, only on index/seed. Sample two frames far apart
-  // in time and confirm neither moved nor resized, which is the property the
-  // rasterized-canvas comparison actually measured on the reference.
+  // Every card holds a FIXED position and size RELATIVE TO THE OTHERS — that
+  // is the property the rasterized-canvas comparison actually measured on
+  // the reference (a 0.5s-apart pair of frames, playhead paused, showed every
+  // visible card in the same spot). A later pass added a shared camera path
+  // on top (the user caught it watching the real export, and it turned out
+  // to be a genuine "Camera path" feature — see the header), which moves
+  // every card's ABSOLUTE position together — so this checks the ratio
+  // between two cards' scales and their separation scaled by that ratio,
+  // both of which the shared camera cancels out of, rather than raw x/y/scale.
   const n = layerCountFor(t.meta.id, v, ctx);
   const f1 = Math.round(ctx.totalFrames * 0.2), f2 = Math.round(ctx.totalFrames * 0.7);
+  // Any single card's own scale ratio between the two frames IS the shared
+  // camera's zoom ratio over that span (each card's fixed sizeFactor cancels
+  // out of scale(f1)/scale(f2)) — so every other card's own scale ratio, and
+  // its separation from this one, has to track that SAME number.
+  const i2 = Math.min(n - 1, 1);
+  const ref1 = t.transform(f1, i2, n, v, ctx), ref2 = t.transform(f2, i2, n, v, ctx);
+  const camRatio = ref1.scale / ref2.scale;
   let moved = 0;
   for (let i = 0; i < n; i++) {
-    const a = t.transform(f1, i, n, v, ctx);
-    const b = t.transform(f2, i, n, v, ctx);
-    if (Math.hypot(a.x - b.x, a.y - b.y) > 1e-6 || Math.abs(a.scale - b.scale) > 1e-6) moved++;
+    if (i === i2) continue;
+    const a = t.transform(f1, i, n, v, ctx), b = t.transform(f2, i, n, v, ctx);
+    const sepA = Math.hypot(a.x - ref1.x, a.y - ref1.y);
+    const sepB = Math.hypot(b.x - ref2.x, b.y - ref2.y);
+    const scaleOk = Math.abs(a.scale / b.scale - camRatio) < 1e-4;
+    const sepOk = sepB < 1e-6 || Math.abs(sepA / sepB - camRatio) < 1e-3;
+    if (!scaleOk || !sepOk) moved++;
   }
-  check(moved === 0, name, `${moved} of ${n} cards changed position or size across the clip — should be fixed per card`);
+  check(moved === 0, name,
+    `${moved} of ${n} cards moved relative to the others (beyond the shared camera) across the clip`);
 
-  // Every card must actually reach full visibility at some point (its
-  // crossfade peaks at 1), and — the fade cue — the peak alpha a far card
-  // ever reaches has to be measurably lower than a near card's, whenever
-  // Fade is on.
+  // Nothing fades over time. Measured: consecutive frames align at correlation
+  // 0.95-0.99 under a single translation, so a card's opacity is a property of
+  // its depth alone. Fade dims the far ones, once and for good.
   let nearest = { d: -1 }, farthest = { d: 2 };
   for (let i = 0; i < n; i++) {
     const p0 = t.transform(0, i, n, v, ctx);
     if (p0.depth > nearest.d) nearest = { i, d: p0.depth };
     if (p0.depth < farthest.d) farthest = { i, d: p0.depth };
   }
-  const peakAlpha = (i) => {
-    let best = 0;
-    for (let f = 0; f <= ctx.totalFrames; f += 2) best = Math.max(best, t.transform(f, i, n, v, ctx).alpha);
-    return best;
-  };
-  // Every card's crossfade has to reach lifecycle=1 (fully in its hold) at
-  // its peak — Fade then dims that peak toward the background by up to
-  // Fade% scaled by how far the card sits (1-depth). Check against each
-  // card's OWN expected ceiling, not a flat threshold: at 140 seeded cards
-  // and Fade 80, the single best-placed card can land at depth 0.79 rather
-  // than 1.0, and 80% of that remaining 21% is a real, correct dim — not a
-  // bug a flat ">0.98" would have wrongly flagged.
-  const expectedPeak = (d) => 1 - (v.fade / 100) * (1 - d);
-  near(peakAlpha(nearest.i), expectedPeak(nearest.d), 0.03, name, 'nearest card peak alpha vs. its own Fade ceiling');
-  near(peakAlpha(farthest.i), expectedPeak(farthest.d), 0.03, name, 'farthest card peak alpha vs. its own Fade ceiling');
+  // Fade must DARKEN, never make a card see-through: an alpha-based recede
+  // let whatever a far card overlapped ghost straight through it. So alpha
+  // stays pinned at 1 and the recede rides `dim`.
+  const expectedDim = (d) => (v.fade / 100) * (1 - d);
+  let varies = 0;
+  for (const i of [nearest.i, farthest.i]) {
+    const p0 = t.transform(0, i, n, v, ctx);
+    for (let f = 0; f <= ctx.totalFrames; f += 5) {
+      const p = t.transform(f, i, n, v, ctx);
+      if (Math.abs(p.alpha - p0.alpha) > 1e-6 || Math.abs((p.dim ?? 0) - (p0.dim ?? 0)) > 1e-6) { varies++; break; }
+    }
+  }
+  check(varies === 0, name, 'a card changes brightness over the clip — this family does not flicker');
+  for (let i = 0; i < n; i++) {
+    if (t.transform(0, i, n, v, ctx).alpha !== 1) {
+      check(false, name, 'a card is semi-transparent — Fade must darken, not make cards see-through');
+      break;
+    }
+  }
+  near(t.transform(0, nearest.i, n, v, ctx).dim ?? 0, expectedDim(nearest.d), 0.02, name, 'nearest card dim vs. its Fade depth');
+  near(t.transform(0, farthest.i, n, v, ctx).dim ?? 0, expectedDim(farthest.d), 0.02, name, 'farthest card dim vs. its Fade depth');
   if (ref.fade > 0) {
-    check(peakAlpha(farthest.i) < peakAlpha(nearest.i) - 0.05, name,
-      'a far card peaks as bright as a near one — Fade is not dimming by depth');
+    check(expectedDim(farthest.d) > expectedDim(nearest.d) + 0.05, name,
+      'a far card is as bright as a near one — Fade is not dimming by depth');
+  }
+
+  // THE MOTION SIGNATURE: the camera HOLDS at each pin and lurches between
+  // them. Measured on the reference by cross-correlating consecutive frames —
+  // the field's velocity hits zero at 0.4/2.5/4.3/7.3/9.7/11.9/14.0s on its
+  // 14s clip, which is its six pin times to within a sample. A continuous
+  // drift (or a flicker duty cycle) cannot produce that, and two earlier
+  // passes of this port shipped exactly those wrong models.
+  if (v.camPath && v.camPath !== 'orbit') {
+    const speedAt = (u) => {
+      const f = u * ctx.totalFrames;
+      const a = t.transform(f, 0, n, v, ctx), b = t.transform(f + 1, 0, n, v, ctx);
+      return Math.hypot(b.x - a.x, b.y - a.y);
+    };
+    let fastest = 0;
+    for (let k = 0; k <= 600; k++) fastest = Math.max(fastest, speedAt(k / 600));
+    // At each interior pin the field must be practically stopped, while the
+    // clip as a whole is clearly moving.
+    check(fastest > 1, name, 'the camera never moves');
+    for (let p = 1; p <= 5; p++) {
+      const atPin = speedAt(p / 6);
+      check(atPin < fastest * 0.12, name,
+        `the camera does not rest at pin ${p}/6 (${atPin.toFixed(1)} vs peak ${fastest.toFixed(1)} px/frame)`);
+    }
+    // ...and the travel must be CONCENTRATED into bursts, not spread evenly.
+    // Peak-over-mean speed is the shape-independent way to say that: uniform
+    // motion gives 1, a held-and-lurching camera gives well above it. Testing a
+    // segment's MIDPOINT instead would have been wrong — Parallax 03's authored
+    // bezier [0.33, 0, 0, 1] is an ease-out, so its burst is at the segment's
+    // start, and only 01/02's [0.76, 0, 0.24, 1] peaks in the middle.
+    let sum = 0;
+    for (let k = 0; k < 600; k++) sum += speedAt(k / 600);
+    const mean = sum / 600;
+    check(fastest > mean * 2, name,
+      `the camera crawls uniformly instead of holding and lurching (peak ${fastest.toFixed(1)} vs mean ${mean.toFixed(1)} px/frame)`);
+  }
+
+  // THE SPATIAL SIGNATURE. Rasterize our own field the way the reference's
+  // canvas was read — lit cards only — and compare the spread and how much of
+  // the frame is covered. A uniform scatter over the whole frame gives
+  // sd/canvas = 1/sqrt(12) = 0.289 on both axes, which is what the reference
+  // measures (0.244-0.306). The bug this guards against read `spread` as a px
+  // radius and clumped everything into the middle: the same rasterization gave
+  // 0.11-0.16, with a lit bbox that never reached an edge.
+  //
+  // Measured on OUR canvas and compared as a FRACTION of it, deliberately:
+  // our card sizes are scaled for a 1080 long edge, so rasterizing them on the
+  // reference's 1440-tall stage understates them and biases every coverage
+  // number — a trap this check itself fell into on the first pass.
+  {
+    const RW = 810, RH = 1080, STEP = 6;
+    const rctx = makeCtx(t.meta.id, { width: RW, height: RH, duration: 14, cardAspect: 3 / 4 });
+    const rn = layerCountFor(t.meta.id, v, rctx);
+    const cols = Math.ceil(RW / STEP), rows = Math.ceil(RH / STEP);
+    const sdxs = [], sdys = [], covers = [];
+    let touchesEveryEdge = false;
+    for (let k = 0; k < 12; k++) {
+      const u = (k * 0.6180339887) % 1;             // non-aliasing sampling
+      const frame = Math.round(u * rctx.totalFrames);
+      const lit = new Uint8Array(cols * rows);
+      for (let i = 0; i < rn; i++) {
+        const p = t.transform(frame, i, rn, v, rctx);
+        if (p.alpha <= 0.05) continue;
+        const long = SPRITE_BASE * p.scale;
+        const cw = long * (3 / 4), ch = long;
+        const x0 = RW / 2 + p.x - cw / 2, y0 = RH / 2 + p.y - ch / 2;
+        const gx0 = Math.max(0, Math.ceil(x0 / STEP)), gx1 = Math.min(cols - 1, Math.floor((x0 + cw) / STEP));
+        const gy0 = Math.max(0, Math.ceil(y0 / STEP)), gy1 = Math.min(rows - 1, Math.floor((y0 + ch) / STEP));
+        for (let gy = gy0; gy <= gy1; gy++) for (let gx = gx0; gx <= gx1; gx++) lit[gy * cols + gx] = 1;
+      }
+      let cnt = 0, sx = 0, sy = 0, sxx = 0, syy = 0;
+      let minX = 1e9, maxX = -1e9, minY = 1e9, maxY = -1e9;
+      for (let gy = 0; gy < rows; gy++) for (let gx = 0; gx < cols; gx++) {
+        if (!lit[gy * cols + gx]) continue;
+        const x = gx * STEP, y = gy * STEP;
+        cnt++; sx += x; sy += y; sxx += x * x; syy += y * y;
+        if (x < minX) minX = x; if (x > maxX) maxX = x;
+        if (y < minY) minY = y; if (y > maxY) maxY = y;
+      }
+      if (!cnt) continue;
+      const mx = sx / cnt, my = sy / cnt;
+      sdxs.push(Math.sqrt(Math.max(0, sxx / cnt - mx * mx)) / RW);
+      sdys.push(Math.sqrt(Math.max(0, syy / cnt - my * my)) / RH);
+      covers.push(100 * cnt / (cols * rows));
+      if (minX <= STEP * 2 && minY <= STEP * 2 && maxX >= RW - STEP * 3 && maxY >= RH - STEP * 3) touchesEveryEdge = true;
+    }
+    const median = (a) => { const s = [...a].sort((p, q) => p - q); return s[Math.floor(s.length / 2)]; };
+    check(touchesEveryEdge, name, 'the lit field never reaches all four frame edges — the scatter is not filling the frame');
+    near(median(sdxs), ref.sdx / 1080, 0.06, name, 'lit-field spread across (fraction of canvas)');
+    near(median(sdys), ref.sdy / 1440, 0.06, name, 'lit-field spread down (fraction of canvas)');
+    // Density: the reference's three presets all sit near a quarter of the
+    // frame lit despite counting 133/200/140 cards, so the wall grows with the
+    // count rather than staying a fixed size. Sizing it independently made the
+    // densest preset cover 63% where the reference covers 35%.
+    near(median(covers), (ref.coverMin + ref.coverMax) / 2, 10, name, 'share of the frame covered');
   }
 }
 

--- a/scripts/verify-tilt.cjs
+++ b/scripts/verify-tilt.cjs
@@ -154,4 +154,66 @@ for (const template of templateList.filter((item) => relevantGroups.has(item.met
   }
 }
 
+// ---------- Card Bend must curve BOTH ways ----------
+// The bent-plane geometry accepts a signed sag, but its arc used to be derived
+// from (a - centre).angle() * 2, which only holds while the arc centre sits
+// BELOW the chord — i.e. for a positive bend. Vector2.angle() returns
+// [0, 2*PI), so a negative bend picked the REFLEX angle and swept the card
+// nearly all the way round its own circle: at bend -0.04 the centre vertex
+// landed 6.25 units out instead of 0.04, about 150x too far. Nothing caught it
+// because no control could reach a negative bend until Orbit 3D's Card Bend
+// was centred on zero.
+{
+  const THREE = require('three');
+  const bentGeometry = (sag) => {
+    // Mirrors lib/renderer3d makeBentPlaneGeometry.
+    const bend = Math.max(-0.45, Math.min(0.45, sag));
+    const g = new THREE.PlaneGeometry(1, 1, 20, 8);
+    if (Math.abs(bend) < 0.0001) return g;
+    const a = new THREE.Vector2(-0.5, 0), b = new THREE.Vector2(0, bend), c = new THREE.Vector2(0.5, 0);
+    const ab = new THREE.Vector2().subVectors(a, b);
+    const bc = new THREE.Vector2().subVectors(b, c);
+    const ac = new THREE.Vector2().subVectors(a, c);
+    const radius = (ab.length() * bc.length() * ac.length()) / (2 * Math.abs(ab.cross(ac)));
+    const centre = new THREE.Vector2(0, bend - Math.sign(bend) * radius);
+    const angleA = new THREE.Vector2().subVectors(a, centre).angle();
+    const angleC = new THREE.Vector2().subVectors(c, centre).angle();
+    let arc = angleA - angleC;
+    if (arc > Math.PI) arc -= Math.PI * 2;
+    if (arc < -Math.PI) arc += Math.PI * 2;
+    const uv = g.attributes.uv, position = g.attributes.position;
+    const pt = new THREE.Vector2();
+    for (let i = 0; i < uv.count; i++) {
+      const ratio = 1 - uv.getX(i);
+      const y = position.getY(i);
+      pt.copy(c).rotateAround(centre, arc * ratio);
+      position.setXYZ(i, pt.x, y, -pt.y);
+    }
+    return g;
+  };
+  const centreZ = (sag) => {
+    const p = bentGeometry(sag).attributes.position;
+    let cz = null, maxAbsX = 0;
+    for (let i = 0; i < p.count; i++) {
+      const x = p.getX(i);
+      maxAbsX = Math.max(maxAbsX, Math.abs(x));
+      if (Math.abs(x) < 1e-6 && cz === null) cz = p.getZ(i);
+    }
+    return { cz, maxAbsX };
+  };
+  for (const sag of [0.04, 0.12, 0.3]) {
+    const pos = centreZ(sag), neg = centreZ(-sag);
+    // The centre displaces by exactly the sag, opposite ways, and the card
+    // never widens — a runaway arc shows up as either.
+    assert(Math.abs(pos.cz + sag) < 1e-6,
+      `Card Bend +${sag} put the centre vertex at ${pos.cz}, expected ${-sag}`);
+    assert(Math.abs(neg.cz - sag) < 1e-6,
+      `Card Bend -${sag} put the centre vertex at ${neg.cz}, expected ${sag}`);
+    assert(Math.abs(pos.maxAbsX - 0.5) < 1e-6,
+      `Card Bend +${sag} widened the card to ${pos.maxAbsX * 2}`);
+    assert(Math.abs(neg.maxAbsX - 0.5) < 1e-6,
+      `Card Bend -${sag} widened the card to ${neg.maxAbsX * 2}`);
+  }
+}
+
 console.log(`Tilt verification passed (${assertions} assertions across ${templateList.length} templates).`);

--- a/templates/orbit3d.ts
+++ b/templates/orbit3d.ts
@@ -61,7 +61,7 @@ function ringPhase(frame: number, v: Record<string, any>, count: number, ctx: { 
 
 const ringStream: Template = {
   meta: {
-    id: 'orbit-3d-01', name: 'Ring Stream', group: 'Orbit',
+    id: 'orbit-3d-01', name: 'Ring Stream', group: 'Orbit', isNew: true,
     // Linear on purpose — see ringPhase above. The curve picker still works for
     // anyone who wants the stepped feel back.
     defaultEasing: { id: 'linear' }, engine: 'webgl', catalog3d: true, repeatAssets: true,
@@ -75,7 +75,12 @@ const ringStream: Template = {
     { key: 'opening', label: 'Ring Opening', type: 'slider', min: 15, max: 85, step: 1, default: 70, section: 'Layout', unit: '%', description: 'Controls the inner diameter while keeping the ring complete.' },
     { key: 'cardSizePct', label: 'Card Size', type: 'slider', min: 8, max: 36, step: 1, default: 18, section: 'Layout', unit: '%' },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 20, step: 0.5, default: 3, section: 'Finish', unit: '%', precision: 1 },
-    { key: 'cardBend', label: 'Card Bend', type: 'slider', min: 0, max: 12, step: 0.5, default: 4, section: 'Depth', unit: '%', precision: 1, description: 'Curves each image surface gently around the ring.' },
+    // Signed, so the slider sits at centre and reads as one axis: negative
+    // cups each image inward toward the ring's centre, positive bows it
+    // outward, 0 is flat. The 3D renderer already flips the arc's centre by
+    // the sign (lib/renderer3d makeBentPlaneGeometry) and clamps to +/-0.45,
+    // so only this range was holding the outward half back.
+    { key: 'cardBend', label: 'Card Bend', type: 'slider', min: -12, max: 12, step: 0.5, default: 4, section: 'Depth', unit: '%', precision: 1, description: 'Curves each image surface around the ring — negative cups inward, positive bows outward.' },
     { key: 'tiltX', label: 'Ring Tilt', type: 'slider', min: -60, max: 60, step: 1, default: -8, section: 'Depth', unit: '°', description: 'Rotates the complete physical ring without changing its radius.' },
     { key: 'perspective', label: 'Perspective', type: 'slider', min: 0, max: 40, step: 1, default: 18, section: 'Depth', unit: '%' },
     { key: 'camDistance', label: 'Camera Distance', type: 'slider', min: 0.5, max: 2.5, step: 0.05, default: 1, section: 'Depth', unit: '×', precision: 2,

--- a/templates/parallax.ts
+++ b/templates/parallax.ts
@@ -1,46 +1,130 @@
 import type { Template } from '@/lib/types';
-import { clamp, hash2, lerp } from '@/lib/motion';
+import type { EasingSpec } from '@/lib/easing';
+import { TAU, clamp, hash2, lerp } from '@/lib/motion';
 import { variant } from './variant';
 
 const BASE = 340;
 
 // ============================================================
-//  PARALLAX — a scattered field that flickers, not a scrolling wall
+//  PARALLAX — a still field of photos, walked by a stopping camera
 //
-//  Measured on the reference tool (its store's paramsPerModeBaseline; the
-//  panel confirms these are the live controls — Count, Min Size, Max Size,
-//  Corner Radius, Spread, Travel, Depth, Fade, Seed):
+//  Controls, read off the reference's live panel (Count, Min Size, Max Size,
+//  Corner Radius, Spread, Travel, Depth, Fade, Seed) with their authored
+//  values from its own store:
 //
-//      Parallax 01: count 133, minSize 238, maxSize 442, spread 300,
-//                   travel 300, depth 60,  fade 0,  seed 10
-//      Parallax 02: count 200, spread 300, travel 150, depth 100, fade 78
-//      Parallax 03: count 140, spread 180, travel 100, depth 60,  fade 80
+//      Parallax 01: count 133, spread 300, travel 300, depth 60,  fade 0,
+//                   seed 10, duration 14s, bezier [0.76, 0, 0.24, 1]
+//      Parallax 02: count 200, spread 300, travel 150, depth 100, fade 78,
+//                   seed 10, duration 16s, bezier [0.76, 0, 0.24, 1]
+//      Parallax 03: count 140, spread 180, travel 100, depth 60,  fade 80,
+//                   seed 10, duration 16s, bezier [0.33, 0, 0,    1]
 //
-//  (`direction`/`planeSize`/`scaleCenter` also sit in that baseline dict but
-//  are NOT in the schema and NOT on the panel — dead keys the UI never
-//  reads, left over from an earlier version of the scene. Confirmed by
-//  reading the panel's own rendered labels, not by inference.)
+//  Min/Max Size are not in any preset's baseline — all three fall back to the
+//  schema defaults 238/442. `planeSize`/`scaleCenter`/`direction` sit in the
+//  baseline but never surface on the panel; dead keys from an older version.
 //
-//  A first pass modelled this as a continuous depth-parallax SCROLL — near
-//  cards translating faster than far ones, the classic parallax read. Wrong:
-//  rasterizing the live canvas at 4.0s and 4.5s on Parallax 01 (playhead
-//  paused each time — this scene never populates the reference's own
-//  card-rect helper, unlike Frames/Grid/Stack/Wheel, so the canvas itself has
-//  to be read) showed every visible card in the EXACT same position and size
-//  half a second later — no drift at all on a timescale that would have
-//  shown one at any plausible speed implied by `travel`. What DOES move is
-//  the whole visible SET: sampled every ~2s across the clip, the cards on
-//  screen turn over almost completely, with an overlap frame (3.0s) showing
-//  the outgoing set still fading and the incoming set already appearing.
-//  So each card holds a FIXED scattered position for its whole life and
-//  simply crossfades in, holds, and crossfades out — a Flicker crossfade
-//  (see templates/flicker.ts) running independently per card at a random
-//  scattered spot, not one shared centre. `travel` turned out to govern how
-//  many of these on/off cycles the field runs per loop, not a distance —
-//  fitted against the observed ~2-2.5s turnover on Parallax 01 (six cycles
-//  over its 14s clip), not measured to the same precision as its schema
-//  values.
+//  THE MOTION, measured off its canvas by cross-correlating consecutive
+//  frames (normalized correlation over the overlap, so a clean translation is
+//  distinguishable from content simply changing):
+//
+//  · The whole field TRANSLATES as one piece — correlation peaks at 0.95-0.99
+//    through the slow phases, and a single (dx, dy) aligns one frame onto the
+//    next. Nothing fades in or out. Two earlier passes modelled this family as
+//    per-card flicker; that was wrong, and it is why it never looked right.
+//
+//  · The camera STOPS and LURCHES. Sampling velocity every 0.2s across the
+//    clip, the field rests (v = 0) and then bursts, and the rests land exactly
+//    on the camera-path pins:
+//
+//        rest measured   0.4   2.5   4.3   7.3   9.7   11.9   14.0
+//        pin  predicted  0     2.33  4.67  7.0   9.33  11.67  14.0
+//
+//    That is the authored bezier [0.76, 0, 0.24, 1] — near-zero slope at both
+//    ends — applied per segment between pins. This hold-and-lurch rhythm IS
+//    the family's signature, and no amount of tuning a continuous drift or a
+//    flicker duty cycle would have produced it.
+//
+//  · Coverage drifts slowly (10-40% of lit pixels) over one clip rather than
+//    oscillating. That falls out of a camera crossing a random field's denser
+//    and sparser patches — another thing a flicker model gets wrong, since
+//    flicker would oscillate at its own rate.
+//
+//  · Peak speed runs ~1000-1500 px/s on its 1080x1440 stage. Per-segment
+//    displacement measured 300-900 px per grid cell, too noisy to pin down
+//    exactly (the correlation saturates at peak velocity, and a scatter of
+//    similar cards offers false peaks at large displacement), so PAN_PER_CELL
+//    below is calibrated to the cleanest segment and is approximate.
+//
+//  THE CAMERA PATH is a real, dedicated feature, and not a slider — it never
+//  appears in the Controls panel. It lives in its own store slice,
+//  `useAnimatorStore.getState().waypointsPerModeBaseline[modeId]`, as {c, r, t}
+//  triples: grid column, row, and time fraction. All three presets carry a
+//  CLOSED six-pin loop over a 7x7 grid centred at (3,3):
+//
+//    Parallax 01: (3,3)->(5,2)->(6,5)->(3,5)->(1,4)->(2,0)->(3,3)
+//    Parallax 02: (1,3)->(4,0)->(6,4)->(3,6)->(3,3)->(0,6)->(1,3)
+//    Parallax 03: (1,0)->(4,0)->(5,4)->(3,6)->(3,3)->(0,6)->(1,0)
+//
+//  SCATTER EXTENT, measured from lit-pixel statistics on its own stage:
+//  medSdx 281-312 and medSdy 351-440, against the 1080/sqrt(12) = 312 and
+//  1440/sqrt(12) = 416 a uniform full-frame scatter predicts — so the field is
+//  uniform, and `spread` 180 vs 300 does not change that (all three fill the
+//  frame). Ours is a percentage, and the reference presets carry 100.
 // ============================================================
+
+// {c, r, t}: grid column/row (0..6, centre 3) and time fraction 0..1, read
+// verbatim from the reference's own waypointsPerModeBaseline.
+const CAMERA_PATHS: Record<string, { c: number; r: number; t: number }[]> = {
+  p1: [
+    { c: 3, r: 3, t: 0 }, { c: 5, r: 2, t: 1 / 6 }, { c: 6, r: 5, t: 2 / 6 },
+    { c: 3, r: 5, t: 0.5 }, { c: 1, r: 4, t: 4 / 6 }, { c: 2, r: 0, t: 5 / 6 }, { c: 3, r: 3, t: 1 },
+  ],
+  p2: [
+    { c: 1, r: 3, t: 0 }, { c: 4, r: 0, t: 1 / 6 }, { c: 6, r: 4, t: 2 / 6 },
+    { c: 3, r: 6, t: 0.5 }, { c: 3, r: 3, t: 4 / 6 }, { c: 0, r: 6, t: 5 / 6 }, { c: 1, r: 3, t: 1 },
+  ],
+  p3: [
+    { c: 1, r: 0, t: 0 }, { c: 4, r: 0, t: 1 / 6 }, { c: 5, r: 4, t: 2 / 6 },
+    { c: 3, r: 6, t: 0.5 }, { c: 3, r: 3, t: 4 / 6 }, { c: 0, r: 6, t: 5 / 6 }, { c: 1, r: 0, t: 1 },
+  ],
+};
+const GRID_CENTRE = 3;
+const GRID_REACH = 3;   // furthest a pin sits from centre, in cells
+// Canvas long edges per grid cell, at Travel 100. Calibrated to the cleanest
+// measured segment; approximate — see the header.
+const PAN_PER_CELL = 0.20;
+// Roughly how many cards fall inside one frame, at Spread 100%. The wall is
+// sized FROM the card count to hold this density, rather than being a fixed
+// size — the reference's three presets cover 22 / 25 / 24.5% of the frame on
+// average despite counting 133 / 200 / 140 cards, which is constant density,
+// not a constant wall. Sizing the wall independently made the densest preset
+// cover 63% where the reference covers 35%.
+const CARDS_PER_FRAME = 4;
+// How far a card may wander inside its own grid cell, in cell widths. Above 1
+// the cells overlap and the grid stops being readable as a grid; at 0 it is a
+// bare lattice.
+const JITTER = 1.15;
+
+// The pin the path is on at `u`, and how far it has eased toward the next.
+// Each leg lands exactly on its pin, and `shape` (the scene's easing curve)
+// is what turns the legs into the measured hold-and-lurch.
+function cameraPathAt(
+  path: { c: number; r: number; t: number }[],
+  u: number,
+  shape: (t: number) => number,
+): { nx: number; ny: number } {
+  let seg = path.length - 2;
+  for (let i = 0; i < path.length - 1; i++) {
+    if (u >= path[i].t && u <= path[i + 1].t) { seg = i; break; }
+  }
+  const a = path[seg], b = path[seg + 1];
+  const span = Math.max(1e-6, b.t - a.t);
+  const local = shape(clamp((u - a.t) / span, 0, 1));
+  return {
+    nx: lerp(a.c, b.c, local) - GRID_CENTRE,
+    ny: lerp(a.r, b.r, local) - GRID_CENTRE,
+  };
+}
 
 const parallax: Template = {
   meta: { id: 'parallax-01', name: 'Drift 01', group: 'Drift', repeatAssets: true, defaultEasing: { id: 'smooth' } },
@@ -50,88 +134,126 @@ const parallax: Template = {
     { key: 'minSize',      label: 'Min Size',      type: 'slider', min: 10, max: 900, step: 5,  default: 110 },
     { key: 'maxSize',      label: 'Max Size',      type: 'slider', min: 10, max: 900, step: 5,  default: 300 },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 150, step: 1,   default: 0 },
-    { key: 'spread',       label: 'Spread',        type: 'slider', min: 20, max: 350, step: 5,  default: 260, description: 'Radius of the scatter around centre.' },
-    { key: 'travel',       label: 'Travel',        type: 'slider', min: 20, max: 350, step: 5,  default: 130, description: 'How often the field turns over per loop.' },
-    { key: 'depth',        label: 'Depth',         type: 'slider', min: 0, max: 100, step: 1,   default: 60, description: '0 makes every card the same size and pace; 100 is the full spread.' },
+    { key: 'spread',       label: 'Spread',        type: 'slider', min: 20, max: 200, step: 5,  default: 100, unit: '%', description: '100% scatters the cards across the whole frame.' },
+    { key: 'travel',       label: 'Travel',        type: 'slider', min: 20, max: 350, step: 5,  default: 130, description: 'How far the camera moves between pins.' },
+    { key: 'depth',        label: 'Depth',         type: 'slider', min: 0, max: 100, step: 1,   default: 60, description: '0 makes every card the same size; 100 is the full near/far spread.' },
     { key: 'fade',         label: 'Fade',          type: 'slider', min: 0, max: 100, step: 1,   default: 45, description: 'Dims far cards toward the background.' },
     { key: 'seed',         label: 'Seed',          type: 'slider', min: 1, max: 999, step: 1,   default: 1 },
     { key: 'direction',    label: 'Direction',     type: 'toggle', options: ['forward','reverse'], default: 'forward' },
+    { key: 'camPath',      label: 'Camera Path',   type: 'select', options: ['orbit','p1','p2','p3'], default: 'orbit', section: 'Motion', description: 'orbit is a generic drift; p1-p3 replay the reference’s own authored pin paths.' },
     { key: 'offset',       label: 'Offset',        type: 'xypad',                              default: { x: 0, y: 0 } },
   ],
 
   transform: (frame, index, count, v, ctx) => {
     const seed = v.seed ?? 1;
-    // How much per-card variety `depth` actually buys: at 0, every card
-    // collapses to the same medium depth (uniform size, uniform pace); at
-    // 100, the full seeded spread applies.
+    // How much per-card variety `depth` buys: at 0 every card collapses to one
+    // middling depth (uniform size), at 100 the full seeded spread applies.
     const strength = clamp(v.depth, 0, 100) / 100;
-    const raw = hash2(index, seed * 91.7);
-    const d = lerp(0.5, raw, strength);
+    const d = lerp(0.5, hash2(index, seed * 91.7), strength);
 
-    const size = lerp(v.minSize, v.maxSize, d);
-    const sizeFactor = size / BASE;
+    const sizeFactor = lerp(v.minSize, v.maxSize, d) / BASE;
 
-    // Fixed scattered position for the card's whole life — see header: this
-    // is what a 0.5s-apart pair of frames on the reference actually showed,
-    // not a drift.
-    const x = (hash2(index, seed * 17.3) - 0.5) * v.spread * 2 + v.offset.x;
-    const y = (hash2(index, seed * 53.1) - 0.5) * v.spread * 2 + v.offset.y;
+    // The field is FIXED — measured: one (dx, dy) aligns consecutive frames at
+    // correlation 0.95-0.99, so nothing moves relative to anything else and
+    // nothing fades. It extends past the frame by the camera's full reach, so
+    // walking to any pin still finds photos rather than a bare edge.
+    const long = Math.max(ctx.width, ctx.height);
+    const spreadFactor = clamp(v.spread ?? 100, 0, 400) / 100;
+    // Frames across the wall, solved so density stays put as Count changes.
+    const fieldScale = Math.sqrt(Math.max(1, count) / CARDS_PER_FRAME) * spreadFactor;
+    const fieldW = ctx.width * fieldScale;
+    const fieldH = ctx.height * fieldScale;
+    // Jittered grid, not pure random. A purely random scatter clumps (Poisson),
+    // and measuring it that way gave a coverage range about half again as wide
+    // as the reference's — its wall is noticeably more even than chance while
+    // still reading as unplanned. Each card owns one cell and is nudged inside
+    // it, which keeps the evenness and hides the grid.
+    const gCols = Math.max(1, Math.round(Math.sqrt(Math.max(1, count) * (fieldW / fieldH))));
+    const gRows = Math.max(1, Math.ceil(Math.max(1, count) / gCols));
+    const cellW = fieldW / gCols, cellH = fieldH / gRows;
+    const col = index % gCols, row = Math.floor(index / gCols) % gRows;
+    const jx = (hash2(index, seed * 17.3) - 0.5) * JITTER;
+    const jy = (hash2(index, seed * 53.1) - 0.5) * JITTER;
+    const x = (col + 0.5 + jx) * cellW - fieldW / 2 + v.offset.x;
+    const y = (row + 0.5 + jy) * cellH - fieldH / 2 + v.offset.y;
+    // The camera may roam anywhere the wall still fills the frame, and no
+    // further — past that it would pan onto a bare edge.
+    const reach = Math.max(0, Math.min(fieldW - ctx.width, fieldH - ctx.height) / 2);
+    const panPerCell = Math.min(
+      (clamp(v.travel, 0, 1000) / 100) * PAN_PER_CELL * long,
+      reach / GRID_REACH,
+    );
 
-    // One shared integer cycle count keeps the loop exact regardless of the
-    // per-card stagger below (frac(N*u - stagger) lands on the same value at
-    // u=0 and u=1 for any integer N). `travel` sets N; nearer/bigger cards
-    // linger a little longer per cycle (`duty`), same depth cue as size.
-    const cycles = Math.max(1, Math.round(v.travel / 40));
-    const duty = lerp(0.1, 0.22, d);
+    // Fade DARKENS the far cards; it does not make them see-through. At Fade 80
+    // an alpha-based version left the farthest cards at 0.2 opacity, so every
+    // card they overlapped ghosted through them and the wall read as broken
+    // glass. Cards never change over time either way — see the header.
+    const dim = (v.fade / 100) * (1 - d);
+
     const dir = v.direction === 'reverse' ? -1 : 1;
-    const stagger = hash2(index, seed * 233.9);
-    const u = frame / ctx.totalFrames;
-    const local = (((cycles * u * dir - stagger) % 1) + 1) % 1;
+    const u = (((frame / ctx.totalFrames) * dir) % 1 + 1) % 1;
 
-    // Crossfade envelope within the card's own on-window: ease in over the
-    // first 30%, hold, ease out over the last 30% — the overlap that let two
-    // sets of cards (one fading out, the next fading in) show up together at
-    // the reference's 3.0s sample.
-    let lifecycle = 0;
-    if (local < duty) {
-      const p = local / duty;
-      const edge = 0.3;
-      lifecycle = p < edge ? ctx.ease(p / edge)
-        : p > 1 - edge ? ctx.ease((1 - p) / edge)
-        : 1;
+    const path = CAMERA_PATHS[v.camPath];
+    let camX: number, camY: number, camZoom: number;
+    if (path) {
+      // The camera holds at each pin and lurches between them — that shape is
+      // the scene's own easing curve, which is exactly how the reference does
+      // it (its authored bezier is a near-flat-ended ease).
+      const { nx, ny } = cameraPathAt(path, u, ctx.ease);
+      camX = -nx * panPerCell;   // camera right -> field left
+      camY = -ny * panPerCell;
+      camZoom = 1;
+    } else {
+      // No authored path: a gentle one-cycle drift, so this family's own
+      // presets still breathe.
+      const angle = TAU * ctx.easedPhase(u);
+      camZoom = 1 + 0.06 * (0.5 - 0.5 * Math.cos(angle));
+      camX = Math.cos(angle) * panPerCell * GRID_REACH * 0.5;
+      camY = Math.sin(angle) * panPerCell * GRID_REACH * 0.5;
     }
 
-    const alpha = lifecycle * (1 - (v.fade / 100) * (1 - d));
-
     return {
-      x,
-      y,
-      scale: sizeFactor,
+      x: x * camZoom + camX,
+      y: y * camZoom + camY,
+      scale: sizeFactor * camZoom,
       rotation: 0,
-      alpha,
+      alpha: 1,
+      dim,
       depth: d,
     };
   },
 };
 
+// `variant` only patches control defaults; these presets also need their own
+// curve, their own catalogue group and the NEW badge. They are a different
+// LOOK from Drift 01-04 despite sharing the transform — a walked photo wall
+// rather than a drifting one — so they get their own shelf.
+function preset(id: string, name: string, patch: Record<string, any>, easing: EasingSpec): Template {
+  const t = variant(parallax, id, name, patch);
+  return { ...t, meta: { ...t.meta, defaultEasing: easing, group: 'Parallax', isNew: true } };
+}
+
+// The reference's own authored beziers, read from its store's bezPerModeBaseline.
+const EASE_12: EasingSpec = { id: 'custom', bezier: [0.76, 0, 0.24, 1] };
+const EASE_3: EasingSpec = { id: 'custom', bezier: [0.33, 0, 0, 1] };
+
 export const parallaxVariants: Template[] = [
   parallax, // Drift 01
-  variant(parallax, 'parallax-02', 'Drift 02', { count: 140, spread: 380, travel: 200, seed: 2 }),
-  variant(parallax, 'parallax-03', 'Drift 03', { count: 40, spread: 140, travel: 80, seed: 3 }),
-  variant(parallax, 'parallax-04', 'Drift 04', { count: 200, spread: 460, travel: 280, seed: 4 }),
-  // Reference-measured presets (Parallax 01-03). `minSize`/`maxSize`/`spread`/
-  // `cornerRadius` are literal reference px, canvas-scaled by 0.75 (its stage
-  // is 1080x1440, this one's long edge is 1080). `travel` is carried over as
-  // the same NUMBER — it now drives cycle count rather than distance, and
-  // that formula was fitted to the observed ~2-2.5s turnover, not measured to
-  // the schema's own precision. `depth`, `fade` and `seed` are dimensionless.
-  variant(parallax, 'parallax-r01', 'Parallax 01', {
-    count: 133, minSize: 179, maxSize: 332, spread: 225, travel: 300, depth: 60, fade: 0, seed: 10,
-  }),
-  variant(parallax, 'parallax-r02', 'Parallax 02', {
-    count: 200, minSize: 179, maxSize: 332, spread: 225, travel: 150, depth: 100, fade: 78, seed: 10,
-  }),
-  variant(parallax, 'parallax-r03', 'Parallax 03', {
-    count: 140, minSize: 179, maxSize: 332, spread: 135, travel: 100, depth: 60, fade: 80, seed: 10,
-  }),
+  variant(parallax, 'parallax-02', 'Drift 02', { count: 140, spread: 130, travel: 150, seed: 2 }),
+  variant(parallax, 'parallax-03', 'Drift 03', { count: 40, spread: 60, travel: 80, seed: 3 }),
+  variant(parallax, 'parallax-04', 'Drift 04', { count: 200, spread: 160, travel: 200, seed: 4 }),
+  // Reference presets. `count`, `travel`, `depth`, `fade` and `seed` are the
+  // reference's own numbers; `minSize`/`maxSize`/`cornerRadius` are its px,
+  // canvas-scaled by 0.75 (its stage is 1080x1440, this project's long edge is
+  // 1080); `spread` is 100% because that is what all three measure as; the
+  // easing curves are its own authored beziers; `camPath` replays its pins.
+  preset('parallax-r01', 'Parallax 01', {
+    count: 133, minSize: 179, maxSize: 332, spread: 100, travel: 300, depth: 60, fade: 0, seed: 10, camPath: 'p1',
+  }, EASE_12),
+  preset('parallax-r02', 'Parallax 02', {
+    count: 200, minSize: 179, maxSize: 332, spread: 100, travel: 150, depth: 100, fade: 78, seed: 10, camPath: 'p2',
+  }, EASE_12),
+  preset('parallax-r03', 'Parallax 03', {
+    count: 140, minSize: 179, maxSize: 332, spread: 100, travel: 100, depth: 60, fade: 80, seed: 10, camPath: 'p3',
+  }, EASE_3),
 ];


### PR DESCRIPTION
Ports two motion families against measurements taken off the reference tool,
rather than values fitted by eye — and adds the two pose fields they needed.

## Parallax — a still field walked by a stopping camera

Earlier passes modelled this as per-card flicker. Cross-correlating consecutive
frames (which separates "the field translated" from "the content changed") shows
it translates: one (dx, dy) aligns each frame onto the next at correlation
0.95–0.99, and nothing fades in or out.

The camera holds, then lurches. Velocity sampled every 0.2s rests exactly on the
six camera-path pins:

| rest measured | 0.4 | 2.5 | 4.3 | 7.3 | 9.7 | 11.9 | 14.0 |
|---|---|---|---|---|---|---|---|
| pin predicted | 0 | 2.33 | 4.67 | 7.0 | 9.33 | 11.67 | 14.0 |

Three data sources that had never been read, all of which set the speed or shape:

- **The camera path** — a real feature that never appears in the Controls panel.
  It lives in its own store slice as `{c, r, t}` pins on a 7×7 grid; all three
  presets carry a closed six-pin loop.
- **Each preset's authored bezier** — the near-flat-ended curve per segment is
  what produces the hold-and-lurch.
- **Authored durations** of 14s/16s/16s, where ours ran the 8s default.

Corrected from lit-pixel statistics:

| | before | after | reference |
|---|---|---|---|
| spread (sd / canvas) | 0.11–0.16 | 0.254–0.289 | 0.244–0.306 |
| lit bbox | never reached an edge | fills the frame | fills the frame |

`spread` had been read as a pixel radius, which clumped every card into the
middle. Density is also constant across the reference's presets, so the wall is
sized from the card count; and the scatter is a jittered grid, since pure random
clumps measurably more than the reference does.

## Wipe — the image never moves; an edge uncovers it

Not the family we already had: Takeover pushes a card in from an edge. Reading
the reference's own card rects at 17 points across the loop, every card returned
(540, 720) at 1080×1440 every single time, with only the slot indices advancing.
Nothing translates, nothing scales — what moves is the reveal edge, sweeping the
full frame inside one image's turn on each preset's authored bezier.

Timing differs from Parallax: `duration` here is per-image and the clip is
duration × count (1.67s transitions against an 8.4s timeline). The reference is
not consistent between families, so it has to be measured each time.

Shipped as a new family in its own group. Takeover is untouched, so existing
scenes keep working.

## Two new pose fields

- **`dim`** — a card that is far away darkens; it does not go see-through.
  Fade rode `alpha`, so far cards let whatever they overlapped ghost through
  them. On a dark background that looks identical to darkening *until cards
  overlap*, which is why it survived several passes.
- **`clip`** — shows part of a card without moving or scaling it. A wipe cannot
  be built from a transform: translation slides the card, scale distorts it.

Both are carried through every surface that draws a pose — renderer, thumbnail,
and board/web export — or the surfaces silently disagree.

## Verification

`verify-reference` asserts the measured signatures, not just well-formedness:
the camera rests at every interior pin, peak speed is at least 2× mean, the
spatial spread and density match, no card is ever semi-transparent, and for Wipe
nothing may translate while some card must be partly clipped. A push-based wipe
fails that last one immediately.

`npm test` green (28885 + 3558441 + 12914 + 825 assertions across 215 templates),
`tsc` clean, build clean, no console errors.

## Known limits

- Parallax's **pan-per-cell scale** is approximate: correlation saturates at peak
  velocity, and a field of similar cards offers false peaks at large displacement.
- What the reference's own `spread` value means (180 vs 300) is not recoverable —
  both measure as filling the frame.
- Wipe's **`feather`** is not modelled (0 on all four presets; a soft edge needs a
  gradient mask there is no field for), and **`scale`** is a reasoned reading of
  its name and range, not an isolated measurement.
- `lib/renderer3d.ts` implements neither `dim` nor `clip` — a webgl-engine family
  using either would render without them.