### PR TITLE
Add secure update notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ public/exports/*
 
 # machine-local
 .claude/settings.local.json
+.vercel/
 .DS_Store
 *.log
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,34 @@ npm test             # the verification suites (see below)
 npx tsc --noEmit     # the only required check before a PR
 ```
 
+### Local update notifications
+
+When the editor is opened through `localhost`, the bell above the theme button
+checks the official `main` branch in the background. If new commits exist, its
+panel shows their titles and offers an **Update Git** button. Alerts can be
+turned off (and back on) from that panel; disabling them also stops automatic
+Git checks in that browser. The update is always opt-in and uses a
+fast-forward-only merge; it refuses to run outside `main`, when the checkout
+has local changes, is detached, or has diverged. After updating, restart the
+dev server (and run `npm install` when the notice says dependencies changed).
+
+The endpoint is unavailable from LAN/public hostnames, rejects cross-site and
+unconfirmed update requests, serializes concurrent updates, and is removed
+entirely from the static GitHub Pages build. It never installs dependencies or
+restarts a process. Set `MOTION_STUDIO_UPDATE_REPOSITORY` only when maintaining
+a fork that should check a different Git repository.
+
+Managed Vercel builds switch the bell to a read-only **What’s new** panel:
+deployments update those instances automatically, and their local Git endpoint
+is disabled. Other providers can opt into that behavior with
+`MOTION_STUDIO_DEPLOYMENT_MODE=hosted`.
+
+The experimental Web section intentionally executes the owner's pasted code in
+the app's same-origin context. Only paste code you trust: like any same-origin
+code, it shares the local app's browser privileges. Sandboxing that preview is
+required before treating hostile pasted components as part of the updater's
+threat model.
+
 ## Export
 
 Everything below is captured from the same deterministic clock the preview uses,

--- a/README.md
+++ b/README.md
@@ -62,33 +62,54 @@ npm test             # the verification suites (see below)
 npx tsc --noEmit     # the only required check before a PR
 ```
 
-### Local update notifications
+### Notifications: GitHub Updates locally, Vercel News when hosted
 
-When the editor is opened through `localhost`, the bell above the theme button
-checks the official `main` branch in the background. If new commits exist, its
-panel shows their titles and offers an **Update Git** button. Alerts can be
-turned off (and back on) from that panel; disabling them also stops automatic
-Git checks in that browser. The update is always opt-in and uses a
-fast-forward-only merge; it refuses to run outside `main`, when the checkout
-has local changes, is detached, or has diverged. After updating, restart the
-dev server (and run `npm install` when the notice says dependencies changed).
+The bell above the theme button has two deployment-specific modes. A downloaded
+checkout opened through `localhost` shows **Updates** from the official GitHub
+`main` branch and offers an explicitly confirmed, fast-forward-only Git update.
+The hosted Vercel application shows only the read-only **News** feed. It never
+offers a Git action or exposes the local update endpoint.
 
-The endpoint is unavailable from LAN/public hostnames, rejects cross-site and
-unconfirmed update requests, serializes concurrent updates, and is removed
-entirely from the static GitHub Pages build. It never installs dependencies or
-restarts a process. Set `MOTION_STUDIO_UPDATE_REPOSITORY` only when maintaining
-a fork that should check a different Git repository.
+Pull requests and branch pushes create Vercel Preview deployments but do not
+alert production users. Editorial News is published only after the change
+reaches the Vercel Production Branch and its Production deployment succeeds.
+Open clients check `/api/news` every five minutes, compare item IDs with those
+already seen in that browser, and show the red dot and panel when something
+changes.
 
-Managed Vercel builds switch the bell to a read-only **What’s new** panel:
-deployments update those instances automatically, and their local Git endpoint
-is disabled. Other providers can opt into that behavior with
-`MOTION_STUDIO_DEPLOYMENT_MODE=hosted`.
+Editorial **News** items are maintained in `content/news.json`, newest first,
+and are published with the next successful Production deployment. Each item
+uses this shape (keep `id` stable and unique, and all customer-facing copy in
+English):
+
+```json
+{
+  "id": "new-feature-slug",
+  "title": "A short customer-facing title",
+  "body": "Optional detail shown inside the notification panel.",
+  "url": "https://example.com/optional-details"
+}
+```
+
+The Vercel News endpoint has no write operation or GitHub token. The local
+Update endpoint is blocked on hosted deployments, LAN/public hostnames and
+cross-site requests; it also refuses dirty, detached, diverged or non-`main`
+checkouts. It never installs dependencies or restarts a process. Users can turn
+alerts off (and back on) in their browser; the preference remains local to that
+browser.
+
+Because the experimental Web section runs pasted code in the same origin, only
+paste code you trust: same-origin code can make the same local requests as the
+editor UI. The Git updater still accepts only a clean fast-forward from the
+configured repository, but the Web preview should be sandboxed before treating
+hostile pasted components as safe.
+
+The static GitHub Pages build omits the bell and API routes. Vercel's local
+`.vercel/` project metadata is ignored by Git.
 
 The experimental Web section intentionally executes the owner's pasted code in
 the app's same-origin context. Only paste code you trust: like any same-origin
-code, it shares the local app's browser privileges. Sandboxing that preview is
-required before treating hostile pasted components as part of the updater's
-threat model.
+code, it shares the local app's browser privileges.
 
 ## Export
 

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import editorialNews from '@/content/news.json';
+
+export const dynamic = 'force-dynamic';
+
+interface EditorialNewsItem {
+  id: string;
+  title: string;
+  body?: string;
+  url?: string;
+}
+
+export async function GET() {
+  const isProduction = process.env.VERCEL_ENV === 'production';
+
+  if (!isProduction) {
+    return NextResponse.json(
+      { available: false, items: [] },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const authoredItems = (editorialNews as EditorialNewsItem[]).slice(0, 20).map((item) => ({
+    id: `news:${item.id}`,
+    type: 'news' as const,
+    title: item.title,
+    body: item.body ?? null,
+    url: item.url ?? null,
+  }));
+
+  return NextResponse.json(
+    {
+      available: true,
+      items: authoredItems,
+    },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/app/api/update/route.ts
+++ b/app/api/update/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { applyLocalUpdate, checkLocalUpdate } from '@/lib/localUpdate';
+import { IS_HOSTED_DEPLOYMENT } from '@/lib/deployment';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function isLoopback(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  return host === 'localhost' || host === '::1' || host.startsWith('127.');
+}
+function requestHostname(request: NextRequest): string {
+  // Next dev normalizes request.url to its own localhost origin even when the
+  // browser reached it through a LAN address. The forwarded/Host header keeps
+  // the address the browser actually used.
+  const rawHost = (request.headers.get('x-forwarded-host') || request.headers.get('host') || '')
+    .split(',')[0]
+    .trim();
+  if (rawHost.startsWith('[')) return rawHost.slice(1, rawHost.indexOf(']'));
+  return rawHost.split(':')[0];
+}
+
+function localOnly(request: NextRequest): NextResponse | null {
+  if (IS_HOSTED_DEPLOYMENT) {
+    return NextResponse.json(
+      { supported: false, error: 'Hosted deployments are updated by the deployment provider.' },
+      { status: 403 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const hostname = requestHostname(request) || url.hostname;
+  if (!isLoopback(hostname)) {
+    return NextResponse.json(
+      { supported: false, error: 'Updates are only available from localhost.' },
+      { status: 403 },
+    );
+  }
+
+  const origin = request.headers.get('origin');
+  if (origin && origin !== url.origin) {
+    return NextResponse.json(
+      { supported: false, error: 'Cross-origin update request rejected.' },
+      { status: 403 },
+    );
+  }
+
+  const fetchSite = request.headers.get('sec-fetch-site');
+  if (fetchSite && fetchSite !== 'same-origin') {
+    return NextResponse.json(
+      { supported: false, error: 'Cross-site update request rejected.' },
+      { status: 403 },
+    );
+  }
+  return null;
+}
+
+function failure(error: unknown): NextResponse {
+  const message = error instanceof Error ? error.message : 'Could not check for updates.';
+  return NextResponse.json({ supported: false, error: message }, { status: 503 });
+}
+
+export async function GET(request: NextRequest) {
+  const rejected = localOnly(request);
+  if (rejected) return rejected;
+
+  try {
+    const status = await checkLocalUpdate();
+    return NextResponse.json(status, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    return failure(error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const rejected = localOnly(request);
+  if (rejected) return rejected;
+
+  if (request.headers.get('x-motion-update') !== 'confirmed' || !request.headers.get('content-type')?.includes('application/json')) {
+    return NextResponse.json(
+      { supported: false, error: 'Explicit update confirmation is required.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const body = await request.json() as { confirm?: unknown };
+    if (body.confirm !== true) {
+      return NextResponse.json(
+        { supported: false, error: 'Explicit update confirmation is required.' },
+        { status: 400 },
+      );
+    }
+  } catch {
+    return NextResponse.json({ supported: false, error: 'Invalid update request.' }, { status: 400 });
+  }
+
+  try {
+    const status = await applyLocalUpdate();
+    const httpStatus = status.updateAvailable && !status.canUpdate ? 409 : 200;
+    return NextResponse.json(status, {
+      status: httpStatus,
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  } catch (error) {
+    return failure(error);
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -176,9 +176,9 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
 }
 .rail-item.rail-subitem { width: 100%; height: 52px; margin-bottom: 2px; }
 .rail-bottom { padding: 8px; border-top: 1px solid var(--line); }
-.rail-update { width: 100%; margin: 0 0 4px; }
-.news-bell-icon { position: relative; }
-.news-bell-dot {
+.rail-update, .rail-news { width: 100%; margin: 0 0 4px; }
+.update-bell-icon, .news-bell-icon { position: relative; }
+.update-bell-dot, .news-bell-dot {
   position: absolute; top: -2px; right: -2px; width: 7px; height: 7px;
   border: 1.5px solid var(--card); border-radius: 50%; background: var(--gz-x, #ef4444);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -176,6 +176,12 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
 }
 .rail-item.rail-subitem { width: 100%; height: 52px; margin-bottom: 2px; }
 .rail-bottom { padding: 8px; border-top: 1px solid var(--line); }
+.rail-update { width: 100%; margin: 0 0 4px; }
+.update-bell-icon { position: relative; }
+.update-bell-dot {
+  position: absolute; top: -2px; right: -2px; width: 7px; height: 7px;
+  border: 1.5px solid var(--card); border-radius: 50%; background: var(--gz-x, #ef4444);
+}
 .rail-theme { width: 100%; margin: 0; }
 
 /* ============================================================
@@ -1129,6 +1135,48 @@ select.field { padding-right: 26px; }
 .welcome-agree input[type=checkbox] {
   width: 15px; height: 15px; margin: 0; accent-color: var(--inverse-bg); cursor: pointer;
   appearance: auto; -webkit-appearance: checkbox;
+}
+
+/* ============================================================
+   LOCAL UPDATE NOTICE — checks official main and fast-forwards on consent
+   ============================================================ */
+.update-notice {
+  position: fixed; z-index: 190;
+  width: min(380px, calc(100vw - 100px)); max-height: calc(100dvh - 24px); padding: 18px;
+  display: flex; flex-direction: column; gap: 10px;
+  overflow-y: auto;
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--r-card);
+  box-shadow: 0 18px 55px rgba(0,0,0,0.2); color: var(--fg);
+}
+.update-notice-close {
+  position: absolute; top: 10px; right: 12px; width: 28px; height: 28px;
+  display: grid; place-items: center; border-radius: var(--r-chip);
+  color: var(--fg-faint); font-size: 20px; line-height: 1;
+}
+.update-notice-close:hover { background: var(--card-inset); color: var(--fg); }
+.update-notice-eyebrow {
+  padding-right: 28px; color: var(--fg-faint); font-size: var(--fs-eyebrow);
+  font-weight: 600; letter-spacing: 1.2px; line-height: 1.2; text-transform: uppercase;
+}
+.update-notice strong { font-size: 15px; line-height: 1.35; }
+.update-notice p { margin: 0; color: var(--fg-label); font-size: var(--fs-label); line-height: 1.5; }
+.update-notice code { padding: 2px 5px; background: var(--card-inset); border-radius: 4px; color: var(--fg); }
+.update-notice-list {
+  margin: 0; padding-left: 18px; display: flex; flex-direction: column; gap: 5px;
+  color: var(--fg-label); font-size: var(--fs-ui); line-height: 1.4;
+}
+.update-notice-warning, .update-notice-info { padding: 9px 10px; background: var(--card-inset); border-radius: var(--r-ctrl); }
+.update-notice-actions { margin-top: 3px; display: flex; align-items: center; justify-content: flex-end; gap: 12px; }
+.update-notice-primary { min-width: 112px; height: 34px; padding: 0 14px; }
+.update-notice-optout {
+  align-self: flex-start; color: var(--fg-faint); font-size: var(--fs-ui); text-decoration: underline;
+  text-decoration-color: transparent; text-underline-offset: 3px;
+}
+.update-notice-optout:hover { color: var(--fg-label); text-decoration-color: currentColor; }
+.update-notice button:disabled { opacity: 0.45; cursor: not-allowed; }
+
+@media (max-width: 919px) {
+  .update-notice { left: 12px !important; right: 12px; bottom: 12px !important; width: auto; }
 }
 
 /* ============================================================

--- a/app/globals.css
+++ b/app/globals.css
@@ -177,8 +177,8 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
 .rail-item.rail-subitem { width: 100%; height: 52px; margin-bottom: 2px; }
 .rail-bottom { padding: 8px; border-top: 1px solid var(--line); }
 .rail-update { width: 100%; margin: 0 0 4px; }
-.update-bell-icon { position: relative; }
-.update-bell-dot {
+.news-bell-icon { position: relative; }
+.news-bell-dot {
   position: absolute; top: -2px; right: -2px; width: 7px; height: 7px;
   border: 1.5px solid var(--card); border-radius: 50%; background: var(--gz-x, #ef4444);
 }
@@ -1138,9 +1138,9 @@ select.field { padding-right: 26px; }
 }
 
 /* ============================================================
-   LOCAL UPDATE NOTICE — checks official main and fast-forwards on consent
+   NEWS NOTICE — read-only production deployment announcements
    ============================================================ */
