### PR TITLE
Show item counts in library and mockup groups

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -260,6 +260,12 @@ input[type=range] { -webkit-appearance: none; appearance: none; background: none
 .tpl-item:hover:not(:disabled) { background: var(--card-inset); color: var(--fg); }
 .tpl-item.active { background: var(--card-inset); color: var(--fg); }
 .tpl-name { flex: 1; }
+.tpl-group-count {
+  flex: 0 0 auto; min-width: 2ch; text-align: right;
+  font-size: var(--fs-micro); font-variant-numeric: tabular-nums;
+  padding: 2px 5px; border-radius: var(--r-chip);
+  background: var(--card-inset); color: var(--fg-muted);
+}
 .tpl-chevron { width: 12px; height: 12px; color: var(--fg-faint); display: grid; place-items: center; }
 .tpl-accordion { width: 100%; }
 .tpl-accordion-chevron {

--- a/components/MockupPanel.tsx
+++ b/components/MockupPanel.tsx
@@ -63,6 +63,7 @@ export default function MockupPanel() {
                 aria-controls={panelId}
               >
                 <span className="tpl-name">{d.label}</span>
+                <span className="tpl-group-count">{MOCKUP_ANIMATIONS.length}</span>
                 <span className="tpl-accordion-chevron"><Chevron /></span>
               </button>
               {isOpen && (

--- a/components/TemplatesCard.tsx
+++ b/components/TemplatesCard.tsx
@@ -273,7 +273,7 @@ export default function TemplatesCard({
               >
                 <span className="tpl-fav-ico"><Heart filled={favorites.length > 0} /></span>
                 <span className="tpl-name">{FAVORITES_GROUP}</span>
-                {favorites.length > 0 && <span className="tpl-fav-count">{favorites.length}</span>}
+                {favorites.length > 0 && <span className="tpl-group-count">{favorites.length}</span>}
                 <span className="tpl-accordion-chevron"><Chevron /></span>
               </button>
               {favoritesOpen && (
@@ -315,6 +315,7 @@ export default function TemplatesCard({
                     {/* A family is new if any of its presets is, so the marker
                         shows on the collapsed list without opening the group. */}
                     {items.some((t) => t.meta.isNew) && <span className="tpl-new-inline">NEW</span>}
+                    <span className="tpl-group-count">{items.length}</span>
                     <span className="tpl-accordion-chevron"><Chevron /></span>
                   </button>
                   {isOpen && (


### PR DESCRIPTION
## Summary
- show the number of templates beside each Library group chevron
- show the number of animation presets beside each Mockup device chevron
- reuse the existing rounded Favorites badge style and hide the Favorites count when it is zero

## Validation
- npx tsc --noEmit --incremental false
- npm test
- visual verification on /library and /mockup