### PR TITLE
Let Card Bend curve outward too, and badge Orbit 3D as new

### DIFF
--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -47,8 +47,18 @@ function makeBentPlaneGeometry(sag: number): THREE.PlaneGeometry {
   const ac = new THREE.Vector2().subVectors(a, c);
   const radius = (ab.length() * bc.length() * ac.length()) / (2 * Math.abs(ab.cross(ac)));
   const centre = new THREE.Vector2(0, bend - Math.sign(bend) * radius);
-  const baseAngle = new THREE.Vector2().subVectors(a, centre).angle() - Math.PI / 2;
-  const arc = baseAngle * 2;
+  // The arc from c to a around the centre, taken the SHORT way. This used to be
+  // `(a - centre).angle() * 2 - PI`, which relies on the centre sitting BELOW
+  // the chord and so only held for a positive bend. Vector2.angle() returns
+  // [0, 2*PI), so a negative bend — centre above the chord — picked the reflex
+  // angle and swept the card nearly all the way round its own circle: at
+  // bend -0.04 the centre vertex landed 6.25 units out instead of 0.04, about
+  // 150x too far. Measuring the signed difference works for either side.
+  const angleA = new THREE.Vector2().subVectors(a, centre).angle();
+  const angleC = new THREE.Vector2().subVectors(c, centre).angle();
+  let arc = angleA - angleC;
+  if (arc > Math.PI) arc -= Math.PI * 2;
+  if (arc < -Math.PI) arc += Math.PI * 2;
   const uv = geometry.attributes.uv;
   const position = geometry.attributes.position;
   const point = new THREE.Vector2();

--- a/scripts/verify-tilt.cjs
+++ b/scripts/verify-tilt.cjs
@@ -154,4 +154,66 @@ for (const template of templateList.filter((item) => relevantGroups.has(item.met
   }
 }
 
+// ---------- Card Bend must curve BOTH ways ----------
+// The bent-plane geometry accepts a signed sag, but its arc used to be derived
+// from (a - centre).angle() * 2, which only holds while the arc centre sits
+// BELOW the chord — i.e. for a positive bend. Vector2.angle() returns
+// [0, 2*PI), so a negative bend picked the REFLEX angle and swept the card
+// nearly all the way round its own circle: at bend -0.04 the centre vertex
+// landed 6.25 units out instead of 0.04, about 150x too far. Nothing caught it
+// because no control could reach a negative bend until Orbit 3D's Card Bend
+// was centred on zero.
+{
+  const THREE = require('three');
+  const bentGeometry = (sag) => {
+    // Mirrors lib/renderer3d makeBentPlaneGeometry.
+    const bend = Math.max(-0.45, Math.min(0.45, sag));
+    const g = new THREE.PlaneGeometry(1, 1, 20, 8);
+    if (Math.abs(bend) < 0.0001) return g;
+    const a = new THREE.Vector2(-0.5, 0), b = new THREE.Vector2(0, bend), c = new THREE.Vector2(0.5, 0);
+    const ab = new THREE.Vector2().subVectors(a, b);
+    const bc = new THREE.Vector2().subVectors(b, c);
+    const ac = new THREE.Vector2().subVectors(a, c);
+    const radius = (ab.length() * bc.length() * ac.length()) / (2 * Math.abs(ab.cross(ac)));
+    const centre = new THREE.Vector2(0, bend - Math.sign(bend) * radius);
+    const angleA = new THREE.Vector2().subVectors(a, centre).angle();
+    const angleC = new THREE.Vector2().subVectors(c, centre).angle();
+    let arc = angleA - angleC;
+    if (arc > Math.PI) arc -= Math.PI * 2;
+    if (arc < -Math.PI) arc += Math.PI * 2;
+    const uv = g.attributes.uv, position = g.attributes.position;
+    const pt = new THREE.Vector2();
+    for (let i = 0; i < uv.count; i++) {
+      const ratio = 1 - uv.getX(i);
+      const y = position.getY(i);
+      pt.copy(c).rotateAround(centre, arc * ratio);
+      position.setXYZ(i, pt.x, y, -pt.y);
+    }
+    return g;
+  };
+  const centreZ = (sag) => {
+    const p = bentGeometry(sag).attributes.position;
+    let cz = null, maxAbsX = 0;
+    for (let i = 0; i < p.count; i++) {
+      const x = p.getX(i);
+      maxAbsX = Math.max(maxAbsX, Math.abs(x));
+      if (Math.abs(x) < 1e-6 && cz === null) cz = p.getZ(i);
+    }
+    return { cz, maxAbsX };
+  };
+  for (const sag of [0.04, 0.12, 0.3]) {
+    const pos = centreZ(sag), neg = centreZ(-sag);
+    // The centre displaces by exactly the sag, opposite ways, and the card
+    // never widens — a runaway arc shows up as either.
+    assert(Math.abs(pos.cz + sag) < 1e-6,
+      `Card Bend +${sag} put the centre vertex at ${pos.cz}, expected ${-sag}`);
+    assert(Math.abs(neg.cz - sag) < 1e-6,
+      `Card Bend -${sag} put the centre vertex at ${neg.cz}, expected ${sag}`);
+    assert(Math.abs(pos.maxAbsX - 0.5) < 1e-6,
+      `Card Bend +${sag} widened the card to ${pos.maxAbsX * 2}`);
+    assert(Math.abs(neg.maxAbsX - 0.5) < 1e-6,
+      `Card Bend -${sag} widened the card to ${neg.maxAbsX * 2}`);
+  }
+}
+
 console.log(`Tilt verification passed (${assertions} assertions across ${templateList.length} templates).`);

--- a/templates/orbit3d.ts
+++ b/templates/orbit3d.ts
@@ -61,7 +61,7 @@ function ringPhase(frame: number, v: Record<string, any>, count: number, ctx: { 
 
 const ringStream: Template = {
   meta: {
-    id: 'orbit-3d-01', name: 'Ring Stream', group: 'Orbit',
+    id: 'orbit-3d-01', name: 'Ring Stream', group: 'Orbit', isNew: true,
     // Linear on purpose — see ringPhase above. The curve picker still works for
     // anyone who wants the stepped feel back.
     defaultEasing: { id: 'linear' }, engine: 'webgl', catalog3d: true, repeatAssets: true,
@@ -75,7 +75,12 @@ const ringStream: Template = {
     { key: 'opening', label: 'Ring Opening', type: 'slider', min: 15, max: 85, step: 1, default: 70, section: 'Layout', unit: '%', description: 'Controls the inner diameter while keeping the ring complete.' },
     { key: 'cardSizePct', label: 'Card Size', type: 'slider', min: 8, max: 36, step: 1, default: 18, section: 'Layout', unit: '%' },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 20, step: 0.5, default: 3, section: 'Finish', unit: '%', precision: 1 },
-    { key: 'cardBend', label: 'Card Bend', type: 'slider', min: 0, max: 12, step: 0.5, default: 4, section: 'Depth', unit: '%', precision: 1, description: 'Curves each image surface gently around the ring.' },
+    // Signed, so the slider sits at centre and reads as one axis: negative
+    // cups each image inward toward the ring's centre, positive bows it
+    // outward, 0 is flat. The 3D renderer already flips the arc's centre by
+    // the sign (lib/renderer3d makeBentPlaneGeometry) and clamps to +/-0.45,
+    // so only this range was holding the outward half back.
+    { key: 'cardBend', label: 'Card Bend', type: 'slider', min: -12, max: 12, step: 0.5, default: 4, section: 'Depth', unit: '%', precision: 1, description: 'Curves each image surface around the ring — negative cups inward, positive bows outward.' },
     { key: 'tiltX', label: 'Ring Tilt', type: 'slider', min: -60, max: 60, step: 1, default: -8, section: 'Depth', unit: '°', description: 'Rotates the complete physical ring without changing its radius.' },
     { key: 'perspective', label: 'Perspective', type: 'slider', min: 0, max: 40, step: 1, default: 18, section: 'Depth', unit: '%' },
     { key: 'camDistance', label: 'Camera Distance', type: 'slider', min: 0.5, max: 2.5, step: 0.05, default: 1, section: 'Depth', unit: '×', precision: 2,


### PR DESCRIPTION
Card Bend only ran 0..12, so the image surface could cup one way. It is now signed, -12..12 centred on zero: negative cups each card inward toward the ring's centre, positive bows it outward, 0 is flat.

That looked like a one-line range change — the geometry already clamps to +/-0.45 and already carries a Math.sign(). It was not. Measuring the built geometry instead of trusting the read:

    bend    centre vertex    expected
    +0.04       -0.04          -0.04   ok
    +0.12       -0.12          -0.12   ok
    -0.04       -6.25          +0.04   ~150x out
    -0.12       -2.08          +0.12   wrong side

The arc came from `(a - centre).angle() * 2 - PI`, which holds only while the arc centre sits BELOW the chord — i.e. for a positive bend. Vector2.angle() returns [0, 2*PI), so a negative bend picked the REFLEX angle and swept the card nearly all the way around its own circle. Nothing had caught it because no control could reach a negative bend before now.

Fixed by taking the signed short-way difference between the two end angles, which is correct on either side. The centre vertex now displaces by exactly the sag, mirrored, with the card's width intact.

verify-tilt asserts that directly, and I checked it fails on the old maths rather than assuming it would: restoring the previous line makes it report "Card Bend -0.04 put the centre vertex at -6.25, expected 0.04".

Orbit 3D also gains the NEW badge — the group header picks it up from any member being flagged.

npm test green (28897 + 3538021 + 12802 + 763 assertions across 211 templates), tsc clean, build clean. Screenshot in .shots/bend-sweep.jpg shows the edge-on cards curving opposite ways at -12 and +12, flat at 0.