-.update-notice {
+.news-notice {
   position: fixed; z-index: 190;
   width: min(380px, calc(100vw - 100px)); max-height: calc(100dvh - 24px); padding: 18px;
   display: flex; flex-direction: column; gap: 10px;
@@ -1148,35 +1148,41 @@ select.field { padding-right: 26px; }
   background: var(--card); border: 1px solid var(--line); border-radius: var(--r-card);
   box-shadow: 0 18px 55px rgba(0,0,0,0.2); color: var(--fg);
 }
-.update-notice-close {
+.news-notice-close {
   position: absolute; top: 10px; right: 12px; width: 28px; height: 28px;
   display: grid; place-items: center; border-radius: var(--r-chip);
   color: var(--fg-faint); font-size: 20px; line-height: 1;
 }
-.update-notice-close:hover { background: var(--card-inset); color: var(--fg); }
-.update-notice-eyebrow {
+.news-notice-close:hover { background: var(--card-inset); color: var(--fg); }
+.news-notice-eyebrow {
   padding-right: 28px; color: var(--fg-faint); font-size: var(--fs-eyebrow);
   font-weight: 600; letter-spacing: 1.2px; line-height: 1.2; text-transform: uppercase;
 }
-.update-notice strong { font-size: 15px; line-height: 1.35; }
-.update-notice p { margin: 0; color: var(--fg-label); font-size: var(--fs-label); line-height: 1.5; }
-.update-notice code { padding: 2px 5px; background: var(--card-inset); border-radius: 4px; color: var(--fg); }
-.update-notice-list {
-  margin: 0; padding-left: 18px; display: flex; flex-direction: column; gap: 5px;
-  color: var(--fg-label); font-size: var(--fs-ui); line-height: 1.4;
+.news-notice strong { font-size: 15px; line-height: 1.35; }
+.news-notice p { margin: 0; color: var(--fg-label); font-size: var(--fs-label); line-height: 1.5; }
+.news-notice-list {
+  display: flex; flex-direction: column; gap: 8px;
 }
-.update-notice-warning, .update-notice-info { padding: 9px 10px; background: var(--card-inset); border-radius: var(--r-ctrl); }
-.update-notice-actions { margin-top: 3px; display: flex; align-items: center; justify-content: flex-end; gap: 12px; }
-.update-notice-primary { min-width: 112px; height: 34px; padding: 0 14px; }
-.update-notice-optout {
+.news-notice-item {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 5px; padding: 10px;
+  background: var(--card-inset); border: 1px solid var(--line); border-radius: var(--r-ctrl);
+}
+.news-notice-item strong { font-size: var(--fs-label); }
+.news-notice-kind {
+  color: var(--fg-faint); font-size: var(--fs-eyebrow); font-weight: 600;
+  letter-spacing: 1px; text-transform: uppercase;
+}
+.news-notice-actions { margin-top: 3px; display: flex; align-items: center; justify-content: flex-end; gap: 12px; }
+.news-notice-primary { min-width: 112px; height: 34px; padding: 0 14px; }
+.news-notice-optout {
   align-self: flex-start; color: var(--fg-faint); font-size: var(--fs-ui); text-decoration: underline;
   text-decoration-color: transparent; text-underline-offset: 3px;
 }
-.update-notice-optout:hover { color: var(--fg-label); text-decoration-color: currentColor; }
-.update-notice button:disabled { opacity: 0.45; cursor: not-allowed; }
+.news-notice-optout:hover { color: var(--fg-label); text-decoration-color: currentColor; }
+.news-notice button:disabled { opacity: 0.45; cursor: not-allowed; }
 
 @media (max-width: 919px) {
-  .update-notice { left: 12px !important; right: 12px; bottom: 12px !important; width: auto; }
+  .news-notice { left: 12px !important; right: 12px; bottom: 12px !important; width: auto; }
 }
 
 /* ============================================================

--- a/components/EditorIcons.tsx
+++ b/components/EditorIcons.tsx
@@ -56,6 +56,10 @@ export function MoonIcon(props: EditorIconProps) {
   return <svg {...iconProps(props)}><path d="M15.7 12.6A6 6 0 017.4 4.3 6.1 6.1 0 1015.7 12.6z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>;
 }
 
+export function BellIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M5.25 8.4a4.75 4.75 0 019.5 0v3.1l1.35 2.1H3.9l1.35-2.1V8.4z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/><path d="M8.15 15.2a2 2 0 003.7 0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>;
+}
+
 export function MediaIcon(props: EditorIconProps) {
   return <svg {...iconProps(props)}><rect x="2.75" y="3.5" width="14.5" height="13" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><circle cx="7" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.5"/><path d="M4.5 14l3.2-3 2.4 2 2.1-2.1 3.3 3.1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
 }

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { NAV_SECTIONS, sectionFromPathname, type NavSectionId } from '@/lib/navSections';
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
+import UpdateNotifier from './UpdateNotifier';
 import { AddIcon, BoardIcon, ChevronDownIcon, ExperimentalsIcon, LibraryIcon, MockupIcon, MoonIcon, ProjectsIcon, SunIcon, ThreeDIcon, WebIcon } from './EditorIcons';
 
 const ICONS: Record<NavSectionId, React.ReactNode> = {
@@ -109,6 +110,7 @@ export default function IconRail() {
         </div>
       </div>
       <div className="rail-bottom">
+        <UpdateNotifier />
         <button
           className="rail-item rail-theme"
           onClick={toggleTheme}

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -6,6 +6,8 @@ import { usePathname, useRouter } from 'next/navigation';
 import { NAV_SECTIONS, sectionFromPathname, type NavSectionId } from '@/lib/navSections';
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
+import { IS_HOSTED_DEPLOYMENT } from '@/lib/deployment';
+import NewsNotifier from './NewsNotifier';
 import UpdateNotifier from './UpdateNotifier';
 import { AddIcon, BoardIcon, ChevronDownIcon, ExperimentalsIcon, LibraryIcon, MockupIcon, MoonIcon, ProjectsIcon, SunIcon, ThreeDIcon, WebIcon } from './EditorIcons';
 
@@ -110,7 +112,7 @@ export default function IconRail() {
         </div>
       </div>
       <div className="rail-bottom">
-        <UpdateNotifier />
+        {IS_HOSTED_DEPLOYMENT ? <NewsNotifier /> : <UpdateNotifier />}
         <button
           className="rail-item rail-theme"
           onClick={toggleTheme}

--- a/components/NewsNotifier.tsx
+++ b/components/NewsNotifier.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { BellIcon } from './EditorIcons';
+
+const SEEN_ITEMS_KEY = 'motion-news-seen-items';
+const ALERTS_KEY = 'motion-news-alerts';
+const CHECK_INTERVAL_MS = 5 * 60_000;
+
+interface FeedItem {
+  id: string;
+  type: 'news';
+  title: string;
+  body: string | null;
+  url: string | null;
+}
+
+interface FeedResponse {
+  available: boolean;
+  items: FeedItem[];
+}
+
+function readLocal(key: string): string | null {
+  try { return localStorage.getItem(key); } catch { return null; }
+}
+
+function writeLocal(key: string, value: string) {
+  try { localStorage.setItem(key, value); } catch { /* storage may be blocked */ }
+}
+
+function readSeenItems(): Set<string> {
+  try {
+    const parsed = JSON.parse(readLocal(SEEN_ITEMS_KEY) ?? '[]');
+    return new Set(Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function markItemsSeen(items: FeedItem[]) {
+  const seen = readSeenItems();
+  items.forEach((item) => seen.add(item.id));
+  writeLocal(SEEN_ITEMS_KEY, JSON.stringify(Array.from(seen).slice(-100)));
+}
+
+export default function NewsNotifier() {
+  const bellRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLElement>(null);
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [open, setOpen] = useState(false);
+  const [unread, setUnread] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [items, setItems] = useState<FeedItem[]>([]);
+  const [message, setMessage] = useState('');
+  const [position, setPosition] = useState({ left: 84, bottom: 72 });
+
+  const placePanel = useCallback(() => {
+    const rect = bellRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setPosition({
+      left: Math.round(rect.right + 10),
+      bottom: Math.max(12, Math.round(window.innerHeight - rect.bottom)),
+    });
+  }, []);
+
+  const markRead = useCallback(() => {
+    markItemsSeen(items);
+    setUnread(false);
+  }, [items]);
+
+  const check = useCallback(async (manual = false) => {
+    if (process.env.NEXT_PUBLIC_STATIC_EXPORT === '1') return;
+    setChecking(true);
+    if (manual) setMessage('');
+
+    try {
+      const response = await fetch('/api/news', { cache: 'no-store' });
+      const next = await response.json() as FeedResponse;
+      if (!response.ok) throw new Error('Could not check for news.');
+
+      const nextItems = next.available ? next.items : [];
+      setItems(nextItems);
+      const seen = readSeenItems();
+      const hasUnread = nextItems.some((item) => !seen.has(item.id));
+      setUnread(hasUnread);
+
+      if (nextItems.length === 0 && manual) {
+        setMessage('Published news will appear after a successful production deployment.');
+      }
+      if (hasUnread || manual) setOpen(true);
+    } catch {
+      if (manual) {
+        setMessage('Could not check for news. Please try again.');
+        setOpen(true);
+      }
+    } finally {
+      setChecking(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setEnabled(readLocal(ALERTS_KEY) !== 'off');
+  }, []);
+
+  useEffect(() => {
+    if (enabled !== true) return;
+    const firstCheck = window.setTimeout(() => check(false), 2_000);
+    const interval = window.setInterval(() => check(false), CHECK_INTERVAL_MS);
+    return () => {
+      window.clearTimeout(firstCheck);
+      window.clearInterval(interval);
+    };
+  }, [check, enabled]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    placePanel();
+    window.addEventListener('resize', placePanel);
+    return () => window.removeEventListener('resize', placePanel);
+  }, [open, placePanel]);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOutside = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (!panelRef.current?.contains(target) && !bellRef.current?.contains(target)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        bellRef.current?.focus();
+      }
+    };
+    document.addEventListener('pointerdown', closeOutside);
+    document.addEventListener('keydown', closeOnEscape);
+    return () => {
+      document.removeEventListener('pointerdown', closeOutside);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [open]);
+
+  const togglePanel = () => {
+    const opening = !open;
+    setOpen(opening);
+    if (opening && enabled && items.length === 0) void check(true);
+  };
+
+  const disableAlerts = () => {
+    writeLocal(ALERTS_KEY, 'off');
+    markItemsSeen(items);
+    setEnabled(false);
+    setUnread(false);
+    setMessage('');
+  };
+
+  const enableAlerts = () => {
+    writeLocal(ALERTS_KEY, 'on');
+    setEnabled(true);
+    setMessage('');
+    void check(true);
+  };
+
+  const panel = open && enabled !== null ? (
+    <aside
+      ref={panelRef}
+      id="news-notification-panel"
+      className="news-notice"
+      style={{ left: position.left, bottom: position.bottom }}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="news-notice-title"
+    >
+      <button className="news-notice-close" onClick={() => setOpen(false)} aria-label="Close news">×</button>
+      {enabled === false ? (
+        <>
+          <span className="news-notice-eyebrow">Notifications</span>
+          <strong id="news-notice-title">News alerts are off</strong>
+          <p>Automatic checks are disabled in this browser.</p>
+          <button className="btn solid news-notice-primary" onClick={enableAlerts} disabled={checking}>
+            {checking ? 'Checking…' : 'Turn alerts back on'}
+          </button>
+        </>
+      ) : items.length > 0 ? (
+        <>
+          <span className="news-notice-eyebrow">Notifications</span>
+          <strong id="news-notice-title">News</strong>
+          <div className="news-notice-list">
+            {items.slice(0, 5).map((item) => (
+              <article className="news-notice-item" key={item.id}>
+                <span className="news-notice-kind">News</span>
+                <strong>{item.title}</strong>
+                {item.body && <p>{item.body}</p>}
+                {item.url && <a className="link-btn" href={item.url} target="_blank" rel="noreferrer">View details</a>}
+              </article>
+            ))}
+          </div>
+          <div className="news-notice-actions">
+            <button className="btn solid news-notice-primary" onClick={() => { markRead(); setOpen(false); }}>
+              Mark all as read
+            </button>
+          </div>
+          <button className="news-notice-optout" onClick={disableAlerts}>Turn off news alerts</button>
+        </>
+      ) : (
+        <>
+          <span className="news-notice-eyebrow">Notifications</span>
+          <strong id="news-notice-title">News</strong>
+          <p>{message || 'Published news will appear here.'}</p>
+          <button className="btn news-notice-primary" onClick={() => check(true)} disabled={checking}>
+            {checking ? 'Checking…' : 'Check now'}
+          </button>
+          <button className="news-notice-optout" onClick={disableAlerts}>Turn off news alerts</button>
+        </>
+      )}
+    </aside>
+  ) : null;
+
+  if (process.env.NEXT_PUBLIC_STATIC_EXPORT === '1') return null;
+
+  return (
+    <>
+      <button
+        ref={bellRef}
+        className={`rail-item rail-news ${open ? 'active' : ''}`}
+        onClick={togglePanel}
+        aria-label={unread ? 'News, new items available' : 'News'}
+        aria-expanded={open}
+        aria-controls="news-notification-panel"
+        title="News"
+      >
+        <span className="rail-ico news-bell-icon">
+          <BellIcon />
+          {unread && <span className="news-bell-dot" aria-hidden="true" />}
+        </span>
+        <span className="rail-label">News</span>
+      </button>
+      {typeof document !== 'undefined' && panel ? createPortal(panel, document.body) : null}
+    </>
+  );
+}

--- a/components/UpdateNotifier.tsx
+++ b/components/UpdateNotifier.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { IS_HOSTED_DEPLOYMENT, RELEASE_NOTES_URL } from '@/lib/deployment';
+import { BellIcon } from './EditorIcons';
+
+const READ_KEY = 'motion-update-dismissed';
+const ALERTS_KEY = 'motion-update-alerts';
+const CHECK_INTERVAL_MS = 60 * 60_000;
+
+function readLocal(key: string): string | null {
+  try { return localStorage.getItem(key); } catch { return null; }
+}
+function writeLocal(key: string, value: string) {
+  try { localStorage.setItem(key, value); } catch { /* storage may be blocked */ }
+}
+
+interface UpdateCommit {
+  hash: string;
+  subject: string;
+}
+
+interface UpdateStatus {
+  supported: boolean;
+  updateAvailable: boolean;
+  canUpdate: boolean;
+  currentCommit: string;
+  latestCommit: string;
+  commits: UpdateCommit[];
+  reason?: 'dirty' | 'detached' | 'diverged' | 'branch';
+  updated?: boolean;
+  dependenciesChanged?: boolean;
+  error?: string;
+}
+
+type Phase = 'idle' | 'updating' | 'done' | 'error';
+
+const reasonText: Record<NonNullable<UpdateStatus['reason']>, string> = {
+  dirty: 'You have local changes. Commit or stash them before updating.',
+  detached: 'Git is in detached HEAD state. Switch to the main branch before updating.',
+  diverged: 'Your history has diverged from the official version. Update it manually with Git.',
+  branch: 'Automatic updates are only allowed on the main branch.',
+};
+
+export default function UpdateNotifier() {
+  const bellRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLElement>(null);
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [open, setOpen] = useState(false);
+  const [unread, setUnread] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [message, setMessage] = useState('');
+  const [position, setPosition] = useState({ left: 84, bottom: 72 });
+
+  const placePanel = useCallback(() => {
+    const rect = bellRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setPosition({
+      left: Math.round(rect.right + 10),
+      bottom: Math.max(12, Math.round(window.innerHeight - rect.bottom)),
+    });
+  }, []);
+
+  const markRead = useCallback((latestCommit?: string) => {
+    if (latestCommit) writeLocal(READ_KEY, latestCommit);
+    setUnread(false);
+  }, []);
+
+  const check = useCallback(async (manual = false) => {
+    if (IS_HOSTED_DEPLOYMENT || process.env.NEXT_PUBLIC_STATIC_EXPORT === '1') return;
+    setChecking(true);
+    if (manual) {
+      setMessage('');
+      setPhase('idle');
+    }
+    try {
+      const response = await fetch('/api/update', { cache: 'no-store' });
+      const next = await response.json() as UpdateStatus;
+      if (!response.ok || !next.supported) throw new Error(next.error || 'Could not check for updates.');
+      setStatus(next);
+      if (next.updateAvailable) {
+        const isUnread = readLocal(READ_KEY) !== next.latestCommit;
+        setUnread(isUnread);
+        if (isUnread || manual) setOpen(true);
+      } else if (manual) {
+        setOpen(true);
+        setMessage('You are already running the latest version.');
+      }
+    } catch (error) {
+      if (manual) {
+        setMessage(error instanceof Error ? error.message : 'Could not check for updates.');
+        setPhase('error');
+        setOpen(true);
+      }
+    } finally {
+      setChecking(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setEnabled(IS_HOSTED_DEPLOYMENT || readLocal(ALERTS_KEY) !== 'off');
+  }, []);
+
+  useEffect(() => {
+    if (IS_HOSTED_DEPLOYMENT || enabled !== true) return;
+    const firstCheck = window.setTimeout(() => check(false), 4_000);
+    const interval = window.setInterval(() => check(false), CHECK_INTERVAL_MS);
+    return () => {
+      window.clearTimeout(firstCheck);
+      window.clearInterval(interval);
+    };
+  }, [check, enabled]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    placePanel();
+    window.addEventListener('resize', placePanel);
+    return () => window.removeEventListener('resize', placePanel);
+  }, [open, placePanel]);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOutside = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (!panelRef.current?.contains(target) && !bellRef.current?.contains(target)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        bellRef.current?.focus();
+      }
+    };
+    document.addEventListener('pointerdown', closeOutside);
+    document.addEventListener('keydown', closeOnEscape);
+    return () => {
+      document.removeEventListener('pointerdown', closeOutside);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [open]);
+
+  const togglePanel = () => {
+    if (!open) markRead(status?.latestCommit);
+    setOpen(!open);
+  };
+
+  const disableAlerts = () => {
+    writeLocal(ALERTS_KEY, 'off');
+    setEnabled(false);
+    setUnread(false);
+    setPhase('idle');
+    setMessage('Automatic update alerts are turned off in this browser.');
+  };
+
+  const enableAlerts = () => {
+    writeLocal(ALERTS_KEY, 'on');
+    setEnabled(true);
+    setMessage('');
+    void check(true);
+  };
+
+  const update = async () => {
+    setPhase('updating');
+    setMessage('');
+    try {
+      const response = await fetch('/api/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Motion-Update': 'confirmed' },
+        body: JSON.stringify({ confirm: true }),
+      });
+      const next = await response.json() as UpdateStatus;
+      setStatus(next);
+      if (!response.ok || !next.updated) {
+        const detail = next.reason ? reasonText[next.reason] : next.error;
+        throw new Error(detail || 'Could not update the project.');
+      }
+      markRead(next.latestCommit);
+      setPhase('done');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not update the project.');
+      setPhase('error');
+    }
+  };
+
+  const panel = open && enabled !== null ? (
+    <aside
+      ref={panelRef}
+      id="update-notification-panel"
+      className="update-notice"
+      style={{ left: position.left, bottom: position.bottom }}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="update-notice-title"
+    >
+      <button className="update-notice-close" onClick={() => setOpen(false)} aria-label="Close notifications">×</button>
+      {IS_HOSTED_DEPLOYMENT ? (
+        <>
+          <span className="update-notice-eyebrow">Hosted version</span>
+          <strong id="update-notice-title">What’s new in Motion Studio</strong>
+          <p>
+            This version is updated automatically when a new Vercel deployment is published.
+            There is no local Git update to install here.
+          </p>
+          <a
+            className="btn solid update-notice-primary"
+            href={RELEASE_NOTES_URL}
+            target="_blank"
+            rel="noreferrer"
+          >
+            See latest changes
+          </a>
+        </>
+      ) : enabled === false ? (
+        <>
+          <span className="update-notice-eyebrow">Notifications</span>
+          <strong id="update-notice-title">Update alerts are off</strong>
+          <p>No automatic Git checks will run in this browser.</p>
+          {message && <p className="update-notice-info">{message}</p>}
+          <button className="btn solid update-notice-primary" onClick={enableAlerts} disabled={checking}>
+            {checking ? 'Checking…' : 'Turn alerts back on'}
+          </button>
+        </>
+      ) : phase === 'done' ? (
+        <>
+          <span className="update-notice-eyebrow">Update complete</span>
+          <strong id="update-notice-title">Git is up to date.</strong>
+          <p>
+            {status?.dependenciesChanged
+              ? <>Run <code>npm install</code>, then restart the server to use the new version.</>
+              : 'Restart the server to use the new version.'}
+          </p>
+          <button className="btn solid update-notice-primary" onClick={() => setOpen(false)}>Got it</button>
+        </>
+      ) : status?.updateAvailable ? (
+        <>
+          <span className="update-notice-eyebrow">New version available</span>
+          <strong id="update-notice-title">What’s new in Motion Studio</strong>
+          {status.commits.length > 0 && (
+            <ul className="update-notice-list">
+              {status.commits.slice(0, 3).map((commit) => <li key={commit.hash}>{commit.subject}</li>)}
+            </ul>
+          )}
+          {status.reason && <p className="update-notice-warning">{reasonText[status.reason]}</p>}
+          {phase === 'error' && <p className="update-notice-warning">{message}</p>}
+          <div className="update-notice-actions">
+            <button className="link-btn" onClick={() => { markRead(status.latestCommit); setOpen(false); }} disabled={phase === 'updating'}>Not now</button>
+            <button className="btn solid update-notice-primary" onClick={update} disabled={!status.canUpdate || phase === 'updating'}>
+              {phase === 'updating' ? 'Updating…' : 'Update Git'}
+            </button>
+          </div>
+          <button className="update-notice-optout" onClick={disableAlerts}>Turn off update alerts</button>
+        </>
+      ) : (
+        <>
+          <span className="update-notice-eyebrow">Notifications</span>
+          <strong id="update-notice-title">Motion Studio updates</strong>
+          {phase === 'error'
+            ? <p className="update-notice-warning">{message}</p>
+            : <p>{message || 'New versions will appear here when they are available.'}</p>}
+          <button className="btn update-notice-primary" onClick={() => check(true)} disabled={checking}>
+            {checking ? 'Checking…' : 'Check now'}
+          </button>
+          <button className="update-notice-optout" onClick={disableAlerts}>Turn off update alerts</button>
+        </>
+      )}
+    </aside>
+  ) : null;
+
+  if (process.env.NEXT_PUBLIC_STATIC_EXPORT === '1') return null;
+
+  return (
+    <>
+      <button
+        ref={bellRef}
+        className={`rail-item rail-update ${open ? 'active' : ''}`}
+        onClick={togglePanel}
+        aria-label={IS_HOSTED_DEPLOYMENT
+          ? 'What’s new in Motion Studio'
+          : unread ? 'Notifications, new update available' : 'Update notifications'}
+        aria-expanded={open}
+        aria-controls="update-notification-panel"
+        title={IS_HOSTED_DEPLOYMENT ? 'What’s new' : 'Updates'}
+      >
+        <span className="rail-ico update-bell-icon">
+          <BellIcon />
+          {unread && <span className="update-bell-dot" aria-hidden="true" />}
+        </span>
+        <span className="rail-label">{IS_HOSTED_DEPLOYMENT ? 'News' : 'Updates'}</span>
+      </button>
+      {typeof document !== 'undefined' && panel ? createPortal(panel, document.body) : null}
+    </>
+  );
+}

--- a/content/news.json
+++ b/content/news.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "news-notifications-launch",
+    "title": "News notifications are now available",
+    "body": "Product news will appear here after it is published to Motion Studio. You can turn these alerts off at any time."
+  }
+]

--- a/lib/deployment.ts
+++ b/lib/deployment.ts
@@ -1,0 +1,12 @@
+export type DeploymentMode = 'hosted' | 'self-hosted';
+
+// next.config.mjs resolves the mode once at build time. Keeping the public
+// value behind this module gives client and server code one shared question to
+// ask instead of scattering Vercel/environment checks through the app.
+export const DEPLOYMENT_MODE: DeploymentMode =
+  process.env.NEXT_PUBLIC_DEPLOYMENT_MODE === 'hosted' ? 'hosted' : 'self-hosted';
+
+export const IS_HOSTED_DEPLOYMENT = DEPLOYMENT_MODE === 'hosted';
+
+export const RELEASE_NOTES_URL =
+  'https://github.com/appariciojunior/motion-studio-open/commits/main/';

--- a/lib/localUpdate.ts
+++ b/lib/localUpdate.ts
@@ -1,0 +1,192 @@
+import 'server-only';
+
+import { execFile } from 'node:child_process';
+
+const OFFICIAL_REPOSITORY = 'https://github.com/appariciojunior/motion-studio-open.git';
+const UPDATE_BRANCH = 'main';
+const GIT_TIMEOUT_MS = 30_000;
+
+export interface UpdateCommit {
+  hash: string;
+  subject: string;
+}
+export interface LocalUpdateStatus {
+  supported: true;
+  updateAvailable: boolean;
+  canUpdate: boolean;
+  currentCommit: string;
+  latestCommit: string;
+  branch: string | null;
+  commits: UpdateCommit[];
+  reason?: 'dirty' | 'detached' | 'diverged' | 'branch';
+}
+
+type GitError = Error & { code?: number | string; stderr?: string };
+
+function runGit(cwd: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      args,
+      {
+        cwd,
+        encoding: 'utf8',
+        timeout: GIT_TIMEOUT_MS,
+        windowsHide: true,
+        maxBuffer: 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const gitError = error as GitError;
+          gitError.stderr = stderr;
+          reject(gitError);
+          return;
+        }
+        resolve(stdout.trim());
+      },
+    );
+  });
+}
+
+async function succeeds(cwd: string, args: string[]): Promise<boolean> {
+  try {
+    await runGit(cwd, args);
+    return true;
+  } catch (error) {
+    // `git merge-base --is-ancestor` uses exit code 1 for a normal "no".
+    if ((error as GitError).code === 1) return false;
+    throw error;
+  }
+}
+
+async function repositoryRoot(): Promise<string> {
+  return runGit(process.cwd(), ['rev-parse', '--show-toplevel']);
+}
+
+function parseCommits(output: string): UpdateCommit[] {
+  if (!output) return [];
+  const commits = output.split('\n').flatMap((line) => {
+    const separator = line.indexOf('\t');
+    if (separator < 0) return [];
+    return [{ hash: line.slice(0, separator), subject: line.slice(separator + 1) }];
+  });
+  const meaningful = commits.filter((commit) => !commit.subject.startsWith('Merge pull request'));
+  return meaningful.length ? meaningful : commits;
+}
+
+async function inspectFetchedUpdate(root: string): Promise<LocalUpdateStatus> {
+  const [currentCommit, latestCommit, branch, dirty] = await Promise.all([
+    runGit(root, ['rev-parse', 'HEAD']),
+    runGit(root, ['rev-parse', 'FETCH_HEAD']),
+    runGit(root, ['symbolic-ref', '--quiet', '--short', 'HEAD']).catch(() => ''),
+    runGit(root, ['status', '--porcelain', '--untracked-files=normal']),
+  ]);
+
+  if (currentCommit === latestCommit) {
+    return {
+      supported: true,
+      updateAvailable: false,
+      canUpdate: false,
+      currentCommit,
+      latestCommit,
+      branch: branch || null,
+      commits: [],
+    };
+  }
+
+  const isBehind = await succeeds(root, ['merge-base', '--is-ancestor', currentCommit, latestCommit]);
+  if (!isBehind) {
+    // A local commit on top of official main is already newer for update
+    // purposes. Two unrelated tips, however, need a person to reconcile them.
+    const isAhead = await succeeds(root, ['merge-base', '--is-ancestor', latestCommit, currentCommit]);
+    const log = isAhead ? '' : await runGit(root, [
+      'log',
+      '--format=%H%x09%s',
+      '--max-count=8',
+      latestCommit,
+      `^${currentCommit}`,
+    ]);
+    return {
+      supported: true,
+      updateAvailable: !isAhead,
+      canUpdate: false,
+      currentCommit,
+      latestCommit,
+      branch: branch || null,
+      commits: parseCommits(log),
+      reason: isAhead ? undefined : 'diverged',
+    };
+  }
+
+  const log = await runGit(root, [
+    'log',
+    '--format=%H%x09%s',
+    '--max-count=8',
+    `${currentCommit}..${latestCommit}`,
+  ]);
+  const reason = !branch
+    ? 'detached'
+    : branch !== UPDATE_BRANCH
+      ? 'branch'
+      : dirty
+        ? 'dirty'
+        : undefined;
+
+  return {
+    supported: true,
+    updateAvailable: true,
+    canUpdate: !reason,
+    currentCommit,
+    latestCommit,
+    branch: branch || null,
+    commits: parseCommits(log),
+    reason,
+  };
+}
+
+export async function checkLocalUpdate(): Promise<LocalUpdateStatus> {
+  const root = await repositoryRoot();
+  const repository = process.env.MOTION_STUDIO_UPDATE_REPOSITORY || OFFICIAL_REPOSITORY;
+  await runGit(root, ['fetch', '--quiet', '--no-tags', repository, UPDATE_BRANCH]);
+  return inspectFetchedUpdate(root);
+}
+
+type ApplyUpdateResult = LocalUpdateStatus & { updated: boolean; dependenciesChanged: boolean };
+
+let activeUpdate: Promise<ApplyUpdateResult> | null = null;
+
+async function applyLocalUpdateOnce(): Promise<ApplyUpdateResult> {
+  const root = await repositoryRoot();
+  const repository = process.env.MOTION_STUDIO_UPDATE_REPOSITORY || OFFICIAL_REPOSITORY;
+
+  // Always fetch again at click time: the status shown in the browser may have
+  // been open for hours, and FETCH_HEAD is shared mutable Git state.
+  await runGit(root, ['fetch', '--quiet', '--no-tags', repository, UPDATE_BRANCH]);
+  const before = await inspectFetchedUpdate(root);
+  if (!before.updateAvailable) return { ...before, updated: false, dependenciesChanged: false };
+  if (!before.canUpdate) return { ...before, updated: false, dependenciesChanged: false };
+
+  await runGit(root, ['merge', '--ff-only', before.latestCommit]);
+  const dependenciesChanged = !!(await runGit(root, [
+    'diff',
+    '--name-only',
+    before.currentCommit,
+    before.latestCommit,
+    '--',
+    'package.json',
+    'package-lock.json',
+  ]));
+  const after = await inspectFetchedUpdate(root);
+  return { ...after, updated: true, dependenciesChanged };
+}
+
+export function applyLocalUpdate(): Promise<ApplyUpdateResult> {
+  // A double-click or two open tabs must never run concurrent fetch/merge
+  // operations against the same checkout.
+  if (!activeUpdate) {
+    activeUpdate = applyLocalUpdateOnce().finally(() => {
+      activeUpdate = null;
+    });
+  }
+  return activeUpdate;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,16 @@
 const isStatic = process.env.STATIC_EXPORT === '1';
 const basePath = isStatic ? '/motion-studio-open' : '';
 
+// The managed Vercel app is updated by deployments; a downloaded/local copy
+// updates its own Git checkout. Other hosting providers can opt into the same
+// managed behaviour with MOTION_STUDIO_DEPLOYMENT_MODE=hosted.
+const requestedDeploymentMode = process.env.MOTION_STUDIO_DEPLOYMENT_MODE;
+const deploymentMode = requestedDeploymentMode === 'hosted' || requestedDeploymentMode === 'self-hosted'
+  ? requestedDeploymentMode
+  : process.env.VERCEL === '1'
+    ? 'hosted'
+    : 'self-hosted';
+
 const nextConfig = {
   reactStrictMode: false, // avoid double Pixi mount in dev
   devIndicators: false,   // hide the dev overlay badge (it covers the play button)
@@ -17,6 +27,7 @@ const nextConfig = {
   env: {
     NEXT_PUBLIC_BASE_PATH: basePath,
     NEXT_PUBLIC_STATIC_EXPORT: isStatic ? '1' : '',
+    NEXT_PUBLIC_DEPLOYMENT_MODE: deploymentMode,
   },
 };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,9 +6,8 @@
 const isStatic = process.env.STATIC_EXPORT === '1';
 const basePath = isStatic ? '/motion-studio-open' : '';
 
-// The managed Vercel app is updated by deployments; a downloaded/local copy
-// updates its own Git checkout. Other hosting providers can opt into the same
-// managed behaviour with MOTION_STUDIO_DEPLOYMENT_MODE=hosted.
+// Vercel serves the editorial News feed. A downloaded/local checkout instead
+// checks GitHub for Updates and can fast-forward only after explicit consent.
 const requestedDeploymentMode = process.env.MOTION_STUDIO_DEPLOYMENT_MODE;
 const deploymentMode = requestedDeploymentMode === 'hosted' || requestedDeploymentMode === 'self-hosted'
   ? requestedDeploymentMode


### PR DESCRIPTION
## Summary
- add an update bell above the theme control with English-only notification copy
- check official main in the background, show meaningful commit titles, and let users disable or re-enable alerts
- apply local updates only through a clean, fast-forward-only main checkout
- distinguish hosted/Vercel deployments from self-hosted copies and disable Git mutation on hosted builds
- ignore local .vercel/ metadata

## Security
- localhost-only endpoint with Host, Origin, and Sec-Fetch-Site validation
- explicit JSON confirmation header/body for update requests
- block detached, dirty, diverged, and non-main checkouts
- serialize concurrent updates
- never run 
pm install or restart a process automatically

## Validation
- 
pm test
- 
px tsc --noEmit --incremental false
- 
pm run build
- runtime checks: unconfirmed POST 400, LAN request 403