### PR TITLE
Feat/typed number entry

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -531,6 +531,7 @@ select.field { padding-right: 26px; }
 }
 .xypad-tag-x { right: 5px; top: 50%; transform: translateY(-50%); }
 .xypad-tag-y { left: 50%; top: 5px; transform: translateX(-50%); }
+.xypad-field { position: absolute; inset: 5px; pointer-events: none; }
 .xypad-dot { position: absolute; width: 10px; height: 10px; border-radius: 50%; background: var(--fg-label); transform: translate(-50%, -50%); }
 .xypad-vals {
   display: flex; align-items: center; justify-content: center; gap: 4px;
@@ -1420,6 +1421,7 @@ select.field { padding-right: 26px; }
   .mobile-composed-panel .icon-btn { width: 44px; height: 44px; }
   .mobile-editor .xypad-wrap { width: 100%; align-items: stretch; flex-direction: column; gap: 8px; }
   .mobile-editor .xypad { width: 100%; min-height: 180px; }
+  .mobile-editor .xypad-field { inset: 14px; }
   .mobile-editor .xypad-dot { width: 28px; height: 28px; border: 7px solid var(--card); box-shadow: 0 0 0 1px var(--handle); }
   .mobile-editor .xypad-vals { text-align: center; font-size: 13px; }
   .mobile-editor .xypad-reset { min-height: 44px; border-radius: var(--r-ctrl); background: var(--card-inset); color: var(--fg-muted); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -515,17 +515,25 @@ select.field { padding-right: 26px; }
 }
 
 /* xypad */
-.xypad-wrap { display: flex; gap: 10px; align-items: center; }
+.xypad-wrap { display: flex; flex-direction: column; gap: 8px; width: 100%; align-items: stretch; }
 .xypad {
-  position: relative; width: 112px; height: 92px;
+  position: relative; width: 100%; aspect-ratio: 1 / 1;
   background: var(--card-inset); border-radius: var(--r-ctrl);
   touch-action: none; cursor: crosshair;
 }
-.xypad-cross-h { position: absolute; top: 50%; left: 8px; right: 8px; height: 1px; background: var(--line); }
-.xypad-cross-v { position: absolute; left: 50%; top: 8px; bottom: 8px; width: 1px; background: var(--line); }
+.xypad-grid { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+.xypad-line { stroke: var(--line); stroke-width: 1; vector-effect: non-scaling-stroke; opacity: 0.5; }
+.xypad-mid { stroke: var(--handle); stroke-width: 1; vector-effect: non-scaling-stroke; }
+/* which way is which, without having to nudge the dot to find out */
+.xypad-tag {
+  position: absolute; font-size: var(--fs-meta); line-height: 1; color: var(--fg-faint);
+  pointer-events: none; letter-spacing: .04em;
+}
+.xypad-tag-x { right: 5px; top: 50%; transform: translateY(-50%); }
+.xypad-tag-y { left: 50%; top: 5px; transform: translateX(-50%); }
 .xypad-dot { position: absolute; width: 10px; height: 10px; border-radius: 50%; background: var(--fg-label); transform: translate(-50%, -50%); }
 .xypad-vals {
-  display: flex; align-items: center; gap: 2px;
+  display: flex; align-items: center; justify-content: center; gap: 2px;
   color: var(--fg-faint); font-size: var(--fs-ui); font-variant-numeric: tabular-nums;
 }
 .xypad-sep { color: var(--fg-faint); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -457,9 +457,15 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
   font-size: var(--fs-ui); line-height: var(--lh-ui); color: var(--fg-value);
   font-variant-numeric: tabular-nums; padding: 2px 6px; border-radius: var(--r-seg); cursor: text;
 }
+/* the readout is a click target, so it has to look like one on hover — an
+   unmarked number reads as a label, not as something you can type into */
+.sval:hover { background: var(--card-thumb); color: var(--fg-body); }
+/* mid-drag the cursor crosses the readout; lighting it up there suggests a
+   click target that is not what the gesture is doing */
+.strack.is-dragging .sval:hover { background: none; color: var(--fg-value); }
 .sval-input {
   position: absolute; right: 4px; top: 50%; transform: translateY(-50%);
-  width: 64px; text-align: right; background: var(--card-thumb); border: none; border-radius: var(--r-seg);
+  max-width: calc(100% - 8px); text-align: right; background: var(--card-thumb); border: none; border-radius: var(--r-seg);
   color: var(--fg-body); font-size: var(--fs-ui); padding: 2px 6px;
   font-variant-numeric: tabular-nums;
 }
@@ -518,7 +524,18 @@ select.field { padding-right: 26px; }
 .xypad-cross-h { position: absolute; top: 50%; left: 8px; right: 8px; height: 1px; background: var(--line); }
 .xypad-cross-v { position: absolute; left: 50%; top: 8px; bottom: 8px; width: 1px; background: var(--line); }
 .xypad-dot { position: absolute; width: 10px; height: 10px; border-radius: 50%; background: var(--fg-label); transform: translate(-50%, -50%); }
-.xypad-vals { color: var(--fg-faint); font-size: var(--fs-ui); font-variant-numeric: tabular-nums; }
+.xypad-vals {
+  display: flex; align-items: center; gap: 2px;
+  color: var(--fg-faint); font-size: var(--fs-ui); font-variant-numeric: tabular-nums;
+}
+.xypad-sep { color: var(--fg-faint); }
+.exact-num {
+  text-align: center; background: var(--card-inset); border: 1px solid transparent;
+  border-radius: var(--r-seg); color: var(--fg-value); font-size: var(--fs-ui); padding: 3px 4px;
+  font-variant-numeric: tabular-nums; cursor: text;
+}
+.exact-num:hover { background: var(--card-thumb); color: var(--fg-body); }
+.exact-num:focus { outline: 1px solid var(--ink); outline-offset: 1px; color: var(--fg-body); }
 
 /* upload / dropzone — Figma: flat #f3f4f6 button, 12px #6b7280 */
 .upload, .dropzone {

--- a/app/globals.css
+++ b/app/globals.css
@@ -533,10 +533,13 @@ select.field { padding-right: 26px; }
 .xypad-tag-y { left: 50%; top: 5px; transform: translateX(-50%); }
 .xypad-dot { position: absolute; width: 10px; height: 10px; border-radius: 50%; background: var(--fg-label); transform: translate(-50%, -50%); }
 .xypad-vals {
-  display: flex; align-items: center; justify-content: center; gap: 2px;
+  display: flex; align-items: center; justify-content: center; gap: 4px;
   color: var(--fg-faint); font-size: var(--fs-ui); font-variant-numeric: tabular-nums;
 }
-.xypad-sep { color: var(--fg-faint); }
+.xypad-axis {
+  font-size: var(--fs-meta); line-height: 1; color: var(--fg-faint);
+  letter-spacing: .04em; padding: 0 2px;
+}
 .exact-num {
   text-align: center; background: var(--card-inset); border: 1px solid transparent;
   border-radius: var(--r-seg); color: var(--fg-value); font-size: var(--fs-ui); padding: 3px 4px;

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -341,6 +341,8 @@ function ExactNumber({ label, value, min, max, step, onCommit }: {
   );
 }
 
+const PAD_GRID = [12.5, 25, 37.5, 62.5, 75, 87.5];
+
 function XYPadControl({ def, value, onChange }: RowProps) {
   const mobile = useMobileInteractions();
   const ref = useRef<HTMLDivElement>(null);
@@ -375,8 +377,14 @@ function XYPadControl({ def, value, onChange }: RowProps) {
         onPointerCancel={() => { pressed.current = false; }}
         onLostPointerCapture={() => { pressed.current = false; }}
       >
-        <div className="xypad-cross-h" />
-        <div className="xypad-cross-v" />
+        <svg className="xypad-grid" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden>
+          {PAD_GRID.map((p) => <line key={`v${p}`} className="xypad-line" x1={p} y1={0} x2={p} y2={100} />)}
+          {PAD_GRID.map((p) => <line key={`h${p}`} className="xypad-line" x1={0} y1={p} x2={100} y2={p} />)}
+          <line className="xypad-mid" x1={50} y1={0} x2={50} y2={100} />
+          <line className="xypad-mid" x1={0} y1={50} x2={100} y2={50} />
+        </svg>
+        <span className="xypad-tag xypad-tag-x">X</span>
+        <span className="xypad-tag xypad-tag-y">Y</span>
         <div className="xypad-dot" style={{ left: `${dotX}%`, top: `${dotY}%` }} />
       </div>
       <div className="xypad-vals">

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -388,6 +388,7 @@ function XYPadControl({ def, value, onChange }: RowProps) {
         <div className="xypad-dot" style={{ left: `${dotX}%`, top: `${dotY}%` }} />
       </div>
       <div className="xypad-vals">
+        <span className="xypad-axis">X</span>
         <ExactNumber
           label={`${def.label} X`}
           value={v.x}
@@ -396,7 +397,7 @@ function XYPadControl({ def, value, onChange }: RowProps) {
           step={1}
           onCommit={(n) => onChange({ x: n, y: v.y })}
         />
-        <span className="xypad-sep">,</span>
+        <span className="xypad-axis">Y</span>
         <ExactNumber
           label={`${def.label} Y`}
           value={v.y}

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -347,15 +347,27 @@ function XYPadControl({ def, value, onChange }: RowProps) {
   const mobile = useMobileInteractions();
   const ref = useRef<HTMLDivElement>(null);
   const pressed = useRef(false);
+  // Where the drag began, in client space: shift locks to one axis and needs a
+  // line to lock ONTO. Anchoring on the press — not on the last move — is what
+  // keeps a shift-drag straight instead of letting it creep a pixel per frame.
+  const anchor = useRef<{ x: number; y: number } | null>(null);
   const range = def.max ?? 400;
   const v = value ?? { x: 0, y: 0 };
 
-  const setFromEvent = (clientX: number, clientY: number) => {
+  const setFromEvent = (clientX: number, clientY: number, lock = false) => {
     const el = ref.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
-    const nx = (clientX - rect.left) / rect.width;
-    const ny = (clientY - rect.top) / rect.height;
+    let px = clientX, py = clientY;
+    const from = anchor.current;
+    if (lock && from) {
+      // travel further across than down means this is a horizontal line, so the
+      // other axis is pinned to where the press left it
+      if (Math.abs(clientX - from.x) >= Math.abs(clientY - from.y)) py = from.y;
+      else px = from.x;
+    }
+    const nx = (px - rect.left) / rect.width;
+    const ny = (py - rect.top) / rect.height;
     onChange({ x: Math.round((nx * 2 - 1) * range), y: Math.round((ny * 2 - 1) * range) });
   };
 
@@ -367,15 +379,18 @@ function XYPadControl({ def, value, onChange }: RowProps) {
       <div
         ref={ref}
         className="xypad"
+        title="Drag to place; hold Shift to travel in a straight line"
         onPointerDown={(e) => {
           try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* no live pointer: nothing to capture */ }
           pressed.current = true;
+          anchor.current = { x: e.clientX, y: e.clientY };
           setFromEvent(e.clientX, e.clientY);
         }}
-        onPointerMove={(e) => { if (pressed.current && e.buttons === 1) setFromEvent(e.clientX, e.clientY); }}
-        onPointerUp={() => { pressed.current = false; }}
-        onPointerCancel={() => { pressed.current = false; }}
-        onLostPointerCapture={() => { pressed.current = false; }}
+        // shift is read per move, so it can be taken and released mid-drag
+        onPointerMove={(e) => { if (pressed.current && e.buttons === 1) setFromEvent(e.clientX, e.clientY, e.shiftKey); }}
+        onPointerUp={() => { pressed.current = false; anchor.current = null; }}
+        onPointerCancel={() => { pressed.current = false; anchor.current = null; }}
+        onLostPointerCapture={() => { pressed.current = false; anchor.current = null; }}
       >
         <svg className="xypad-grid" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden>
           {PAD_GRID.map((p) => <line key={`v${p}`} className="xypad-line" x1={p} y1={0} x2={p} y2={100} />)}

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ControlDef } from '@/lib/types';
 import MobileSheet from './MobileSheet';
 import { useMobileInteractions } from './MobileInteractions';
+
+// grows with what is typed, so nothing clips and nothing floats in empty box
+const fieldWidth = (text: string) => `calc(${Math.min(8, Math.max(3, text.length))}ch + 14px)`;
 
 interface RowProps {
   def: ControlDef;
@@ -66,13 +69,42 @@ function SliderControl({ def, value, onChange }: RowProps) {
   };
 
   const clampValue = (next: number) => Number(Math.max(min, Math.min(max, next)).toFixed(4));
+  // Typed values land on the same grid dragging uses, otherwise a step-1 row
+  // could store 18.5 while showing "19" — the readout would be lying.
+  // Shift means a finer grid here too, same as shift-dragging the track.
+  const snapValue = (next: number, grid = step) => clampValue(Math.round(next / grid) * grid);
+  // Escape has to leave without writing, so the unmount-triggered blur needs
+  // to be told to keep quiet.
+  const abortEdit = useRef(false);
+  const primed = useRef(false);
+  const settled = useRef(false);
+  // A move only counts as a drag if THIS track was the one pressed. Checking
+  // e.buttons alone let any held pointer sweeping past a row rewrite it — drag
+  // one slider, cross its neighbour, and the neighbour moved too.
+  const pressed = useRef(false);
+  // Where a press on the readout started, to tell a click apart from a drag.
+  const valPress = useRef<{ x: number; y: number } | null>(null);
+  const startEdit = () => {
+    abortEdit.current = false;
+    primed.current = false;
+    settled.current = false;
+    setDraft(String(Number(num.toFixed(decimals))));
+    setEditing(true);
+  };
+  // A half-typed value ("-", "1.", "") is not a number yet: parse, and only
+  // write when the result is finite. A comma reads as a decimal separator so a
+  // pt-BR keyboard commits the value it shows.
+  const commitDraft = (rawDraft: string) => {
+    const next = Number(String(rawDraft).trim().replace(',', '.'));
+    if (Number.isFinite(next)) onChange(snapValue(next));
+  };
   const openExact = () => {
     setDraft(String(num));
     setSheetOpen(true);
   };
   const applyExact = () => {
-    const next = Number(draft);
-    if (Number.isFinite(next)) onChange(clampValue(next));
+    const next = Number(String(draft).trim().replace(',', '.'));
+    if (Number.isFinite(next)) onChange(snapValue(next));
     setSheetOpen(false);
   };
 
@@ -83,15 +115,19 @@ function SliderControl({ def, value, onChange }: RowProps) {
       tabIndex={0}
       onPointerDown={(e) => {
         if (editing) return;
-        (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+        try { (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId); } catch { /* no live pointer: nothing to capture */ }
+        pressed.current = true;
         setDragging(true);
         setFromX(e.clientX, e.shiftKey);
       }}
-      onPointerMove={(e) => { if (!editing && e.buttons === 1) setFromX(e.clientX, e.shiftKey); }}
-      onPointerUp={() => setDragging(false)}
-      onPointerCancel={() => setDragging(false)}
+      onPointerMove={(e) => { if (!editing && pressed.current && e.buttons === 1) setFromX(e.clientX, e.shiftKey); }}
+      onPointerUp={() => { pressed.current = false; setDragging(false); }}
+      onPointerCancel={() => { pressed.current = false; setDragging(false); }}
+      onLostPointerCapture={() => { pressed.current = false; setDragging(false); }}
       onKeyDown={(e) => {
-        if (editing || !['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp'].includes(e.key)) return;
+        if (editing) return;
+        if (e.key === 'Enter') { e.preventDefault(); startEdit(); return; }
+        if (!['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp'].includes(e.key)) return;
         e.preventDefault();
         const sign = e.key === 'ArrowRight' || e.key === 'ArrowUp' ? 1 : -1;
         const delta = step * (e.shiftKey ? 0.1 : 1) * sign;
@@ -118,21 +154,57 @@ function SliderControl({ def, value, onChange }: RowProps) {
       {editing ? (
         <input
           className="sval-input"
-          type="number"
-          autoFocus
-          min={min}
-          max={max}
-          step={step}
-          defaultValue={Number(num.toFixed(decimals))}
+          // text + inputMode, not type="number": a number input refuses to
+          // report a selection, so select-on-focus is impossible and every
+          // keystroke lands NEXT TO the old value (340 then "5" gave 3405).
+          type="text"
+          inputMode="decimal"
+          style={{ width: fieldWidth(draft) }}
+          value={draft}
+          // autoFocus + onFocus was not enough: the caret landed at the end of
+          // the old value, so typing still appended. Focus and select from the
+          // mount ref instead, once per edit, so the first keystroke replaces.
+          ref={(el) => {
+            if (!el || primed.current) return;
+            primed.current = true;
+            el.focus();
+            el.select();
+          }}
           onPointerDown={(e) => e.stopPropagation()}
-          onChange={(e) => onChange(Number(e.target.value))}
-          onBlur={() => setEditing(false)}
-          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditing(false); }}
+          onFocus={(e) => e.currentTarget.select()}
+          onMouseUp={(e) => { if (settled.current) return; settled.current = true; e.preventDefault(); }}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => { if (!abortEdit.current) commitDraft(draft); setEditing(false); }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') { commitDraft(draft); setEditing(false); return; }
+            if (e.key === 'Escape') { abortEdit.current = true; setEditing(false); return; }
+            if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+            // nudge from what is typed, not from what is stored
+            e.preventDefault();
+            const typed = Number(draft.trim().replace(',', '.'));
+            const base = Number.isFinite(typed) ? typed : num;
+            const grid = step * (e.shiftKey ? 0.1 : 1);
+            const next = snapValue(base + grid * (e.key === 'ArrowUp' ? 1 : -1), grid);
+            setDraft(String(next));
+            onChange(next);
+          }}
         />
       ) : (
         <span
           className="sval"
-          onPointerDown={(e) => { e.stopPropagation(); mobile ? openExact() : setEditing(true); }}
+          title={mobile ? 'Tap to enter an exact value' : 'Click to type an exact value'}
+          // pointerdown only shields the track from starting a drag — pressing
+          // the number must never move the value. The edit opens on release,
+          // and only if the pointer stayed put: a drag that happens to start
+          // over the readout is ignored rather than turned into a text field.
+          onPointerDown={(e) => { e.stopPropagation(); valPress.current = { x: e.clientX, y: e.clientY }; }}
+          onClick={(e) => {
+            e.stopPropagation();
+            const from = valPress.current;
+            valPress.current = null;
+            if (from && Math.abs(e.clientX - from.x) + Math.abs(e.clientY - from.y) > 4) return;
+            mobile ? openExact() : startEdit();
+          }}
         >
           {num.toFixed(decimals)}{def.unit ?? ''}
         </span>
@@ -148,6 +220,7 @@ function SliderControl({ def, value, onChange }: RowProps) {
               step={step}
               value={draft}
               onChange={(event) => setDraft(event.target.value)}
+              onFocus={(event) => event.currentTarget.select()}
               autoFocus
             />
             <button onClick={() => setDraft(String(clampValue((Number(draft) || 0) + step)))} aria-label={`Increase ${def.label}`}>+</button>
@@ -211,9 +284,67 @@ function ColorControl({ value, onChange }: { value: any; onChange: (v: any) => v
   );
 }
 
+// A small always-editable number field: typing replaces (the whole value is
+// selected on focus), Enter or leaving commits clamped and snapped, Escape puts
+// the stored value back. Same rules as the slider readout, minus the track.
+function ExactNumber({ label, value, min, max, step, onCommit }: {
+  label: string; value: number; min: number; max: number; step: number; onCommit: (v: number) => void;
+}) {
+  const [draft, setDraft] = useState(String(value));
+  const [focused, setFocused] = useState(false);
+  const settled = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  // while the field is not being typed in, it mirrors the store
+  useEffect(() => { if (!focused) setDraft(String(value)); }, [value, focused]);
+  // Selecting once per visit, from whichever of focus/click arrives first, so
+  // the first keystroke replaces the value instead of extending it.
+  const selectAll = () => {
+    if (settled.current) return;
+    settled.current = true;
+    inputRef.current?.select();
+  };
+  const commit = (raw: string) => {
+    const n = Number(String(raw).trim().replace(',', '.'));
+    if (!Number.isFinite(n)) { setDraft(String(value)); return; }
+    const snapped = Math.round(n / step) * step;
+    onCommit(Number(Math.max(min, Math.min(max, snapped)).toFixed(4)));
+  };
+  return (
+    <input
+      ref={inputRef}
+      className="exact-num"
+      type="text"
+      inputMode="decimal"
+      style={{ width: fieldWidth(draft) }}
+      aria-label={label}
+      value={draft}
+      onFocus={() => { setFocused(true); selectAll(); }}
+      // a real mouse release would drop the caret mid-value, so the release
+      // that opened the field is swallowed; a second click places it normally
+      onMouseUp={(e) => { if (!settled.current) e.preventDefault(); }}
+      onClick={selectAll}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => { setFocused(false); settled.current = false; commit(draft); }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') { commit(draft); e.currentTarget.blur(); return; }
+        if (e.key === 'Escape') { setDraft(String(value)); e.currentTarget.blur(); return; }
+        if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+        e.preventDefault();
+        const typed = Number(draft.trim().replace(',', '.'));
+        const base = Number.isFinite(typed) ? typed : value;
+        const grid = step * (e.shiftKey ? 0.1 : 1);
+        const next = Number(Math.max(min, Math.min(max, Math.round((base + grid * (e.key === 'ArrowUp' ? 1 : -1)) / grid) * grid)).toFixed(4));
+        setDraft(String(next));
+        onCommit(next);
+      }}
+    />
+  );
+}
+
 function XYPadControl({ def, value, onChange }: RowProps) {
   const mobile = useMobileInteractions();
   const ref = useRef<HTMLDivElement>(null);
+  const pressed = useRef(false);
   const range = def.max ?? 400;
   const v = value ?? { x: 0, y: 0 };
 
@@ -234,14 +365,39 @@ function XYPadControl({ def, value, onChange }: RowProps) {
       <div
         ref={ref}
         className="xypad"
-        onPointerDown={(e) => { (e.target as HTMLElement).setPointerCapture(e.pointerId); setFromEvent(e.clientX, e.clientY); }}
-        onPointerMove={(e) => { if (e.buttons === 1) setFromEvent(e.clientX, e.clientY); }}
+        onPointerDown={(e) => {
+          try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* no live pointer: nothing to capture */ }
+          pressed.current = true;
+          setFromEvent(e.clientX, e.clientY);
+        }}
+        onPointerMove={(e) => { if (pressed.current && e.buttons === 1) setFromEvent(e.clientX, e.clientY); }}
+        onPointerUp={() => { pressed.current = false; }}
+        onPointerCancel={() => { pressed.current = false; }}
+        onLostPointerCapture={() => { pressed.current = false; }}
       >
         <div className="xypad-cross-h" />
         <div className="xypad-cross-v" />
         <div className="xypad-dot" style={{ left: `${dotX}%`, top: `${dotY}%` }} />
       </div>
-      <div className="xypad-vals">{v.x}, {v.y}</div>
+      <div className="xypad-vals">
+        <ExactNumber
+          label={`${def.label} X`}
+          value={v.x}
+          min={-range}
+          max={range}
+          step={1}
+          onCommit={(n) => onChange({ x: n, y: v.y })}
+        />
+        <span className="xypad-sep">,</span>
+        <ExactNumber
+          label={`${def.label} Y`}
+          value={v.y}
+          min={-range}
+          max={range}
+          step={1}
+          onCommit={(n) => onChange({ x: v.x, y: n })}
+        />
+      </div>
       {mobile && <button className="xypad-reset" onClick={() => onChange({ x: 0, y: 0 })}>Reset to center</button>}
     </div>
   );

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -351,28 +351,43 @@ function XYPadControl({ def, value, onChange }: RowProps) {
   // line to lock ONTO. Anchoring on the press — not on the last move — is what
   // keeps a shift-drag straight instead of letting it creep a pixel per frame.
   const anchor = useRef<{ x: number; y: number } | null>(null);
+  // Which axis a shift-drag committed to, and whether shift was held last move.
+  const axis = useRef<'x' | 'y' | null>(null);
+  const wasLocked = useRef(false);
   const range = def.max ?? 400;
   const v = value ?? { x: 0, y: 0 };
+  const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
 
   const setFromEvent = (clientX: number, clientY: number, lock = false) => {
     const el = ref.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
     let px = clientX, py = clientY;
+    // Taking shift mid-drag re-anchors on the spot: the line starts from where
+    // the hand is, instead of yanking the value back to the press point.
+    if (lock && !wasLocked.current) { anchor.current = { x: clientX, y: clientY }; axis.current = null; }
+    if (!lock) axis.current = null;
+    wasLocked.current = lock;
     const from = anchor.current;
     if (lock && from) {
-      // travel further across than down means this is a horizontal line, so the
-      // other axis is pinned to where the press left it
-      if (Math.abs(clientX - from.x) >= Math.abs(clientY - from.y)) py = from.y;
-      else px = from.x;
+      const dx = Math.abs(clientX - from.x), dy = Math.abs(clientY - from.y);
+      // Commit to an axis once the drag clears 6px, then STAY on it. Re-deciding
+      // every move made a near-diagonal drag flip axis frame to frame.
+      if (!axis.current && Math.max(dx, dy) > 6) axis.current = dx >= dy ? 'x' : 'y';
+      if (axis.current === 'x') py = from.y;
+      else if (axis.current === 'y') px = from.x;
+      else { px = from.x; py = from.y; }
     }
-    const nx = (px - rect.left) / rect.width;
-    const ny = (py - rect.top) / rect.height;
+    // A captured pointer reports moves well outside the pad; without this the
+    // value ran past ±range and the dot left the square entirely.
+    const nx = clamp01((px - rect.left) / rect.width);
+    const ny = clamp01((py - rect.top) / rect.height);
     onChange({ x: Math.round((nx * 2 - 1) * range), y: Math.round((ny * 2 - 1) * range) });
   };
 
-  const dotX = ((v.x / range + 1) / 2) * 100;
-  const dotY = ((v.y / range + 1) / 2) * 100;
+  const pct = (n: number) => Math.max(0, Math.min(100, ((n / range + 1) / 2) * 100));
+  const dotX = pct(v.x);
+  const dotY = pct(v.y);
 
   return (
     <div className="xypad-wrap">
@@ -384,13 +399,14 @@ function XYPadControl({ def, value, onChange }: RowProps) {
           try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* no live pointer: nothing to capture */ }
           pressed.current = true;
           anchor.current = { x: e.clientX, y: e.clientY };
-          setFromEvent(e.clientX, e.clientY);
+          axis.current = null;
+          setFromEvent(e.clientX, e.clientY, e.shiftKey);
         }}
         // shift is read per move, so it can be taken and released mid-drag
         onPointerMove={(e) => { if (pressed.current && e.buttons === 1) setFromEvent(e.clientX, e.clientY, e.shiftKey); }}
-        onPointerUp={() => { pressed.current = false; anchor.current = null; }}
-        onPointerCancel={() => { pressed.current = false; anchor.current = null; }}
-        onLostPointerCapture={() => { pressed.current = false; anchor.current = null; }}
+        onPointerUp={() => { pressed.current = false; anchor.current = null; axis.current = null; wasLocked.current = false; }}
+        onPointerCancel={() => { pressed.current = false; anchor.current = null; axis.current = null; wasLocked.current = false; }}
+        onLostPointerCapture={() => { pressed.current = false; anchor.current = null; axis.current = null; wasLocked.current = false; }}
       >
         <svg className="xypad-grid" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden>
           {PAD_GRID.map((p) => <line key={`v${p}`} className="xypad-line" x1={p} y1={0} x2={p} y2={100} />)}
@@ -400,7 +416,9 @@ function XYPadControl({ def, value, onChange }: RowProps) {
         </svg>
         <span className="xypad-tag xypad-tag-x">X</span>
         <span className="xypad-tag xypad-tag-y">Y</span>
-        <div className="xypad-dot" style={{ left: `${dotX}%`, top: `${dotY}%` }} />
+        <div className="xypad-field">
+          <div className="xypad-dot" style={{ left: `${dotX}%`, top: `${dotY}%` }} />
+        </div>
       </div>
       <div className="xypad-vals">
         <span className="xypad-axis">X</span>


### PR DESCRIPTION
## What

Every number in the control panel can now be typed, and a drag knows which control started it.

## Why

Values could only be set by dragging. The readout already opened an editor on click, but three defects made typing unusable — all measured in the running app:

| Defect | Measured |
|---|---|
| Committed on every keystroke, no clamp | a `max: 360` slider stored **3405**, handle pinned at 100% |
| `Escape` did not revert | editor closed, typed value stayed |
| Typed value skipped the step grid | `18.5` stored while the row displayed `19` |

`XYPadControl` had no typed entry at all — `.xypad-vals` was static text.

Two drag defects surfaced from the same work:

| Gesture | Before |
|---|---|
| Press the readout and drag | value followed the cursor (**8 → 20**): `stopPropagation` on `pointerdown` blocks only the track's own handler, the move keeps bubbling |
| Drag one slider across its neighbour | the neighbour moved too (**100 → 190**): `onPointerMove` trusted `e.buttons` alone, with no idea where the drag began. Same hole in `.xypad`, which also took `setPointerCapture` on `e.target` instead of the pad |

## How

- Click the number to type, with the whole value selected so the first keystroke **replaces** it (selection claimed once per visit, from whichever of focus/click arrives first; the opening `mouseup` is swallowed so it cannot drop a caret mid-value — a second click places it normally).
- `Enter` or blur commits, clamped to min/max and snapped to the same grid dragging uses; `Escape` reverts; `↑`/`↓` nudge by one step (`shift` for a tenth); a comma reads as a decimal separator.
- The XY pad gets one such field per axis (new shared `ExactNumber`).
- A `pressed` ref claimed on `pointerdown` and released on `pointerup` / `pointercancel` / `lostpointercapture` — in the slider and in the pad — so a move only counts when this control was the one pressed.
- The readout opens the editor only if the pointer stayed within 4px, so a drag that happens to start over the number is ignored instead of becoming a text field.
- Field width comes from the content (floor 3 characters, ceiling 8) instead of a fixed 64px box.

## Sizing, measured not guessed

Across the catalogue — 2707 slider defs, 189 XY pads:

| Metric | Value |
|---|---|
| Widest readout with unit | 6 chars — `20.00%`, `2400px`, `-20.0°`, `300.0%` |
| Widest number a field holds | 5 chars — `-45.0`, `300.0`, `2400` |
| Length distribution | 1618 defs at 3 chars, 1136 at 4, 609 at 5, 74 at 6 |
| Offset pad range | ±400 in every pad across all 86 refs, orbit included → `-400` |

A 3-digit cap would have blocked half the catalogue; the fixed 64px box was ~1.7× too wide for the common case. Rendered widths now: 37px for ≤3 chars, 44px for `2400`/`-400`, 52px for `-45.0`, never exceeding the 243px track and never clipping.

## Verification

Measured in the running dev server, not eyeballed:

| Case | Result |
|---|---|
| Click the number (Count, Big Scale, Outer Fade) | editor opens with the value fully selected |
| Type `12` + Enter | committed; a `min: 100` row clamps `12` → `100` |
| `99999` / `abc` / `-` + Enter | clamped / rejected / no `NaN` written |
| `18,5` on a step-1 row | stores 19, readout and handle agree |
| Escape after typing | old value back |
| Press the readout and drag | value unchanged, no editor |
| Drag from the track | 50 → 80, unchanged behaviour |
| Held pointer sweeping a slider it never pressed | inert |
| XY pad: press-drag, phantom sweep, typed `-400` | dot follows / inert / clamped, field 44px |
| `npx tsc --noEmit` | clean |
| `npm test` | exit 0 — 4 suites, 4,049,877 assertions |

## Scope

Only `components/Controls.tsx` and `app/globals.css`. Unrelated work in progress in the working tree (a loader component, 3D and mockup changes, a workflow bump) is deliberately left out of this branch.

## The XY pad, sized to be aimed at

The pad was 112x92 — and not square, so on the same ±400 range a pixel of travel meant 7.1 units across and 8.7 down: the control lied about its own scale.

| | Before | After |
|---|---|---|
| Size | 112 × 92 | **243 × 243** (panel width at 1:1 — the easing card's shape) |
| Units per pixel | 7.1 across / 8.7 down | **3.29 / 3.29** |
| Grid | one bare cross | 12 lines on the eighths + 2 weighted centre lines |
| Axes | unmarked | a tag on each axis, and each number field named |

The readout was `0, 0` — a comma between two numbers that never said which was which. Each field now carries its axis, the way the orientation ball names its three.

Measured in the running app: click at 75%/25% reads `200 / -200`; drag to 10%/90% reads `-320 / 320`; typing `400` puts the dot on the right edge; `X=200, Y=-100` lands the dot at exactly 75% / 37.5%; a sweep after release stays inert.

### Shift keeps a pad drag straight

A drag meant to move one axis never quite does — the hand drifts a few units on the other, and a value that reads `0` is really `-7`. Shift locks the drag to whichever axis it has travelled further along and pins the other to where the press left it.

The anchor is the **press point**, not the previous move, so the line stays straight instead of creeping a pixel per frame; the key is read per move, so it can be taken or released mid-drag.

| Gesture | Reads |
|---|---|
| Centre → 90%/70%, free | `320, 160` |
| Same drag, Shift held | `320, 0` — y pinned |
| Carrying on to 56%/95%, Shift held | `0, 360` — x back on the anchor |
| Shift released mid-drag | `-240, -280` — free again |
| Press with Shift already down | anchors on the press: `-200,-200` → `280, -200` |

Note the pad and the slider read Shift differently, each following its own convention: on a slider Shift is the fine step, on a 2D pad it is the straight line.