### PR TITLE
Unify project persistence across 2D and Mockup editors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1996,3 +1996,214 @@ select.field { padding-right: 26px; }
   .ld-cards i:nth-child(2) { transform: translateX(calc(12px * var(--dir, 1))) scale(.8, .6667); opacity: .55; }
   .ld-cards i:nth-child(3) { transform: translateX(calc(22px * var(--dir, 1))) scale(.6, .4); opacity: .3; }
 }
+
+/* ============================================================
+   PROJECTS TAB — nav: "Projects"
+   A section of its own rather than a list in the left column: the rail keeps
+   its 64px and the projects shelf takes everything else, the way Library and
+   Mockup own the middle of the screen.
+
+   The side columns and the transport are HIDDEN, not unmounted (see
+   DesktopEditor): the shared editor layout exists so the Pixi/Three canvases
+   survive a section change, and tearing the panels down here would defeat it.
+   The stage keeps drawing behind .pj, which is opaque and covers it.
+   ============================================================ */
+.app-projects {
+  grid-template-columns: var(--rail-w) minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  grid-template-areas: "rail stage";
+}
+.app-projects .templates,
+.app-projects .controls,
+.app-projects .right,
+.app-projects .bottom,
+.app-projects .panel-toggle,
+.app-projects .stage-history,
+.app-projects .stage-fs { display: none; }
+
+.pj {
+  position: absolute; inset: 0; z-index: 60;
+  background: var(--card); overflow: auto;
+}
+/* A column, not the full window. Filling 1600px gave six 210px cards in one
+   thin row with a screenful of white under them — a strip, not a shelf. */
+.pj-inner { max-width: 1180px; margin: 0 auto; padding: 0 28px 40px; }
+
+.pj-head {
+  position: sticky; top: 0; z-index: 1;
+  display: flex; align-items: flex-end; justify-content: space-between; gap: 20px;
+  padding: 26px 0 18px; margin-bottom: 22px;
+  background: var(--card); border-bottom: 1px solid var(--line);
+}
+.pj-head-titles { min-width: 0; }
+.pj-title { margin: 0; font-size: 21px; line-height: 1.15; font-weight: 500; letter-spacing: -0.01em; color: var(--fg); }
+.pj-sub { margin: 6px 0 0; font-size: var(--fs-ui); color: var(--fg-faint); }
+.pj-tools { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
+.pj-search { width: 190px; height: var(--ctl-h); }
+.pj-sort { width: auto; }
+.pj-sort .seg { flex: 0 0 auto; padding: 5px 12px; }
+
+.pj-grid {
+  display: grid; align-content: start; gap: 22px 20px;
+  grid-template-columns: repeat(auto-fill, minmax(268px, 1fr));
+}
+
+.pj-card {
+  position: relative; display: flex; flex-direction: column; min-width: 0;
+  background: var(--card);
+}
+/* The picture is the card; the frame around it is a hairline that thickens into
+   the theme's ink when this is the project currently open. No accent colour
+   exists in this design system, so "current" is stated in weight, not in hue. */
+.pj-shot {
+  position: relative; width: 100%; aspect-ratio: 4 / 3;
+  display: grid; place-items: center; overflow: hidden;
+  background: var(--card-inset);
+  border: 1px solid var(--line);
+  transition: border-color var(--t-fast), background var(--t-fast);
+}
+.pj-card:hover .pj-shot { border-color: var(--handle); }
+.pj-card.active .pj-shot { border-color: var(--fg); }
+/* The frame carries the project's canvas ratio (sized inline, see
+   ProjectsBrowser) plus a hairline and a soft lift, so a light poster on a light
+   mat still reads as a picture with an edge instead of dissolving into it. The
+   image fills that frame absolutely: a flowed image's own min-content height can
+   push an aspect-ratio box taller than it should be — measured 278px in a 166px
+   window. Cover, not contain, because the frame is ALREADY the project's ratio;
+   the only thing it can crop is a poster taken before the canvas was resized. */
+.pj-frame {
+  position: relative; display: block;
+  outline: 1px solid var(--stage-edge); outline-offset: -1px;
+  box-shadow: 0 3px 12px var(--stage-shadow);
+}
+.pj-shot-img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; display: block; }
+.pj-noshot {
+  position: absolute; bottom: 8px; left: 50%; transform: translateX(-50%);
+  font-size: var(--fs-meta); line-height: 1; color: var(--fg-faint);
+  background: color-mix(in srgb, var(--card) 86%, transparent);
+  padding: 4px 7px; backdrop-filter: blur(4px);
+}
+.pj-flag {
+  position: absolute; top: 8px; left: 8px;
+  font-size: var(--fs-meta); line-height: 1; letter-spacing: .07em; text-transform: uppercase;
+  color: var(--fg); background: color-mix(in srgb, var(--card) 88%, transparent);
+  border: 1px solid var(--line); padding: 4px 7px; backdrop-filter: blur(4px);
+}
+
+/* Actions ride over the thumbnail. In the name row they collided with any name
+   longer than the card, on every card narrower than ~260px. */
+.pj-actions {
+  position: absolute; top: 7px; right: 7px; z-index: 2;
+  display: flex; gap: 1px; opacity: 0; pointer-events: none;
+  background: color-mix(in srgb, var(--card) 88%, transparent);
+  border: 1px solid var(--line); backdrop-filter: blur(4px);
+  transition: opacity var(--t-fast);
+}
+.pj-card:hover .pj-actions,
+.pj-card:focus-within .pj-actions { opacity: 1; pointer-events: auto; }
+.pj-act {
+  width: 27px; height: 27px; display: grid; place-items: center;
+  color: var(--fg-muted); transition: color var(--t-fast), background var(--t-fast);
+}
+.pj-act:hover { color: var(--fg); background: var(--card-inset); }
+.pj-act.danger { color: var(--gz-x); }
+
+.pj-foot { display: flex; flex-direction: column; gap: 3px; min-width: 0; padding: 10px 1px 0; }
+.pj-name {
+  font-size: var(--fs-label); line-height: 1.3; color: var(--fg-body);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.pj-card.active .pj-name { color: var(--fg); font-weight: 500; }
+.pj-meta { font-size: var(--fs-meta); color: var(--fg-faint); }
+/* The facts row is what makes a card recognisable when the poster is a dark
+   rectangle: template, layer count, saved device, canvas size. */
+.pj-facts { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 5px; }
+.pj-fact {
+  font-size: var(--fs-meta); line-height: 1; color: var(--fg-muted);
+  background: var(--card-inset); padding: 4px 6px; white-space: nowrap;
+}
+.pj-rename { width: 100%; height: 30px; }
+
+/* Deleting is the one action here that cannot be undone, so it asks in place —
+   an armed bin icon somewhere in a grid of look-alike cards is too quiet. */
+.pj-confirm {
+  position: absolute; inset: 0; z-index: 3;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px;
+  padding: 18px; text-align: center;
+  font-size: var(--fs-ui); line-height: 1.4; color: var(--fg-body);
+  background: color-mix(in srgb, var(--card) 94%, transparent);
+  border: 1px solid var(--fg); backdrop-filter: blur(3px);
+}
+.pj-confirm-row { display: flex; gap: 8px; }
+.btn.solid.danger { background: var(--gz-x); color: #ffffff; }
+.btn.solid.danger:hover { background: var(--gz-x); opacity: 0.88; }
+
+/* Create tile — the shelf should show where the next project comes from even
+   when it holds one card. */
+.pj-new {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px;
+  aspect-ratio: 4 / 3; width: 100%;
+  border: 1px dashed var(--handle); color: var(--fg-muted);
+  transition: border-color var(--t-fast), color var(--t-fast), background var(--t-fast);
+}
+.pj-new:hover { border-color: var(--fg); color: var(--fg); background: var(--card-soft); }
+.pj-new-mark { display: grid; place-items: center; }
+.pj-new-label { font-size: var(--fs-label); }
+.pj-new-hint { font-size: var(--fs-meta); color: var(--fg-faint); }
+.pj-empty { grid-column: 1 / -1; font-size: var(--fs-ui); color: var(--fg-faint); }
+
+/* ============================================================
+   PROJECT DOCK — the open project's name and save state, floating at the top
+   of the stage. The editor named neither before, so autosaved work looked
+   unsaved and two different projects looked like the same document.
+   ============================================================ */
+/* Undo/redo owns the stage's top-LEFT corner (63px + its own 10px inset), and
+   the stage column can be as narrow as 320px. Capping the dock against the
+   column keeps a long project name from sliding under those buttons. */
+.pdock { position: absolute; top: 10px; right: 10px; z-index: 45; max-width: calc(100% - 96px); }
+.pdock-chip {
+  display: flex; align-items: center; gap: 8px; max-width: min(320px, 100%);
+  height: 30px; padding: 0 10px;
+  background: color-mix(in srgb, var(--card) 92%, transparent);
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+  backdrop-filter: blur(8px);
+  color: var(--fg-label); font-size: var(--fs-ui);
+  transition: color var(--t-fast), background var(--t-fast);
+}
+.pdock-chip:hover, .pdock-chip.open { background: var(--card); color: var(--fg); }
+.pdock-ico { display: grid; place-items: center; color: var(--fg-faint); flex: 0 0 auto; }
+.pdock-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pdock-state {
+  flex: 0 0 auto; padding-left: 8px; border-left: 1px solid var(--line);
+  color: var(--fg-faint); font-size: var(--fs-meta);
+}
+/* "Saving…" is the only transient state, so it is the only one that moves. */
+.pdock-state.busy { color: var(--fg-muted); animation: pdock-pulse 1.1s ease-in-out infinite; }
+@keyframes pdock-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+@media (prefers-reduced-motion: reduce) { .pdock-state.busy { animation: none; } }
+
+.pdock-menu {
+  position: absolute; top: 36px; right: 0; width: 264px;
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 14px; background: var(--card); border: 1px solid var(--line);
+  box-shadow: 0 14px 34px var(--stage-shadow);
+}
+.pdock-field-label {
+  font-size: var(--fs-eyebrow); letter-spacing: .12em; text-transform: uppercase;
+  color: var(--fg-faint);
+}
+.pdock-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.pdock-hint { font-size: var(--fs-meta); color: var(--fg-faint); line-height: 1.4; }
+.pdock-sep { height: 1px; background: var(--line); margin: 2px 0; }
+.pdock-recents { display: flex; flex-direction: column; }
+.pdock-recent {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+  padding: 7px 8px; margin: 0 -8px; min-width: 0; text-align: left;
+  transition: background var(--t-fast);
+}
+.pdock-recent:hover { background: var(--card-inset); }
+.pdock-recent-name {
+  font-size: var(--fs-ui); color: var(--fg-body); min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.pdock-recent-meta { font-size: var(--fs-meta); color: var(--fg-faint); flex: 0 0 auto; }

--- a/components/DesktopEditor.tsx
+++ b/components/DesktopEditor.tsx
@@ -15,7 +15,8 @@ import IconRail from '@/components/IconRail';
 import ModelColors from '@/components/ModelColors';
 import ModelControl from '@/components/ModelControl';
 import MockupPanel from '@/components/MockupPanel';
-import ProjectsPanel from '@/components/ProjectsPanel';
+import ProjectDock from '@/components/ProjectDock';
+import ProjectsBrowser from '@/components/ProjectsBrowser';
 import ScenePanel from '@/components/ScenePanel';
 import ScreenContent from '@/components/ScreenContent';
 import TemplatesCard from '@/components/TemplatesCard';
@@ -59,12 +60,18 @@ export default function DesktopEditor() {
   }, [isMockup, is3D]);
 
   return (
-    <div className={`app ${isWeb || isBoard ? 'app-web' : ''} ${tplCollapsed ? 'app-tpl-collapsed' : ''} ${leftCollapsed ? 'left-collapsed' : ''} ${rightCollapsed ? 'right-collapsed' : ''}`}>
+    <div className={`app ${isWeb || isBoard ? 'app-web' : ''} ${isProjects ? 'app-projects' : ''} ${tplCollapsed ? 'app-tpl-collapsed' : ''} ${leftCollapsed ? 'left-collapsed' : ''} ${rightCollapsed ? 'right-collapsed' : ''}`}>
       <IconRail />
 
-      {tplCollapsed ? <CollapsedStrip /> : isProjects ? <ProjectsPanel /> : is3D ? <Effects3DPanel /> : isMockup ? <MockupPanel /> : <TemplatesCard controlsInline={isBoard} />}
+      {/* Projects is a tab of its own: it takes the middle of the screen (see
+          the stage below) instead of listing files in the left column while the
+          stage keeps showing whichever project happens to be open. The side
+          columns and the transport are hidden by .app-projects rather than
+          unmounted — the whole point of the shared editor layout is that the
+          Pixi/Three canvases survive a section change. */}
+      {isProjects ? null : tplCollapsed ? <CollapsedStrip /> : is3D ? <Effects3DPanel /> : isMockup ? <MockupPanel /> : <TemplatesCard controlsInline={isBoard} />}
 
-      {!isWeb && !isBoard && (
+      {!isWeb && !isBoard && !isProjects && (
         <section className="card controls card-scroll">
           {is3D || isMockup ? (
             <>
@@ -87,6 +94,7 @@ export default function DesktopEditor() {
       )}
 
       <main className="stage-col">
+        {isProjects && <ProjectsBrowser />}
         {isBoard ? <BoardStage /> : isWeb ? <WebStage /> : is3D || isMockup ? <ThreeStage3D effectId={isMockup ? 'mockup' : undefined} /> : (
           <>
             <PreviewStage />
@@ -95,6 +103,9 @@ export default function DesktopEditor() {
             </button>
           </>
         )}
+        {/* Which project is open, and whether it is saved. Not in the Projects
+            tab: there the whole screen is that answer. */}
+        {!isProjects && <ProjectDock />}
         <HistoryControls />
         <button className="panel-toggle panel-toggle-left" onClick={toggleLeftPanel} aria-expanded={!leftCollapsed} aria-label={leftCollapsed ? 'Expand left sidebar' : 'Collapse left sidebar'} title={leftCollapsed ? 'Expand left sidebar' : 'Collapse left sidebar'}>
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 3.5L10.5 8 6 12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
@@ -105,7 +116,7 @@ export default function DesktopEditor() {
       </main>
 
       <section className="card right card-scroll">
-        {isBoard ? <BoardPanel /> : isWeb ? (
+        {isProjects ? null : isBoard ? <BoardPanel /> : isWeb ? (
           <><WebSelectionPanel /><div className="hairline" /><WebScenePanel /></>
         ) : is3D ? (
           <><CanvasPanel is3DMode /><div className="hairline" /><BackgroundFill /></>

--- a/components/EditorShell.tsx
+++ b/components/EditorShell.tsx
@@ -6,8 +6,10 @@ import { usePathname } from 'next/navigation';
 import AppTour from '@/components/AppTour';
 import { StrataLoader } from '@/components/StrataLoader';
 import WelcomeDialog from '@/components/WelcomeDialog';
-import { sectionFromPathname } from '@/lib/navSections';
-import { startSceneAutosave } from '@/lib/scenePersist';
+import { modeForSection, sectionFromPathname } from '@/lib/navSections';
+import { capturePoster } from '@/lib/projectPoster';
+import { flushScene, startSceneAutosave } from '@/lib/scenePersist';
+import { flushThreeD, startThreeDAutosave } from '@/lib/three3dPersist';
 import { useHistoryStore } from '@/store/useHistoryStore';
 import { useProjectStore } from '@/store/useProjectStore';
 import { useUIStore } from '@/store/useUIStore';
@@ -30,6 +32,10 @@ const DesktopEditor = dynamic(() => import('@/components/DesktopEditor'), {
 // grid actually fits. Keep this in step with the same breakpoint in
 // app/globals.css and components/ExportDialog.tsx.
 const MOBILE_QUERY = '(max-width: 919px)';
+
+// Belt-and-braces save interval, asked for explicitly. The autosaves are the
+// real save path; this is the floor under them.
+const SAVE_HEARTBEAT_MS = 5 * 60_000;
 type ViewportMode = 'pending' | 'mobile' | 'desktop';
 
 function useViewportMode(): ViewportMode {
@@ -68,6 +74,11 @@ export default function EditorShell({ children }: { children?: React.ReactNode }
   const pathname = usePathname();
   const section = sectionFromPathname(pathname);
   const seeded = useRef(false);
+  const projects = useProjectStore((s) => s.projects);
+  const activeProjectId = useProjectStore((s) => s.activeId);
+  const projectsBooted = useProjectStore((s) => s.booted);
+  const openProject = useProjectStore((s) => s.open);
+  const createProject = useProjectStore((s) => s.create);
 
   // Seed the store during the first render rather than in the effect below:
   // an effect lands after the editor's first paint, so a deep link to /mockup
@@ -75,27 +86,64 @@ export default function EditorShell({ children }: { children?: React.ReactNode }
   // subscriber is mounted yet — DesktopEditor is rendered by this component.
   if (!seeded.current) {
     seeded.current = true;
-    if (useUIStore.getState().nav !== section) useUIStore.setState({ nav: section });
+    // Through the action, not setState: setNav also records the last EDITING
+    // section, which the Projects tab hands back to when a project is opened.
+    if (useUIStore.getState().nav !== section) useUIStore.getState().setNav(section);
   }
 
   // Later changes — rail clicks, back/forward, a pasted URL. Rail clicks also
   // set the store optimistically, so this mostly matters for history moves.
   useEffect(() => {
-    if (useUIStore.getState().nav !== section) useUIStore.setState({ nav: section });
+    // Through the action, not setState: setNav also records the last EDITING
+    // section, which the Projects tab hands back to when a project is opened.
+    if (useUIStore.getState().nav !== section) useUIStore.getState().setNav(section);
   }, [section]);
 
   useEffect(() => {
     useUIStore.getState().hydratePreferences();
-    useProjectStore.getState().bootstrap();
+    useProjectStore.getState().bootstrap(modeForSection(section));
     const stopHistory = useHistoryStore.getState().start();
     const stopAutosave = startSceneAutosave();
-    // No 3D equivalent on purpose: the Mockup studio is saved from its own
-    // button (see MockupPanel), not on every store tick.
+    // The Mockup/3D studio autosaves too. It used to be explicit-only, which
+    // read as "the mockup doesn't save": leaving the section never wrote, so an
+    // arrangement survived only if the button in the Mockup panel was found and
+    // clicked. That button is gone; "Save now" lives in the project dock, next
+    // to the state of these two autosaves.
+    const stopThreeDAutosave = startThreeDAutosave();
+
+    // Five-minute heartbeat on top of the two autosaves. They already write
+    // within half a second of an edit, so this is a backstop, not the save
+    // path: it catches anything a dirty-check skipped, and it is the moment the
+    // project's card picture is refreshed for a long editing session that never
+    // touches the rail. Both flushes are no-ops when nothing changed, so an idle
+    // tab costs two signature comparisons every five minutes and no writes.
+    const heartbeat = setInterval(() => {
+      const wroteScene = flushScene();
+      const wroteStudio = flushThreeD();
+      if (wroteScene || wroteStudio) capturePoster(useProjectStore.getState().activeId);
+    }, SAVE_HEARTBEAT_MS);
+
     return () => {
       stopHistory();
       stopAutosave();
+      stopThreeDAutosave();
+      clearInterval(heartbeat);
     };
   }, []);
+
+  // Library and Mockup are two document modes in one project list. Entering a
+  // mode selects its most recent project; if none exists yet, it creates one.
+  // This keeps the inactive store target null, so one project can never save
+  // both documents just because the user clicked another rail tab.
+  useEffect(() => {
+    if (!projectsBooted || (section !== 'library' && section !== 'mockup')) return;
+    const wanted = modeForSection(section);
+    const active = projects.find((project) => project.id === activeProjectId);
+    if (active?.mode === wanted) return;
+    const existing = projects.find((project) => project.mode === wanted);
+    if (existing) openProject(existing.id);
+    else createProject(`Project ${projects.length + 1}`, wanted);
+  }, [activeProjectId, createProject, openProject, projects, projectsBooted, section]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -3,9 +3,10 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { NAV_SECTIONS, sectionFromPathname, type NavSectionId } from '@/lib/navSections';
+import { modeForSection, NAV_SECTIONS, sectionFromPathname, type NavSectionId } from '@/lib/navSections';
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
+import { capturePoster } from '@/lib/projectPoster';
 import { AddIcon, BoardIcon, ChevronDownIcon, ExperimentalsIcon, LibraryIcon, MockupIcon, MoonIcon, ProjectsIcon, SunIcon, ThreeDIcon, WebIcon } from './EditorIcons';
 
 const ICONS: Record<NavSectionId, React.ReactNode> = {
@@ -34,10 +35,19 @@ export default function IconRail() {
   const [experimentalsOpen, setExperimentalsOpen] = useState(false);
   const experimentalActive = EXPERIMENTAL_NAV.some((item) => item.id === active);
 
+  // Leaving a section is the one moment the stage still shows what the user was
+  // working on AND we know they're about to look elsewhere — so that is when the
+  // project's card picture is grabbed. Reading the id at click time keeps the
+  // rail from re-rendering on every project switch.
+  const leaveSection = (next: NavSectionId) => {
+    if (next !== active) capturePoster(useProjectStore.getState().activeId);
+    setNav(next);
+  };
+
   // An ACTION, not a nav section — so it never takes the active state. The +
   // icon at the top of the rail now creates what it looks like it creates.
   const newProject = () => {
-    createProject(`Project ${projectCount + 1}`);
+    createProject(`Project ${projectCount + 1}`, modeForSection(active));
     setNav('projects');
     router.push('/projects');
   };
@@ -68,7 +78,7 @@ export default function IconRail() {
             // Setting the store on click as well as on the URL change keeps the
             // panel swap on the same frame as the click: the mirror in
             // EditorShell is an effect, which lands a frame later.
-            onClick={() => setNav(n.id)}
+            onClick={() => leaveSection(n.id)}
             aria-current={active === n.id ? 'page' : undefined}
             className={`rail-item ${active === n.id ? 'active' : ''}`}
           >
@@ -97,7 +107,7 @@ export default function IconRail() {
                 key={n.id}
                 href={n.href}
                 tabIndex={experimentalsOpen ? 0 : -1}
-                onClick={() => setNav(n.id)}
+                onClick={() => leaveSection(n.id)}
                 aria-current={active === n.id ? 'page' : undefined}
                 className={`rail-item rail-subitem ${active === n.id ? 'active' : ''}`}
               >

--- a/components/MockupPanel.tsx
+++ b/components/MockupPanel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
-import { saveThreeD } from '@/lib/three3dPersist';
+import React, { useState } from 'react';
 import { use3DStore, defaultModelFor } from '@/store/use3DStore';
 import { DEVICES, findDevice, selectDevice } from '@/three3d/devices';
 import { MOCKUP_ANIMATIONS } from '@/three3d/animations';
@@ -24,19 +23,10 @@ export default function MockupPanel() {
   const activeDevice = findDevice(modelUrl);
   const [openDevice, setOpenDevice] = useState<string | null>(activeDevice?.key ?? null);
 
-  // Confirmation is transient rather than a permanent "saved" state: the studio
-  // becomes dirty again on the very next control the user touches, and a label
-  // that stayed on "Saved" would be lying by the second click.
-  const [saved, setSaved] = useState(false);
-  const savedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  useEffect(() => () => clearTimeout(savedTimer.current), []);
-  const onSave = () => {
-    if (!saveThreeD()) return; // no open project, or storage refused the write
-    setSaved(true);
-    clearTimeout(savedTimer.current);
-    savedTimer.current = setTimeout(() => setSaved(false), 1600);
-  };
-
+  // No save button here any more. The studio autosaves into the open project,
+  // and the one place that says so — and offers "Save now" — is the project chip
+  // on the stage (components/ProjectDock). A second save control in this footer,
+  // scoped to only half the document, was the reason saving read as unreliable.
   const handleDeviceClick = (key: string) => {
     if (openDevice === key) {
       setOpenDevice(null);
@@ -97,16 +87,6 @@ export default function MockupPanel() {
         })}
       </div>
 
-      {/* Saving the studio is explicit, the same shape as "Save as custom" in
-          the templates panel. The 2D scene autosaves because it is the timeline
-          being continuously edited; a mockup is arranged and then kept, and an
-          autosave meant a stray drag of the model quietly became the project's
-          saved state. */}
-      <div className="tpl-foot">
-        <button className="btn full" onClick={onSave} disabled={saved}>
-          {saved ? 'Saved' : 'Save mockup to project'}
-        </button>
-      </div>
     </section>
   );
 }

--- a/components/ProjectDock.tsx
+++ b/components/ProjectDock.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { useRouter } from 'next/navigation';
+import { sectionForProject } from '@/lib/navSections';
+import type { ProjectMeta } from '@/lib/projects';
+import { capturePoster } from '@/lib/projectPoster';
+import { ago } from '@/lib/relativeTime';
+import { getSaveStatus, subscribeSaveStatus } from '@/lib/saveStatus';
+import { flushScene } from '@/lib/scenePersist';
+import { flushThreeD } from '@/lib/three3dPersist';
+import { useProjectStore } from '@/store/useProjectStore';
+import { useUIStore } from '@/store/useUIStore';
+import { ProjectsIcon } from './EditorIcons';
+
+// ============================================================
+//  PROJECT DOCK — which project am I in, and is it saved?
+//
+//  The editor never said either. Nothing on the desktop screen named the open
+//  project, and the only save the UI admitted to was a button in the Mockup
+//  panel — so work that WAS being autosaved looked unsaved, and work in another
+//  project looked like the same document.
+//
+//  So: a chip at the top of the stage carrying the project name and the state of
+//  the autosave, and a menu for the three things you actually want from it —
+//  rename, save right now, jump to another project.
+// ============================================================
+
+const RECENTS = 4;   // enough to switch between what you're juggling, not a list
+
+function statusLabel(pending: boolean, savedAt: number | null, tick: number): string {
+  void tick;                                     // re-renders on the clock, see below
+  if (pending) return 'Saving…';
+  if (savedAt === null) return 'Not saved yet';
+  // Under a minute, "Saved" alone is truer than "saved 0 min ago" and quieter.
+  return Date.now() - savedAt < 45_000 ? 'Saved' : `Saved ${ago(savedAt)}`;
+}
+
+export default function ProjectDock() {
+  const projects = useProjectStore((s) => s.projects);
+  const activeId = useProjectStore((s) => s.activeId);
+  const open = useProjectStore((s) => s.open);
+  const rename = useProjectStore((s) => s.rename);
+  const refresh = useProjectStore((s) => s.refresh);
+  const setNav = useUIStore((s) => s.setNav);
+  const router = useRouter();
+
+  const status = useSyncExternalStore(subscribeSaveStatus, getSaveStatus, getSaveStatus);
+  // "Saved" has to age into "Saved 3 min ago" on its own — nothing writes to the
+  // store while the user reads, so the clock is the only thing that changes.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [draftName, setDraftName] = useState('');
+  const [savedFlash, setSavedFlash] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => () => clearTimeout(flashTimer.current), []);
+
+  const active = projects.find((p) => p.id === activeId) ?? null;
+
+  // Pointer-down rather than click: a click listener on the document fires after
+  // the element under the pointer has already been re-rendered, so closing on
+  // click can swallow the very button the user aimed at.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setMenuOpen(false); };
+    document.addEventListener('pointerdown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [menuOpen]);
+
+  const openMenu = () => {
+    refresh();                       // dates and names may have moved on disk
+    setDraftName(active?.name ?? '');
+    setMenuOpen(true);
+  };
+
+  const commitName = () => {
+    const next = draftName.trim();
+    if (active && next && next !== active.name) rename(active.id, next);
+  };
+
+  const saveNow = () => {
+    if (active?.mode === 'mockup') flushThreeD();
+    else flushScene();
+    capturePoster(activeId);         // and refresh the card picture while here
+    setSavedFlash(true);
+    clearTimeout(flashTimer.current);
+    flashTimer.current = setTimeout(() => setSavedFlash(false), 1400);
+  };
+
+  const goToProjects = () => {
+    setMenuOpen(false);
+    capturePoster(activeId);
+    setNav('projects');
+    router.push('/projects');
+  };
+
+  // Same fixed mode rule as the Projects tab.
+  const switchTo = (project: ProjectMeta) => {
+    setMenuOpen(false);
+    open(project.id);
+    const target = sectionForProject(project.mode);
+    if (useUIStore.getState().nav !== target.id) {
+      setNav(target.id);
+      router.push(target.href);
+    }
+  };
+
+  if (!active) return null;
+  const recents = projects.filter((p) => p.id !== active.id).slice(0, RECENTS);
+  const label = statusLabel(status.pending, status.savedAt, tick);
+
+  return (
+    <div className="pdock" ref={rootRef}>
+      <button
+        className={`pdock-chip ${menuOpen ? 'open' : ''}`}
+        onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())}
+        aria-expanded={menuOpen}
+        title="Project"
+      >
+        <span className="pdock-ico"><ProjectsIcon size={13} /></span>
+        <span className="pdock-name">{active.name}</span>
+        <span className={`pdock-state ${status.pending ? 'busy' : ''}`}>{label}</span>
+      </button>
+
+      {menuOpen && (
+        <div className="pdock-menu" role="dialog" aria-label="Project">
+          <label className="pdock-field-label" htmlFor="pdock-name">Project name</label>
+          <input
+            id="pdock-name"
+            className="field"
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+            onBlur={commitName}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') { commitName(); setMenuOpen(false); }
+              if (e.key === 'Escape') setDraftName(active.name);
+            }}
+          />
+
+          <div className="pdock-row">
+            <span className="pdock-hint">
+              {status.pending
+                ? 'Writing your changes…'
+                : status.savedAt
+                  ? `Autosaved to this browser · ${new Date(status.savedAt).toLocaleTimeString()}`
+                  : 'Autosaves as you work.'}
+            </span>
+          </div>
+          <button className="btn full" onClick={saveNow} disabled={savedFlash}>
+            {savedFlash ? 'Saved' : 'Save now'}
+          </button>
+
+          {recents.length > 0 && (
+            <>
+              <div className="pdock-sep" />
+              <span className="pdock-field-label">Switch to</span>
+              <div className="pdock-recents">
+                {recents.map((p) => (
+                  <button key={p.id} className="pdock-recent" onClick={() => switchTo(p)}>
+                    <span className="pdock-recent-name">{p.name}</span>
+                    <span className="pdock-recent-meta">{ago(p.updatedAt)}</span>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+
+          <div className="pdock-sep" />
+          <button className="btn full" onClick={goToProjects}>All projects</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ProjectsBrowser.tsx
+++ b/components/ProjectsBrowser.tsx
@@ -1,0 +1,393 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { modeForSection, sectionForProject } from '@/lib/navSections';
+import { loadPoster, subscribePosters } from '@/lib/projectPoster';
+import { readProjectScene, type ProjectMeta } from '@/lib/projects';
+import { ago } from '@/lib/relativeTime';
+import { readProjectThreeD } from '@/lib/three3dPersist';
+import { templates } from '@/templates';
+import { useProjectStore } from '@/store/useProjectStore';
+import { useUIStore } from '@/store/useUIStore';
+
+// ============================================================
+//  PROJECTS TAB — the section's own full-width view
+//
+//  Projects used to be a list in the left column while the stage behind it kept
+//  showing the open project, so picking one was a blind swap: the panel named
+//  files, it never showed them. Here the section behaves like the other tabs —
+//  it owns the middle of the screen — and every card carries the last picture of
+//  its stage (lib/projectPoster), so you recognise the work before opening it.
+//
+//  Where a card has no picture yet (a project last touched before posters
+//  existed, or one never opened) it falls back to a sketch built from the SAVED
+//  scene: the real canvas ratio and the real background, with the template name
+//  in the card's own meta line rather than stamped over the artwork.
+//
+//  Layout notes worth keeping:
+//  - The grid is inside a max-width column. Left to fill a 1600px window it made
+//    six 210px cards in one thin row with a screen of white under them: a file
+//    browser reads as a shelf, not as a strip.
+//  - Row actions live over the thumbnail, not in the name row. In the name row
+//    they collided with long project names on every card narrower than ~260px.
+// ============================================================
+
+const SEARCH_THRESHOLD = 6;   // below this, a filter box is just another control
+type Sort = 'recent' | 'name';
+
+/** The poster bytes for one project as an object URL, refreshed on each capture. */
+function usePosterUrl(projectId: string): string | null {
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let dead = false;
+    let own: string | null = null;
+    const load = () => {
+      loadPoster(projectId).then((blob) => {
+        if (dead) return;
+        const next = blob ? URL.createObjectURL(blob) : null;
+        if (own) URL.revokeObjectURL(own);
+        own = next;
+        setUrl(next);
+      });
+    };
+    load();
+    // A capture writes to IndexedDB, which no React state watches — so the
+    // module tells its cards to read again.
+    const off = subscribePosters(load);
+    return () => {
+      dead = true;
+      off();
+      if (own) URL.revokeObjectURL(own);
+    };
+  }, [projectId]);
+
+  return url;
+}
+
+interface Sketch {
+  ratio: number;          // canvas aspect, so the placeholder has the project's shape
+  bg: string;             // the scene's own background, as a CSS value
+  template: string | null;
+  size: string | null;    // "1080 × 1350"
+  layers: number;
+  device: string | null;  // the saved Mockup device, when the project has one
+  animation: string | null;
+  screen: boolean;        // artwork loaded onto the device's screen
+}
+
+// 'tilt-slow' → 'Tilt slow'. The preset table lives in three3d/animations, which
+// imports three.js — not something the Projects tab should pull in for a label.
+function humanize(key: string): string {
+  const words = key.replace(/[-_]+/g, ' ').trim();
+  return words ? words[0].toUpperCase() + words.slice(1) : '';
+}
+
+function sketchFor(p: ProjectMeta): Sketch {
+  const scene = p.mode === '2d' ? readProjectScene(p.id) : null;
+  const studio = p.mode === 'mockup' ? readProjectThreeD(p.id) : null;
+  const w = studio?.canvas?.width || scene?.width || 1080;
+  const h = studio?.canvas?.height || scene?.height || 1350;
+  const bgSpec = scene?.background;
+  const bg = bgSpec
+    ? bgSpec.gradient
+      ? `linear-gradient(160deg, ${bgSpec.color} 0%, ${bgSpec.color2} 100%)`
+      : bgSpec.color
+    : 'var(--card-thumb)';
+  const tracks = scene?.tracks ?? [];
+  const templateId = scene?.activeTemplateId ?? tracks[0]?.templateId;
+  const template = templateId ? templates[templateId]?.meta.name ?? templateId : null;
+  const animation = studio?.mockupAnimation && studio.mockupAnimation !== 'static'
+    ? humanize(studio.mockupAnimation)
+    : null;
+  return {
+    ratio: w / h,
+    bg,
+    template,
+    size: scene || studio ? `${w} × ${h}` : null,
+    layers: tracks.length,
+    device: studio?.models?.mockup?.name ?? null,
+    animation,
+    screen: Object.values(studio?.screenMedia ?? {}).some((m) => !!m),
+  };
+}
+
+/**
+ * Size the picture frame inside the 4:3 window. ONE axis is fixed and the other
+ * is left to aspect-ratio: fixing both (a size plus a max- in the other axis)
+ * silently breaks the ratio the moment the max clamps — and the frame exists to
+ * state the project's shape. The sketch also paints the scene's background;
+ * a poster brings its own pixels.
+ */
+function frameStyle(sketch: Sketch, poster: string | null): React.CSSProperties {
+  const axis = sketch.ratio < 4 / 3 ? { height: '76%' } : { width: '82%' };
+  return { aspectRatio: String(sketch.ratio), ...axis, ...(poster ? null : { background: sketch.bg }) };
+}
+
+const RenameIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M10.5 2.5l3 3-8 8H2.5v-3l8-8z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/></svg>
+);
+const DuplicateIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><rect x="2.5" y="2.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.3"/><path d="M5.5 13.5h6a2 2 0 002-2v-6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
+);
+const BinIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 5h10M6.5 5V3.5h3V5M5 5l.6 8h4.8L11 5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/></svg>
+);
+const PlusIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 20 20" fill="none"><path d="M10 4.5v11M4.5 10h11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+);
+
+export default function ProjectsBrowser() {
+  const projects = useProjectStore((s) => s.projects);
+  const activeId = useProjectStore((s) => s.activeId);
+  const open = useProjectStore((s) => s.open);
+  const create = useProjectStore((s) => s.create);
+  const duplicate = useProjectStore((s) => s.duplicate);
+  const rename = useProjectStore((s) => s.rename);
+  const remove = useProjectStore((s) => s.remove);
+  const refresh = useProjectStore((s) => s.refresh);
+  const setNav = useUIStore((s) => s.setNav);
+  const lastEditorNav = useUIStore((s) => s.lastEditorNav);
+  const router = useRouter();
+
+  // Both autosaves stamp updatedAt straight into localStorage without going
+  // through this store, so the list it holds can be stale by the time the tab
+  // opens: measured a card reading "edited 13 h ago" seconds after the write.
+  // Re-reading the index on mount is one localStorage parse.
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const [query, setQuery] = useState('');
+  const [sort, setSort] = useState<Sort>('recent');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  // Deleting a project throws away its scene, so it asks first.
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+
+  const shown = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const list = q ? projects.filter((p) => p.name.toLowerCase().includes(q)) : projects.slice();
+    // `projects` already arrives most-recent-first (lib/projects sorts the index).
+    return sort === 'name' ? list.sort((a, b) => a.name.localeCompare(b.name)) : list;
+  }, [projects, query, sort]);
+
+  // Opening a project means going to its fixed editor mode. Navigation history
+  // cannot turn a 2D project into a mockup or vice versa.
+  //
+  // Same optimistic setNav as the rail: the URL is the source of truth, but a
+  // first navigation to an uncompiled route takes seconds in dev.
+  const openProject = (project: ProjectMeta) => {
+    if (project.id !== activeId) open(project.id);
+    const target = sectionForProject(project.mode);
+    setNav(target.id);
+    router.push(target.href);
+  };
+
+  // Create and stay here, with the new card's name selected — a project is named
+  // at birth or never, and dropping straight into the editor is what the card
+  // click is for. The kind comes from the group the button belongs to, so a
+  // mockup project is a mockup project from the moment it exists.
+  const newProject = () => {
+    const name = `Project ${projects.length + 1}`;
+    create(name, modeForSection(lastEditorNav));
+    setQuery('');
+    setEditingId(null);
+    setEditName(name);
+    // The store's activeId is the project just created; pick it up after the
+    // state lands rather than guessing its id here.
+    queueMicrotask(() => {
+      const id = useProjectStore.getState().activeId;
+      if (id) setEditingId(id);
+    });
+  };
+
+  const commitRename = (id: string) => {
+    if (editName.trim()) rename(id, editName.trim());
+    setEditingId(null);
+    setEditName('');
+  };
+
+  return (
+    <div className="pj">
+      <div className="pj-inner">
+        <header className="pj-head">
+          <div className="pj-head-titles">
+            <h1 className="pj-title">Projects</h1>
+            <p className="pj-sub">
+              {projects.length === 0
+                ? 'Nothing saved in this browser yet'
+                : `${projects.length} ${projects.length === 1 ? 'project' : 'projects'} saved in this browser · autosaved as you work`}
+              {shown.length !== projects.length ? ` · ${shown.length} shown` : ''}
+            </p>
+          </div>
+
+          <div className="pj-tools">
+            {projects.length >= SEARCH_THRESHOLD && (
+              <input
+                className="field pj-search"
+                placeholder="Search projects"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+            )}
+            {projects.length > 1 && (
+              <div className="segmented pj-sort">
+                <button className={`seg ${sort === 'recent' ? 'active' : ''}`} onClick={() => setSort('recent')}>Recent</button>
+                <button className={`seg ${sort === 'name' ? 'active' : ''}`} onClick={() => setSort('name')}>Name</button>
+              </div>
+            )}
+            <button className="btn solid" onClick={newProject}>New project</button>
+          </div>
+        </header>
+
+        {/* One shelf, two document modes. The type chip on each card says which
+            editor and which persistence slice that project owns. */}
+        <div className="pj-grid">
+          {shown.map((p) => (
+            <ProjectCard
+              key={p.id}
+              project={p}
+              isActive={p.id === activeId}
+              isEditing={editingId === p.id}
+              isConfirming={confirmId === p.id}
+              editName={editName}
+              onOpen={() => openProject(p)}
+              onEditName={setEditName}
+              onStartRename={() => { setEditingId(p.id); setEditName(p.name); setConfirmId(null); }}
+              onCommitRename={() => commitRename(p.id)}
+              onCancelRename={() => { setEditingId(null); setEditName(''); }}
+              onDuplicate={() => duplicate(p.id)}
+              onDelete={() => (confirmId === p.id ? (remove(p.id), setConfirmId(null)) : setConfirmId(p.id))}
+              onCancelDelete={() => setConfirmId(null)}
+            />
+          ))}
+
+          {/* The create affordance sits IN the grid as well as in the header: a
+              shelf with one card should still show where the next one comes
+              from. Hidden while filtering — a tile that ignores the query would
+              read as a result. */}
+          {!query.trim() && (
+            <button className="pj-new" onClick={newProject}>
+              <span className="pj-new-mark"><PlusIcon /></span>
+              <span className="pj-new-label">New project</span>
+              <span className="pj-new-hint">Starts empty · pick a template</span>
+            </button>
+          )}
+
+          {shown.length === 0 && query.trim() && (
+            <p className="pj-empty">Nothing matches “{query.trim()}”.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProjectCard({
+  project,
+  isActive,
+  isEditing,
+  isConfirming,
+  editName,
+  onOpen,
+  onEditName,
+  onStartRename,
+  onCommitRename,
+  onCancelRename,
+  onDuplicate,
+  onDelete,
+  onCancelDelete,
+}: {
+  project: ProjectMeta;
+  isActive: boolean;
+  isEditing: boolean;
+  isConfirming: boolean;
+  editName: string;
+  onOpen: () => void;
+  onEditName: (v: string) => void;
+  onStartRename: () => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  onCancelDelete: () => void;
+}) {
+  const poster = usePosterUrl(project.id);
+  // Re-read on every stamped edit: a rename or a save changes what the sketch
+  // should say, and the scene it reads from is localStorage, not React state.
+  const sketch = useMemo(() => sketchFor(project), [project.id, project.updatedAt]);   // eslint-disable-line react-hooks/exhaustive-deps
+
+  const facts = (project.mode === 'mockup'
+    ? ['Mockup', sketch.device ?? 'No device yet', sketch.animation, sketch.screen ? 'Screen art' : null, sketch.size]
+    : ['2D', sketch.template, sketch.layers > 0 ? `${sketch.layers} ${sketch.layers === 1 ? 'layer' : 'layers'}` : 'Empty', sketch.size]
+  ).filter(Boolean) as string[];
+
+  return (
+    <article className={`pj-card ${isActive ? 'active' : ''} ${isConfirming ? 'confirming' : ''}`}>
+      <button
+        className="pj-shot"
+        onClick={onOpen}
+        title={isActive ? `Continue in ${project.name}` : `Open ${project.name}`}
+      >
+        {/* Poster and sketch get the SAME treatment: a frame at the project's
+            own canvas ratio, sitting on the mat with a hairline of its own. A
+            poster stretched edge to edge with object-fit: contain has no visible
+            edge, so a light scene dissolved into the light mat and read as a
+            washed-out blob rather than as a picture. */}
+        <span className={`pj-frame ${poster ? '' : 'sketch'}`} style={frameStyle(sketch, poster)}>
+          {poster && <img className="pj-shot-img" src={poster} alt="" draggable={false} />}
+        </span>
+        {isActive && <span className="pj-flag">Open</span>}
+        {!poster && <span className="pj-noshot">No preview yet</span>}
+      </button>
+
+      {/* Over the thumbnail, revealed on hover/focus — see the layout note at
+          the top of the file. */}
+      <div className="pj-actions">
+        <button className="pj-act" title="Rename" onClick={onStartRename}><RenameIcon /></button>
+        <button className="pj-act" title="Duplicate" onClick={onDuplicate}><DuplicateIcon /></button>
+        <button className={`pj-act ${isConfirming ? 'danger' : ''}`} title={isConfirming ? 'Click again to delete' : 'Delete'} onClick={onDelete}><BinIcon /></button>
+      </div>
+
+      <div className="pj-foot">
+        {isEditing ? (
+          <input
+            className="field pj-rename"
+            autoFocus
+            value={editName}
+            onChange={(e) => onEditName(e.target.value)}
+            onBlur={onCommitRename}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') onCommitRename();
+              if (e.key === 'Escape') onCancelRename();
+            }}
+          />
+        ) : (
+          <>
+            <span className="pj-name" title={project.name}>{project.name}</span>
+            {/* The open project keeps its date too: "open now" alone dropped the
+                one fact every other card in the row states. */}
+            <span className="pj-meta">
+              {isActive ? `open now · edited ${ago(project.updatedAt)}` : `edited ${ago(project.updatedAt)}`}
+            </span>
+            {facts.length > 0 && (
+              <span className="pj-facts">
+                {facts.map((f) => <span key={f} className="pj-fact">{f}</span>)}
+              </span>
+            )}
+          </>
+        )}
+      </div>
+
+      {isConfirming && (
+        <div className="pj-confirm">
+          <span>Delete “{project.name}”? Its saved document goes with it.</span>
+          <div className="pj-confirm-row">
+            <button className="btn" onClick={onCancelDelete}>Keep</button>
+            <button className="btn solid danger" onClick={onDelete}>Delete</button>
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/components/ProjectsPanel.tsx
+++ b/components/ProjectsPanel.tsx
@@ -1,21 +1,11 @@
 'use client';
 
 import { useState } from 'react';
+import { ago } from '@/lib/relativeTime';
 import { useProjectStore } from '@/store/useProjectStore';
 
-// Relative time, coarse on purpose — an exact timestamp is noise in a list you
-// scan to find "the one I was just working on".
-function ago(ms: number): string {
-  const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
-  if (s < 60) return 'just now';
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m} min ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h} h ago`;
-  const d = Math.floor(h / 24);
-  return d === 1 ? 'yesterday' : `${d} days ago`;
-}
-
+// The mobile projects sheet. On desktop the section is the full-width Projects
+// tab instead (components/ProjectsBrowser).
 export default function ProjectsPanel({ onProjectOpen }: { onProjectOpen?: () => void } = {}) {
   const projects = useProjectStore((s) => s.projects);
   const activeId = useProjectStore((s) => s.activeId);

--- a/lib/navSections.ts
+++ b/lib/navSections.ts
@@ -1,3 +1,5 @@
+import type { ProjectMode } from './projects';
+
 // The editor's sections in one place: the IconRail renders its buttons from
 // this list, the route folders under app/(editor) are named after the slugs,
 // and EditorShell maps the current URL back to the nav id every panel reads
@@ -42,4 +44,15 @@ const SECTION_IDS = new Set<string>(NAV_SECTIONS.map((section) => section.id));
 export function sectionFromPathname(pathname: string | null | undefined): NavSectionId {
   const segment = (pathname ?? '').split('?')[0].split('/').filter(Boolean)[0];
   return segment && SECTION_IDS.has(segment) ? (segment as NavSectionId) : DEFAULT_SECTION;
+}
+
+/** Convert the current editor tab into the type of document it creates. */
+export function modeForSection(section: string | null | undefined): ProjectMode {
+  return section === 'mockup' ? 'mockup' : '2d';
+}
+
+/** A project's mode is fixed, so its route no longer depends on navigation history. */
+export function sectionForProject(mode: ProjectMode): NavSection {
+  const id: NavSectionId = mode === 'mockup' ? 'mockup' : 'library';
+  return NAV_SECTIONS.find((section) => section.id === id)!;
 }

--- a/lib/projectPoster.ts
+++ b/lib/projectPoster.ts
@@ -1,0 +1,109 @@
+import { idbDelete, idbGet, idbPut } from './assetDb';
+import { getRendererInstance } from './rendererInstance';
+import { useSceneStore } from '@/store/useSceneStore';
+
+// ============================================================
+//  PROJECT POSTERS — the picture on a project card
+//
+//  The Projects tab is a launcher, so a card has to show the project rather
+//  than name it. There is no way to RENDER another project's scene on demand:
+//  both renderers read the live useSceneStore singleton (see lib/renderer.ts),
+//  so drawing project B's scene would mean swapping the open document. What is
+//  available instead is the stage that is already on screen — so a poster is
+//  grabbed from the live canvas and cached per project.
+//
+//  Bytes go to IndexedDB, not localStorage: the project index and every scene
+//  share that ~5MB quota, and a poster per project would be the biggest thing
+//  in it.
+//
+//  Engine-agnostic on purpose — whichever stage is mounted (Pixi 2D, Three
+//  mockup/3D) has registered itself as the renderer instance, so the poster
+//  shows the tab the user was actually working in.
+// ============================================================
+
+const POSTER_W = 480;          // long edge of the cached image
+const POSTER_QUALITY = 0.72;
+
+export const posterKey = (projectId: string) => `poster:${projectId}`;
+
+// Cards render from IndexedDB, which they read once. A capture has to tell them
+// to read again — hence a version counter rather than a store: posters are not
+// document state, and nothing but a card ever reads them.
+let version = 0;
+const listeners = new Set<() => void>();
+
+export function posterVersion(): number {
+  return version;
+}
+
+export function subscribePosters(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}
+
+function bump(): void {
+  version += 1;
+  for (const fn of listeners) fn();
+}
+
+/**
+ * Grab the live stage into `projectId`'s poster.
+ *
+ * The pixel read is SYNCHRONOUS (renderFrame + drawImage in this same task) for
+ * two reasons: a WebGL drawing buffer without `preserveDrawingBuffer` is only
+ * readable before the browser composites it, and callers capture *while
+ * switching away* — one tick later the canvas already shows a different
+ * project. Only the JPEG encode and the write are deferred.
+ */
+export function capturePoster(projectId: string | null | undefined): void {
+  if (!projectId || typeof document === 'undefined') return;
+  const renderer = getRendererInstance();
+  if (!renderer) return;
+
+  let src: HTMLCanvasElement | null = null;
+  try {
+    renderer.renderFrame(useSceneStore.getState().frame);
+    src = renderer.extractCanvas();
+  } catch {
+    return; // stage mid-teardown — a stale poster beats a broken one
+  }
+  if (!src?.width || !src.height) return;
+
+  const k = Math.min(1, POSTER_W / Math.max(src.width, src.height));
+  const w = Math.max(1, Math.round(src.width * k));
+  const h = Math.max(1, Math.round(src.height * k));
+  const off = document.createElement('canvas');
+  off.width = w;
+  off.height = h;
+  const g = off.getContext('2d');
+  if (!g) return;
+  try {
+    g.drawImage(src, 0, 0, w, h);
+  } catch {
+    return; // tainted or zero-sized source
+  }
+
+  off.toBlob(
+    (blob) => {
+      if (!blob) return;
+      idbPut(posterKey(projectId), blob).then(bump).catch(() => { /* quota — card falls back to its sketch */ });
+    },
+    'image/jpeg',
+    POSTER_QUALITY,
+  );
+}
+
+export function loadPoster(projectId: string): Promise<Blob | undefined> {
+  return idbGet(posterKey(projectId)).catch(() => undefined);
+}
+
+export function deletePoster(projectId: string): void {
+  idbDelete(posterKey(projectId)).then(bump).catch(() => { /* non-fatal */ });
+}
+
+/** Copy a poster across on duplicate, so the copy isn't a blank card. */
+export function copyPoster(fromId: string, toId: string): void {
+  loadPoster(fromId)
+    .then((blob) => (blob ? idbPut(posterKey(toId), blob).then(bump) : undefined))
+    .catch(() => { /* non-fatal */ });
+}

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -22,11 +22,20 @@ export const LEGACY_SCENE_KEY = 'motion-scene-v1';
 
 const sceneKeyFor = (id: string) => `motion-project-${id}`;
 
+export type ProjectMode = '2d' | 'mockup';
+
 export interface ProjectMeta {
   id: string;
   name: string;
   createdAt: number;  // epoch ms
   updatedAt: number;
+  /** A project persists exactly one document: the 2D scene or the Mockup studio. */
+  mode: ProjectMode;
+  /**
+   * Legacy field from the short-lived model where one project carried both
+   * documents. Kept only so existing browser data can be classified safely.
+   */
+  section?: string;
 }
 
 interface ProjectsIndex {
@@ -53,9 +62,14 @@ function readIndex(): ProjectsIndex {
     const parsed = JSON.parse(raw) as ProjectsIndex;
     if (!Array.isArray(parsed.projects)) return emptyIndex();
     // Drop malformed entries rather than letting them crash the panel later.
-    const projects = parsed.projects.filter(
-      (p): p is ProjectMeta => !!p && typeof p.id === 'string' && typeof p.name === 'string',
-    );
+    const projects = parsed.projects
+      .filter((p): p is ProjectMeta => !!p && typeof p.id === 'string' && typeof p.name === 'string')
+      .map((p) => ({
+        ...p,
+        // Existing mixed projects reopen in the last section they used. This
+        // selects one active document without deleting the other legacy key.
+        mode: p.mode === 'mockup' || p.section === 'mockup' ? 'mockup' as const : '2d' as const,
+      }));
     return { activeId: typeof parsed.activeId === 'string' ? parsed.activeId : null, projects };
   } catch {
     return emptyIndex();
@@ -86,8 +100,14 @@ export function readProjectScene(id: string): ScenePartial | null {
   }
 }
 
+export function projectMode(id: string): ProjectMode | null {
+  return readIndex().projects.find((p) => p.id === id)?.mode ?? null;
+}
+
 // Persist a project's scene and stamp it as the most recently touched.
 export function writeProjectScene(id: string, partial: ScenePartial): void {
+  // Defence in depth: only a 2D project may own a scene key.
+  if (projectMode(id) !== '2d') return;
   try { localStorage.setItem(sceneKeyFor(id), JSON.stringify(partial)); } catch { return; }
   const ix = readIndex();
   const i = ix.projects.findIndex((p) => p.id === id);
@@ -96,16 +116,36 @@ export function writeProjectScene(id: string, partial: ScenePartial): void {
   writeIndex(ix);
 }
 
-export function createProject(name: string, scene?: ScenePartial | null): ProjectMeta {
+/**
+ * Stamp a mockup project as just edited without touching a 2D scene. The 3D/Mockup
+ * slice lives in its own key (lib/three3dPersist) and its writer has no scene to
+ * hand to writeProjectScene, so it calls this instead — otherwise a session
+ * spent entirely in Mockup never updates the date the projects list sorts by.
+ */
+export function touchProject(id: string): void {
+  const ix = readIndex();
+  const i = ix.projects.findIndex((p) => p.id === id);
+  if (i < 0 || ix.projects[i].mode !== 'mockup') return;
+  ix.projects[i] = { ...ix.projects[i], updatedAt: Date.now() };
+  writeIndex(ix);
+}
+
+export function createProject(
+  name: string,
+  mode: ProjectMode = '2d',
+  scene?: ScenePartial | null,
+): ProjectMeta {
   const now = Date.now();
-  const meta: ProjectMeta = { id: newId(), name: name.trim() || 'Untitled', createdAt: now, updatedAt: now };
+  const meta: ProjectMeta = {
+    id: newId(), name: name.trim() || 'Untitled', createdAt: now, updatedAt: now, mode,
+  };
   const ix = readIndex();
   ix.projects.push(meta);
   ix.activeId = meta.id;
   writeIndex(ix);
   // No scene → the app keeps its current state / built-in defaults. Writing an
   // empty object here would hydrate a blank scene over the defaults.
-  if (scene) {
+  if (mode === '2d' && scene) {
     try { localStorage.setItem(sceneKeyFor(meta.id), JSON.stringify(scene)); } catch { /* quota */ }
   }
   return meta;
@@ -123,7 +163,11 @@ export function duplicateProject(id: string): ProjectMeta | null {
   const ix = readIndex();
   const src = ix.projects.find((p) => p.id === id);
   if (!src) return null;
-  return createProject(`${src.name} copy`, readProjectScene(id));
+  return createProject(
+    `${src.name} copy`,
+    src.mode,
+    src.mode === '2d' ? readProjectScene(id) : null,
+  );
 }
 
 // Removing the active project hands the active slot to the next most recent one,
@@ -153,7 +197,10 @@ export function setActiveProject(id: string): void {
  * Runs once on mount. Non-destructive by design: a pre-projects scene is COPIED
  * into a project and the legacy key is left in place as a backup.
  */
-export function openInitialProject(defaultName: string): { meta: ProjectMeta; scene: ScenePartial | null } {
+export function openInitialProject(
+  defaultName: string,
+  defaultMode: ProjectMode = '2d',
+): { meta: ProjectMeta; scene: ScenePartial | null } {
   const ix = readIndex();
 
   if (ix.projects.length === 0) {
@@ -163,7 +210,8 @@ export function openInitialProject(defaultName: string): { meta: ProjectMeta; sc
       if (raw) legacy = JSON.parse(raw) as ScenePartial;
     } catch { /* corrupt legacy blob — start fresh instead of failing to boot */ }
     // A migrated scene keeps its own name so the user recognizes their work.
-    const meta = createProject(legacy ? 'My project' : defaultName, legacy);
+    const mode: ProjectMode = legacy ? '2d' : defaultMode;
+    const meta = createProject(legacy ? 'My project' : defaultName, mode, legacy);
     return { meta, scene: legacy };
   }
 
@@ -171,5 +219,5 @@ export function openInitialProject(defaultName: string): { meta: ProjectMeta; sc
   const sorted = ix.projects.slice().sort((a, b) => b.updatedAt - a.updatedAt);
   const meta = ix.projects.find((p) => p.id === wanted) ?? sorted[0];
   if (meta.id !== ix.activeId) setActiveProject(meta.id);
-  return { meta, scene: readProjectScene(meta.id) };
+  return { meta, scene: meta.mode === '2d' ? readProjectScene(meta.id) : null };
 }

--- a/lib/relativeTime.ts
+++ b/lib/relativeTime.ts
@@ -1,0 +1,13 @@
+// Relative time, coarse on purpose — an exact timestamp is noise in a list you
+// scan to find "the one I was just working on". Shared by the projects panel
+// (mobile sheet) and the Projects tab, so the two never word it differently.
+export function ago(ms: number): string {
+  const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
+  if (s < 60) return 'just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} h ago`;
+  const d = Math.floor(h / 24);
+  return d === 1 ? 'yesterday' : `${d} days ago`;
+}

--- a/lib/saveStatus.ts
+++ b/lib/saveStatus.ts
@@ -1,0 +1,72 @@
+// ============================================================
+//  SAVE STATUS — one signal for "is my work in the project yet?"
+//
+//  Both autosaves (lib/scenePersist for the 2D document, lib/three3dPersist for
+//  the Mockup/3D studio) write straight to localStorage without going through
+//  any store, which is exactly why the editor could never say whether anything
+//  had been saved. The Mockup panel's button was the only save the UI ever
+//  admitted to, and it looked like the ONLY save there was.
+//
+//  So the writers report here, and the editor's project chip (components/
+//  ProjectDock) reads it. Deliberately not a zustand store: this is a signal
+//  about persistence, not part of any document, and the writers must be able to
+//  report from module scope without importing a store that imports them back.
+// ============================================================
+
+export interface SaveStatus {
+  /** Edits are queued but not written yet (the throttle window). */
+  pending: boolean;
+  /** When the last write landed, or null if nothing has been written yet. */
+  savedAt: number | null;
+}
+
+// One object identity per state, so useSyncExternalStore can compare snapshots.
+let status: SaveStatus = { pending: false, savedAt: null };
+// A counter, not a boolean: the 2D and 3D autosaves each schedule their own
+// flush, and one finishing must not clear the other's pending state.
+let queued = 0;
+
+const subscribers = new Set<() => void>();
+
+function set(next: SaveStatus): void {
+  if (next.pending === status.pending && next.savedAt === status.savedAt) return;
+  status = next;
+  for (const fn of subscribers) fn();
+}
+
+export function getSaveStatus(): SaveStatus {
+  return status;
+}
+
+export function subscribeSaveStatus(fn: () => void): () => void {
+  subscribers.add(fn);
+  return () => { subscribers.delete(fn); };
+}
+
+/** An edit landed and a write is scheduled. */
+export function markPending(): void {
+  queued += 1;
+  set({ ...status, pending: true });
+}
+
+/** A write landed. */
+export function markSaved(at = Date.now()): void {
+  queued = Math.max(0, queued - 1);
+  set({ pending: queued > 0, savedAt: at });
+}
+
+/** The scheduled write ran and found nothing to write (unchanged slice). */
+export function markSettled(): void {
+  queued = Math.max(0, queued - 1);
+  set({ ...status, pending: queued > 0 });
+}
+
+/**
+ * Switching projects: the "saved 2 min ago" of the project being left says
+ * nothing about the one being opened. Queued flushes from before the switch are
+ * dropped too — they belong to a target that has already moved.
+ */
+export function resetSaveStatus(savedAt: number | null = null): void {
+  queued = 0;
+  set({ pending: false, savedAt });
+}

--- a/lib/scenePersist.ts
+++ b/lib/scenePersist.ts
@@ -1,5 +1,6 @@
 import { useSceneStore, type SceneState } from '@/store/useSceneStore';
 import { writeProjectScene } from './projects';
+import { markPending, markSaved, markSettled } from './saveStatus';
 
 // Client-side scene persistence. Settings live in localStorage; uploaded media
 // bytes live in IndexedDB (see lib/assetDb). A refresh restores the full working
@@ -77,17 +78,21 @@ export function setAutosaveTarget(projectId: string | null, seedSig?: SceneParti
 /**
  * Write the live scene into the active project now, bypassing the throttle.
  * Call before switching projects, or the last edits land in the wrong one.
+ * Returns whether it actually wrote — the autosave uses that to settle the
+ * "saving…" state when the slice turned out to be unchanged.
  */
-export function flushScene(): void {
-  if (!autosaveTarget) return;
+export function flushScene(): boolean {
+  if (!autosaveTarget) return false;
   try {
     const partial = buildScenePartial(useSceneStore.getState());
     const sig = JSON.stringify(partial);
-    if (sig === lastSig) return;
+    if (sig === lastSig) return false;
     lastSig = sig;
     writeProjectScene(autosaveTarget, partial);
+    markSaved();
+    return true;
   } catch {
-    /* quota exceeded or serialize error — skip this write, non-fatal */
+    return false; /* quota exceeded or serialize error — skip this write, non-fatal */
   }
 }
 
@@ -96,13 +101,44 @@ export function flushScene(): void {
 // changed — so play/scrub (frame churn) produces zero writes.
 export function startSceneAutosave(): () => void {
   let scheduled = false;
+  let announced = false;
   const flush = () => {
     scheduled = false;
-    flushScene();
+    const wrote = flushScene();          // reports markSaved itself
+    if (announced && !wrote) markSettled();
+    announced = false;
   };
-  return useSceneStore.subscribe(() => {
+  return useSceneStore.subscribe((state, prev) => {
+    // The write is scheduled on EVERY tick, exactly as before — the signature
+    // check inside flushScene is what makes that cheap, and nothing may depend
+    // on the guess below to decide whether to save.
+    //
+    // The editor's save indicator is a different question: during playback
+    // `frame` changes ~60×/s, so a pending flag set on every tick meant the chip
+    // read "Saving…" forever while the preview played, which is a lie about a
+    // scene nobody is editing. So the SIGNAL is announced only when a persisted
+    // field changed identity — cheap, and it cannot suppress a write.
+    if (!announced && documentTouched(state, prev)) {
+      announced = true;
+      markPending();
+    }
     if (scheduled) return;
     scheduled = true;
     setTimeout(flush, 500);
   });
+}
+
+// Every field buildScenePartial reads. Compared by identity: the store replaces
+// these rather than mutating them, so a changed reference means a changed
+// document — and the clock (frame/playing), which is not in the partial at all,
+// can never look like one.
+const DOC_KEYS = [
+  'tracks', 'activeTrackId', 'activeTemplateId', 'values', 'easing', 'fps', 'duration',
+  'aspect', 'width', 'height', 'customW', 'customH', 'safeArea', 'background', 'logo',
+  'cardShape', 'videoEnd', 'effects', 'assets',
+] as const satisfies readonly (keyof SceneState)[];
+
+function documentTouched(a: SceneState, b: SceneState): boolean {
+  for (const k of DOC_KEYS) if (a[k] !== b[k]) return true;
+  return false;
 }

--- a/lib/three3dPersist.ts
+++ b/lib/three3dPersist.ts
@@ -1,4 +1,7 @@
 import { use3DStore, type ThreeDState } from '@/store/use3DStore';
+import { useSceneStore } from '@/store/useSceneStore';
+import { projectMode, touchProject } from './projects';
+import { markPending, markSaved, markSettled } from './saveStatus';
 
 // Per-project persistence for 3D and Mockup state.
 //
@@ -29,6 +32,7 @@ const keyFor = (projectId: string) => `${KEY_PREFIX}${projectId}`;
 // IndexedDB; an uploaded .glb and a sun mask have no byte store behind them, so
 // they fall back to the bundled default rather than to a broken reference.
 export function buildThreeDPartial(s: ThreeDState) {
+  const canvas = useSceneStore.getState();
   const models: ThreeDState['models'] = {};
   for (const [effectId, m] of Object.entries(s.models)) {
     models[effectId] = m.url?.startsWith('blob:') ? { ...m, url: null, name: null } : m;
@@ -66,6 +70,19 @@ export function buildThreeDPartial(s: ThreeDState) {
     statusBarTime: s.statusBarTime,
     statusBarBattery: s.statusBarBattery,
     statusBarSignal: s.statusBarSignal,
+    // Mockup owns its canvas/timeline settings too. They live in useSceneStore
+    // at runtime because both renderers consume them, but are persisted inside
+    // the Mockup document — never in a parallel 2D scene key.
+    canvas: {
+      fps: canvas.fps,
+      duration: canvas.duration,
+      aspect: canvas.aspect,
+      width: canvas.width,
+      height: canvas.height,
+      customW: canvas.customW,
+      customH: canvas.customH,
+      safeArea: canvas.safeArea,
+    },
   };
 }
 
@@ -81,6 +98,8 @@ export function readProjectThreeD(projectId: string): ThreeDPartial | null {
 }
 
 export function writeProjectThreeD(projectId: string, partial: ThreeDPartial): void {
+  // Defence in depth: a 2D project may never acquire a Mockup document.
+  if (projectMode(projectId) !== 'mockup') return;
   try { localStorage.setItem(keyFor(projectId), JSON.stringify(partial)); } catch { /* quota — non-fatal */ }
 }
 
@@ -91,12 +110,15 @@ export function deleteProjectThreeD(projectId: string): void {
 // Which project a save writes into. While null a save is a no-op rather than
 // stamping 3D state onto whichever project happens to be open next.
 //
-// Saving here is EXPLICIT, unlike the 2D scene next door, which autosaves. The
-// two are not inconsistent by accident: the 2D scene is the timeline the user is
-// continuously editing, while a mockup is a studio they arrange and then keep,
-// and an autosave on every store tick meant a stray drag of the model silently
-// became the project's new saved state. So this exposes a save the UI calls from
-// a button, and nothing writes on its own.
+// This USED to be explicit-only — a button in MockupPanel and nothing else —
+// on the reasoning that a mockup is arranged and then kept, so an autosave on
+// every store tick would let a stray drag of the model become the saved state.
+// In practice that made the studio read as not saving at all: arrange a device,
+// switch section or project (or just reload without noticing the button) and the
+// arrangement was gone, because leaving deliberately did NOT write. So the 3D
+// slice now autosaves on the same terms as the 2D scene — throttled, and only
+// when the serialised slice actually changed — and `saveThreeD` stays as the
+// explicit "save now" the button calls.
 let target: string | null = null;
 let lastSaved = '';
 
@@ -114,10 +136,46 @@ export function saveThreeD(): boolean {
     const partial = buildThreeDPartial(use3DStore.getState());
     lastSaved = JSON.stringify(partial);
     writeProjectThreeD(target, partial);
+    // The projects list sorts and dates itself by updatedAt, which only the 2D
+    // scene writer stamps. Without this a session spent entirely in Mockup left
+    // its project reading "edited 3 days ago" and sinking down the list.
+    touchProject(target);
+    markSaved();
     return true;
   } catch {
     return false; // serialize or quota error
   }
+}
+
+/**
+ * Write now if the studio differs from what was last saved. Same contract as
+ * scenePersist's flushScene: call it before switching projects, or the last
+ * arrangement lands in the wrong one (or nowhere).
+ */
+export function flushThreeD(): boolean {
+  if (!target || !isThreeDDirty()) return false;
+  return saveThreeD();
+}
+
+/**
+ * Throttled autosave of the 3D/Mockup slice into the open project. Returns an
+ * unsubscribe. Mirrors startSceneAutosave, including why it is hand-rolled: the
+ * store churns during playback (mockup animation reads the clock, not the store,
+ * but model nudges arrive in bursts), and the dirty check means a burst costs one
+ * write instead of one per tick.
+ */
+export function startThreeDAutosave(): () => void {
+  let scheduled = false;
+  const flush = () => {
+    scheduled = false;
+    if (!flushThreeD()) markSettled();
+  };
+  return use3DStore.subscribe(() => {
+    if (scheduled) return;
+    scheduled = true;
+    markPending();
+    setTimeout(flush, 600);
+  });
 }
 
 /** Whether the studio differs from what was last saved (or loaded). */

--- a/store/use3DStore.ts
+++ b/store/use3DStore.ts
@@ -84,6 +84,7 @@ export interface ThreeDState {
   hydrate3D: (partial: Partial<ThreeDState>) => void;
   // Back to the app's own defaults — what a brand-new project starts from.
   reset3D: () => void;
+  // Forget the live studio without deleting bytes owned by another project.
   // Rebuild screen-media urls from IndexedDB after hydrate3D.
   rehydrateScreenMedia: () => Promise<void>;
   setScreenFit: (fit: 'cover' | 'width' | 'contain') => void;
@@ -370,3 +371,15 @@ export const use3DStore = create<ThreeDState>((set) => ({
   setSunMaskScale: (v) => set({ sunMaskScale: v }),
   setSunMaskOffset: (x, y) => set({ sunMaskOffsetX: x, sunMaskOffsetY: y }),
 }));
+
+/**
+ * Clear only the live Mockup state while preserving its IndexedDB media.
+ * This stays outside the Zustand state shape so hot reload cannot leave an
+ * older store instance without the cleanup action during development.
+ */
+export function reset3DMemory(): void {
+  for (const media of Object.values(use3DStore.getState().screenMedia)) {
+    if (media?.url?.startsWith('blob:')) URL.revokeObjectURL(media.url);
+  }
+  use3DStore.setState(() => initial3DState());
+}

--- a/store/useProjectStore.ts
+++ b/store/useProjectStore.ts
@@ -9,17 +9,21 @@ import {
   readProjectScene,
   renameProject,
   setActiveProject,
+  type ProjectMode,
   type ProjectMeta,
 } from '@/lib/projects';
+import { capturePoster, copyPoster, deletePoster } from '@/lib/projectPoster';
+import { resetSaveStatus } from '@/lib/saveStatus';
 import { flushScene, setAutosaveTarget } from '@/lib/scenePersist';
 import {
   deleteProjectThreeD,
+  flushThreeD,
   readProjectThreeD,
   setThreeDSaveTarget,
   writeProjectThreeD,
 } from '@/lib/three3dPersist';
 import { useSceneStore } from './useSceneStore';
-import { use3DStore } from './use3DStore';
+import { reset3DMemory, use3DStore } from './use3DStore';
 import { useHistoryStore } from './useHistoryStore';
 
 // Any switch of the open project drops undo history: undoing across a switch
@@ -35,11 +39,11 @@ export interface ProjectState {
   booted: boolean;
 
   // Mount-time: resolve/create the project to open and hydrate its scene.
-  bootstrap: () => void;
+  bootstrap: (mode?: ProjectMode) => void;
   refresh: () => void;
 
   open: (id: string) => void;
-  create: (name: string) => void;
+  create: (name: string, mode?: ProjectMode) => void;
   duplicate: (id: string) => void;
   rename: (id: string, name: string) => void;
   remove: (id: string) => void;
@@ -51,20 +55,51 @@ const DEFAULT_NAME = 'Default project';
 // switch below has to move it in step with the 2D scene. Restoring it is one
 // helper so the five paths cannot drift, and it RETURNS the slice it loaded so
 // each caller can seed the SAVE signature with it — opening a project is not an
-// edit. Unlike the 2D scene it is never written automatically; MockupPanel's
-// button is the only writer. A project saved before any of this existed simply
-// has no slice and falls back to the app defaults.
+// edit, and an unseeded signature would make the autosave rewrite the slice it
+// just read. A project saved before any of this existed simply has no slice and
+// falls back to the app defaults.
 function load3D(projectId: string) {
   const slice = readProjectThreeD(projectId);
+  // Release only the previous tab's object URLs. Deleting its IndexedDB rows
+  // here would corrupt the saved mockup we just left.
+  reset3DMemory();
   if (slice) {
     use3DStore.getState().hydrate3D(slice);
     // Screen media saves an id, never a blob: url — those are dead after a
     // reload. Rebuild the urls from the stored bytes.
     void use3DStore.getState().rehydrateScreenMedia();
   } else {
-    use3DStore.getState().reset3D();
+    // reset3DMemory above already established the defaults.
   }
   return slice;
+}
+
+function flushProject(meta: ProjectMeta | undefined): void {
+  if (meta?.mode === 'mockup') flushThreeD();
+  else if (meta) flushScene();
+}
+
+/** Hydrate one document and explicitly disable the other save target. */
+function loadProject(meta: ProjectMeta): void {
+  if (meta.mode === 'mockup') {
+    useSceneStore.getState().blankScene();
+    setAutosaveTarget(null);
+    const studio = load3D(meta.id);
+    if (studio?.canvas) useSceneStore.setState(studio.canvas);
+    setThreeDSaveTarget(meta.id, studio);
+    return;
+  }
+
+  const scene = readProjectScene(meta.id);
+  if (scene) {
+    useSceneStore.getState().hydrate(scene);
+    void useSceneStore.getState().rehydrateUploads();
+  } else {
+    useSceneStore.getState().blankScene();
+  }
+  setAutosaveTarget(meta.id, scene);
+  reset3DMemory();
+  setThreeDSaveTarget(null);
 }
 
 export const useProjectStore = create<ProjectState>((set, get) => ({
@@ -74,81 +109,88 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
   refresh: () => set(() => ({ projects: listProjects(), activeId: activeProjectId() })),
 
-  bootstrap: () => {
+  bootstrap: (mode = '2d') => {
     if (get().booted || typeof window === 'undefined') return;
-    const { meta, scene } = openInitialProject(DEFAULT_NAME);
-    // A migrated/saved scene hydrates; a brand-new project keeps the store's
-    // own defaults (openInitialProject returns null for it).
-    if (scene) {
-      useSceneStore.getState().hydrate(scene);
-      void useSceneStore.getState().rehydrateUploads();
-    }
-    // Seed the autosave signature with what we just loaded, so simply opening a
-    // project doesn't rewrite it and bump its updatedAt.
-    setAutosaveTarget(meta.id, scene);
-    setThreeDSaveTarget(meta.id, load3D(meta.id));
+    const { meta } = openInitialProject(DEFAULT_NAME, mode);
+    loadProject(meta);
+    // Seed the editor's save indicator with when this project was last written,
+    // not with "now" and not with nothing: a project that has been on disk for
+    // two hours must not open reading "Not saved yet".
+    resetSaveStatus(meta.updatedAt);
     set(() => ({ projects: listProjects(), activeId: meta.id, booted: true }));
   },
 
   open: (id) => {
     if (id === get().activeId) return;
-    flushScene();                       // the edits so far belong to the OLD project
-    setAutosaveTarget(null);            // ...and nothing may be written mid-swap
-    // The Mockup studio is saved by hand, so leaving a project does NOT write
-    // it — unsaved arrangement is discarded, the same as any explicit-save
-    // document. Only the target moves.
+    // The card picture of the project being left, grabbed while its stage is
+    // still the one on screen (see lib/projectPoster: the pixel read is sync).
+    const current = get().projects.find((p) => p.id === get().activeId);
+    capturePoster(get().activeId);
+    flushProject(current);              // only the document this project owns
+    setAutosaveTarget(null);            // nothing may be written mid-swap
     setThreeDSaveTarget(null);
     setActiveProject(id);
-    const scene = readProjectScene(id);
-    if (scene) {
-      useSceneStore.getState().hydrate(scene);
-      void useSceneStore.getState().rehydrateUploads();
-    } else {
-      useSceneStore.getState().resetScene();
-    }
-    setAutosaveTarget(id, scene);
-    setThreeDSaveTarget(id, load3D(id));
+    const next = listProjects().find((p) => p.id === id);
+    if (!next) return;
+    loadProject(next);
     resetHistory();
-    set(() => ({ projects: listProjects(), activeId: id }));
+    // The "saved 2 min ago" of the project just left says nothing about this
+    // one, whose true answer is when IT was last written.
+    const list = listProjects();
+    resetSaveStatus(list.find((p) => p.id === id)?.updatedAt ?? Date.now());
+    set(() => ({ projects: list, activeId: id }));
   },
 
-  create: (name) => {
-    flushScene();
+  create: (name, mode = '2d') => {
+    const current = get().projects.find((p) => p.id === get().activeId);
+    capturePoster(get().activeId);
+    flushProject(current);
     setAutosaveTarget(null);
     setThreeDSaveTarget(null);
-    const meta = createProject(name);
-    // A new project starts from the app defaults, not from whatever the previous
-    // project happened to be showing.
-    useSceneStore.getState().resetScene();
+    const meta = createProject(name, mode);
+    // A new project starts BLANK — no layers at all. It used to start from the
+    // app's default template ('carousel', shown as "Runway") with the demo set
+    // animating, so every new project was a copy of the last one and the list
+    // read as two of the same thing. The first template pick is the user's, and
+    // nothing from the library is in it until they make one.
+    useSceneStore.getState().blankScene();
     // Empty signature → the flush below actually writes, persisting the starting
     // scene now so the project isn't an empty shell if the user switches away
     // before the first autosave tick.
-    setAutosaveTarget(meta.id, null);
-    // A new project starts from the 3D defaults too. Nothing is written for it:
-    // a project with no saved studio falls back to those same defaults, so the
-    // first save is the user's.
-    use3DStore.getState().reset3D();
-    setThreeDSaveTarget(meta.id, null);
-    flushScene();
+    setAutosaveTarget(mode === '2d' ? meta.id : null, null);
+    // A new project starts from the 3D defaults too. The empty signature means
+    // the autosave's next tick writes those defaults out, which is the same
+    // state a missing slice falls back to — so either way a fresh project opens
+    // an empty studio.
+    reset3DMemory();
+    setThreeDSaveTarget(mode === 'mockup' ? meta.id : null, null);
+    if (mode === 'mockup') flushThreeD();
+    else flushScene();
     resetHistory();
+    resetSaveStatus(Date.now());
     set(() => ({ projects: listProjects(), activeId: meta.id }));
   },
 
   duplicate: (id) => {
     // Duplicating the ACTIVE project must capture its unsaved edits first.
-    if (id === get().activeId) flushScene();
+    const source = get().projects.find((p) => p.id === id);
+    if (id === get().activeId) flushProject(source);
     const meta = duplicateProject(id);
     if (!meta) return;
-    setAutosaveTarget(meta.id, readProjectScene(meta.id));
+    // Posters live outside the project record, so the copy starts blank unless
+    // its picture is copied across too.
+    copyPoster(id, meta.id);
+    setAutosaveTarget(meta.mode === '2d' ? meta.id : null, readProjectScene(meta.id));
     // duplicateProject only knows about the 2D scene, so the SAVED 3D slice is
     // copied across by hand — otherwise a duplicated mockup opens as an empty
     // studio. Unsaved arrangement is not copied, because it was never a document.
     // Both projects then resolve the same IndexedDB rows for their screen media,
     // which is intended: those rows are keyed by id and neither owns them.
-    const src = readProjectThreeD(id);
+    const src = meta.mode === 'mockup' ? readProjectThreeD(id) : null;
     if (src) writeProjectThreeD(meta.id, src);
-    setThreeDSaveTarget(meta.id, src);
+    setThreeDSaveTarget(meta.mode === 'mockup' ? meta.id : null, src);
     resetHistory();
+    resetSaveStatus(Date.now());
     set(() => ({ projects: listProjects(), activeId: meta.id }));
   },
 
@@ -165,30 +207,25 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     }
     deleteProject(id);
     deleteProjectThreeD(id);
+    deletePoster(id);            // nothing else would ever collect it
     const nextActive = activeProjectId();
     if (wasActive) {
       if (nextActive) {
-        const scene = readProjectScene(nextActive);
-        if (scene) {
-          useSceneStore.getState().hydrate(scene);
-          void useSceneStore.getState().rehydrateUploads();
-        } else {
-          useSceneStore.getState().resetScene();
-        }
-        setAutosaveTarget(nextActive, scene);
-        setThreeDSaveTarget(nextActive, load3D(nextActive));
+        const next = listProjects().find((p) => p.id === nextActive);
+        if (next) loadProject(next);
       } else {
-        // Deleted the last project — start a fresh default one rather than
-        // leaving the app with nowhere to save.
-        useSceneStore.getState().resetScene();
-        use3DStore.getState().reset3D();
-        const meta = createProject(DEFAULT_NAME);
+        // Deleted the last project — start a fresh one rather than leaving the
+        // app with nowhere to save. Blank, like any created project.
+        useSceneStore.getState().blankScene();
+        reset3DMemory();
+        const meta = createProject(DEFAULT_NAME, '2d');
         setAutosaveTarget(meta.id, null);
-        setThreeDSaveTarget(meta.id, null);
+        setThreeDSaveTarget(null);
         flushScene();
       }
     }
     resetHistory();
+    if (wasActive) resetSaveStatus(Date.now());
     set(() => ({ projects: listProjects(), activeId: activeProjectId() }));
   },
 }));

--- a/store/useSceneStore.ts
+++ b/store/useSceneStore.ts
@@ -174,7 +174,8 @@ export interface SceneState {
 
   // persistence (see lib/scenePersist)
   hydrate: (partial: Partial<SceneState>) => void;   // apply a loaded scene
-  resetScene: () => void;                            // back to defaults (new project)
+  resetScene: () => void;                            // back to the app defaults (demo scene)
+  blankScene: () => void;                            // back to defaults with NO layers (new project)
   rehydrateUploads: () => Promise<void>;             // rebuild upload urls from IndexedDB
 
   loadCustomPresets: () => void;
@@ -239,6 +240,14 @@ export function makeTrack(templateId: string, name: string, patch: Partial<Motio
 // track — the invariant 3D/web/board/persist depend on.
 function projectActive(tracks: MotionTrack[], activeTrackId: string) {
   const active = tracks.find((t) => t.id === activeTrackId) ?? tracks[0];
+  // A scene with NO layers is a real state: a new project starts blank so the
+  // first template is chosen rather than inherited. Nothing downstream needs a
+  // stand-in track — the renderer's forEach over an empty list draws just the
+  // background, getTemplate('') falls back on its own, and setActiveTemplate
+  // turns the first pick into the first layer.
+  if (!active) {
+    return { tracks, activeTrackId: '', activeTemplateId: '', values: {}, easing: easingFor('') };
+  }
   return {
     tracks,
     activeTrackId: active.id,
@@ -271,6 +280,22 @@ const initDims = dimsFor('3:4');
  * and hearted templates are a user-wide library, not per-project, so creating a
  * project must not wipe them.
  */
+/**
+ * What an explicitly CREATED project starts from: the same canvas, assets and
+ * clock as `initialSceneState`, with no layers at all.
+ *
+ * A new project used to open on the app's default template (`carousel`, which
+ * the UI calls "Runway") with the demo set already animating — so every new
+ * project was a copy of the last one and the list read as two of the same thing.
+ * Blank means the first template pick is the user's.
+ *
+ * First run still gets the demo scene: the store's own defaults are what boots,
+ * and a first-time visitor with an empty stage would have nothing to look at.
+ */
+export function blankSceneState() {
+  return { ...initialSceneState(), ...projectActive([], '') };
+}
+
 function initialSceneState() {
   const tracks = [makeTrack(INITIAL_TEMPLATE, 'Layer 1')];
   return {
@@ -447,8 +472,14 @@ export const useSceneStore = create<SceneState>((set, get) => ({
         : isRef2dPreset || isGlobeRefPreset || isRef3dPreset ? '3:4'
         : null;
       const referenceCanvas = referenceAspect ? dimsFor(referenceAspect) : null;
+      // A blank scene has no track to patch, so the first pick BECOMES Layer 1.
+      // Without this the click would land on nothing and picking a template in a
+      // new project would look broken.
+      const layers = s.tracks.length === 0
+        ? (() => { const first = makeTrack(id, 'Layer 1'); return projectActive([first], first.id); })()
+        : withTrack(s, s.activeTrackId, { templateId: id, values: defaultsFor(id), easing: easingFor(id) });
       return {
-        ...withTrack(s, s.activeTrackId, { templateId: id, values: defaultsFor(id), easing: easingFor(id) }),
+        ...layers,
         // These reconstructed families have an intrinsic source ratio, just as
         // their reference presets do. Users can still change it afterwards.
         // Spinner takes 'auto' rather than one ratio for the whole family: the
@@ -699,8 +730,10 @@ export const useSceneStore = create<SceneState>((set, get) => ({
       // Scenes saved before motion tracks existed carry only the flat
       // activeTemplateId/values/easing triple — fold it into a single track so
       // an old autosave still opens.
-      const rawTracks: MotionTrack[] = partial.tracks?.length
-        ? partial.tracks
+      const hasTrackList = Array.isArray(partial.tracks);
+      const explicitlyBlank = hasTrackList && partial.tracks!.length === 0;
+      const rawTracks: MotionTrack[] = hasTrackList
+        ? partial.tracks!
         : [makeTrack(partial.activeTemplateId ?? s.activeTemplateId, 'Layer 1', {
             values: partial.values,
             easing: partial.easing,
@@ -727,10 +760,15 @@ export const useSceneStore = create<SceneState>((set, get) => ({
         }));
       seedIdCounter(tracks);
 
-      const safeTracks = tracks.length > 0 ? tracks : s.tracks;
-      const activeId = safeTracks.some((t) => t.id === partial.activeTrackId)
-        ? partial.activeTrackId!
-        : safeTracks[0].id;
+      // An explicitly persisted empty list is the intentional blank-project
+      // state. Only a non-empty list made invalid by removed templates falls
+      // back to the currently loaded scene.
+      const safeTracks = tracks.length > 0 ? tracks : explicitlyBlank ? [] : s.tracks;
+      const activeId = safeTracks.length === 0
+        ? ''
+        : safeTracks.some((t) => t.id === partial.activeTrackId)
+          ? partial.activeTrackId!
+          : safeTracks[0].id;
 
       return {
         ...s,
@@ -745,6 +783,7 @@ export const useSceneStore = create<SceneState>((set, get) => ({
   // IndexedDB are deliberately NOT deleted: they still belong to the scenes of
   // other projects, which reference them by asset id.
   resetScene: () => set(() => initialSceneState()),
+  blankScene: () => set(() => blankSceneState()),
 
   // Rebuild object URLs for uploaded assets from their IndexedDB bytes. Runs after
   // hydrate; assets whose bytes are gone (evicted/quota) keep an empty url and

--- a/store/useUIStore.ts
+++ b/store/useUIStore.ts
@@ -4,6 +4,10 @@ import { create } from 'zustand';
 // the 2D scene store so 3D mode doesn't couple to motion/template state.
 export interface UIState {
   nav: string;              // active IconRail section id
+  // Where "open project" goes back to. Projects is a launcher, not a place you
+  // work in, so opening a project from it should return to the section you came
+  // from rather than always dropping you in the library.
+  lastEditorNav: string;
   theme: 'light' | 'dark';
   leftCollapsed: boolean;
   rightCollapsed: boolean;
@@ -39,6 +43,7 @@ function savePreferences(prefs: UIPreferences) {
 
 export const useUIStore = create<UIState>((set) => ({
   nav: 'library',
+  lastEditorNav: 'library',
   theme: 'light',
   leftCollapsed: false,
   rightCollapsed: false,
@@ -46,7 +51,7 @@ export const useUIStore = create<UIState>((set) => ({
   mobileTab: 'templates',
   mobileProjectsOpen: false,
   mobilePanelOpen: false,
-  setNav: (nav) => set({ nav }),
+  setNav: (nav) => set(nav === 'projects' ? { nav } : { nav, lastEditorNav: nav }),
   toggleTheme: () => set((state) => {
     const next = { ...state, theme: state.theme === 'dark' ? 'light' as const : 'dark' as const };
     savePreferences(next);


### PR DESCRIPTION
## Context

Projects previously mixed the 2D scene and Mockup studio under the same saved entry. This made navigation dependent on whichever editor had been open most recently, allowed state from one mode to leak into the other, and caused new projects to inherit the default Runway scene or previously loaded content.

## What changed

- Replaced the projects side panel with a dedicated, full-width Projects workspace.
- Added project cards with saved previews, document type, canvas dimensions, layer or device information, and recent activity.
- Made each project own exactly one document type: **2D** or **Mockup**.
- Made project routing deterministic: 2D projects always open in `/library`, while Mockup projects always open in `/mockup`.
- Disabled the inactive persistence target while switching projects, preventing one project from writing both document formats.
- Made newly created 2D projects start with an empty timeline instead of Runway or content from the previous project.
- Preserved intentionally empty 2D scenes when they are saved and reopened.
- Added Mockup autosaving, a shared save-status control, manual “Save now”, and a five-minute persistence heartbeat.
- Added project preview capture and cleanup when projects are duplicated or deleted.

## Existing projects

Existing browser-saved projects are classified safely during index migration. Projects last used in Mockup remain Mockup projects; all other projects remain 2D projects. Legacy inactive data is ignored and is no longer written.

## Validation

- `tsc --noEmit`
- `npm run build -- --webpack`
- Verified in the browser that a new 2D project starts with zero layers.
- Switched from that project to Mockup and back through the Projects workspace.
- Confirmed that reopening the saved 2D card navigates to `/library`, restores the correct project, and keeps the timeline empty.
- Confirmed that the PR is mergeable and that the Vercel checks pass.
