### PR TITLE
Stabilize and speed up thumbnail loading

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2336,3 +2336,43 @@ select.field { padding-right: 26px; }
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .pdock-recent-meta { font-size: var(--fs-meta); color: var(--fg-faint); flex: 0 0 auto; }
+
+/* ---- Thumbnail skeleton: the box while its still is being rendered ----
+   The thumbnails are rendered now (three for the webgl presets, Pixi for the
+   2D ones), which means there IS a wait where the div path had none — measured
+   at ~1.3s for a 34-card search to have every still. The box itself never
+   collapsed (aspect-ratio holds it at 147px), so what showed was an empty
+   frame, which reads as broken rather than as loading.
+
+   A sweep rather than a pulse: a pulse on 271 boxes at once reads as the whole
+   list flashing, while a sweep travelling in one direction reads as progress.
+   Built from the surface tokens — a skeleton is a surface, not an accent, and
+   the palette has no accent to borrow. */
+.tpl-thumb-skeleton {
+  position: absolute; inset: 0;
+  background: var(--card-inset);
+  overflow: hidden;
+}
+.tpl-thumb-skeleton::after {
+  content: '';
+  position: absolute; inset: 0;
+  /* 200% wide so the highlight can travel a full box width before repeating. */
+  background: linear-gradient(
+    100deg,
+    transparent 20%,
+    color-mix(in srgb, var(--fg) 7%, transparent) 45%,
+    color-mix(in srgb, var(--fg) 7%, transparent) 55%,
+    transparent 80%
+  );
+  background-size: 200% 100%;
+  animation: tpl-thumb-sweep 1.4s linear infinite;
+}
+@keyframes tpl-thumb-sweep {
+  from { background-position: 150% 0; }
+  to   { background-position: -50% 0; }
+}
+/* Reduced motion: keep the surface, drop the travel. The box still reads as
+   "not content yet" because it is a flat inset rather than the frame colour. */
+@media (prefers-reduced-motion: reduce) {
+  .tpl-thumb-skeleton::after { animation: none; }
+}

--- a/components/MockupThumb.tsx
+++ b/components/MockupThumb.tsx
@@ -35,7 +35,12 @@ function getShared(): SharedCtx {
   // Style the shared canvas so it fills the .tpl-thumb container when inserted
   canvas.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;display:block;';
 
-  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: true,
+    powerPreference: 'high-performance',
+  });
   renderer.setSize(THUMB_W, THUMB_H, false);
   renderer.setClearColor(0x000000, 0);
   renderer.toneMapping = THREE.ACESFilmicToneMapping;

--- a/components/TemplateThumb.tsx
+++ b/components/TemplateThumb.tsx
@@ -6,11 +6,32 @@ import { defaultsFor, easingFor, layerCountFor } from '@/templates';
 import { resolveEasing } from '@/lib/easing';
 import dynamic from 'next/dynamic';
 
+// The skeleton, also used as the `loading` for the dynamic imports below.
+//
+// That `loading` is not optional dressing: without it a dynamic import renders
+// NOTHING while its chunk is in flight — not even the box. The card has no
+// thumbnail to hold its height at that moment, so the whole row collapses and
+// then pops open when the chunk lands. With the box present from the first
+// paint, the layout never moves and the wait reads as loading.
+function ThumbSkeleton() {
+  return (
+    <div className="tpl-thumb" aria-hidden="true">
+      <div className="tpl-thumb-skeleton" />
+    </div>
+  );
+}
+
 // three only loads for the catalogues that actually show a webgl preset. Client
 // only: it opens a GL context on mount, which SSR cannot do.
-const TemplateThumb3D = dynamic(() => import('@/components/TemplateThumb3D'), { ssr: false });
+const TemplateThumb3D = dynamic(() => import('@/components/TemplateThumb3D'), {
+  ssr: false,
+  loading: () => <ThumbSkeleton />,
+});
 // Pixi likewise: it initialises a GL context on mount.
-const TemplateThumb2DGL = dynamic(() => import('@/components/TemplateThumb2DGL'), { ssr: false });
+const TemplateThumb2DGL = dynamic(() => import('@/components/TemplateThumb2DGL'), {
+  ssr: false,
+  loading: () => <ThumbSkeleton />,
+});
 
 // Live template thumbnail: run the template's own transform at a fixed frame
 // and render the resulting card layout as plain divs. Because it uses the real

--- a/components/TemplateThumb2DGL.tsx
+++ b/components/TemplateThumb2DGL.tsx
@@ -13,6 +13,8 @@
 // shared canvas moved into this card while previewing.
 import { useEffect, useRef, useState } from 'react';
 import type { Template } from '@/lib/types';
+import { frameColour, onThemeChange } from '@/lib/thumbStill';
+import { cachedThumb, scheduleThumb } from '@/lib/thumbQueue';
 import {
   CTX_BASE,
   attachCanvas2d,
@@ -43,10 +45,16 @@ export default function TemplateThumb2DGL({
   const hostRef = useRef<HTMLDivElement>(null);
   const [still, setStill] = useState<string | null>(null);
   const [previewing, setPreviewing] = useState(false);
+  const [themeVersion, setThemeVersion] = useState(0);
+
+  useEffect(() => onThemeChange(() => setThemeVersion((n) => n + 1)), []);
 
   useEffect(() => {
     let alive = true;
-    snapshotThumb2d(template, THUMB_FRAME)
+    const key = `2d:${template.meta.id}:${THUMB_FRAME}:${frameColour()}`;
+    setStill(cachedThumb(key));
+    const scheduled = scheduleThumb(key, () => snapshotThumb2d(template, THUMB_FRAME));
+    scheduled.promise
       .then((src) => { if (alive) setStill(src); })
       // Never silent: a preset that cannot draw has to say so, or the card just
       // stays blank and the reason is invisible.
@@ -54,8 +62,11 @@ export default function TemplateThumb2DGL({
         console.warn(`[thumb2d] ${template.meta.id} sem contexto, caindo para divs:`, err);
         onUnavailable?.();
       });
-    return () => { alive = false; };
-  }, [template]);
+    return () => { alive = false; scheduled.cancel(); };
+  // `onUnavailable` is an inline fallback supplied by the parent. Depending on
+  // its identity would reschedule the still after every state update.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [template, themeVersion]);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -148,6 +159,10 @@ export default function TemplateThumb2DGL({
       className={`tpl-thumb ${previewing ? 'is-previewing' : ''}`}
       aria-hidden="true"
     >
+      {/* Skeleton while the still is being rendered. Without it the box sits
+          empty — aspect-ratio holds its size, so what shows is a bare frame,
+          which reads as broken rather than as loading. */}
+      {!previewing && !still && <div className="tpl-thumb-skeleton" />}
       {!previewing && still && (
         <img
           src={still}

--- a/components/TemplateThumb3D.tsx
+++ b/components/TemplateThumb3D.tsx
@@ -15,6 +15,8 @@
 // matter how long the catalogue gets.
 import { useEffect, useRef, useState } from 'react';
 import type { Template } from '@/lib/types';
+import { frameColour, onThemeChange } from '@/lib/thumbStill';
+import { cachedThumb, scheduleThumb } from '@/lib/thumbQueue';
 import {
   CTX_BASE,
   attachCanvas,
@@ -44,16 +46,21 @@ export default function TemplateThumb3D({
   const hostRef = useRef<HTMLDivElement>(null);
   const [still, setStill] = useState<string | null>(null);
   const [previewing, setPreviewing] = useState(false);
+  const [themeVersion, setThemeVersion] = useState(0);
+
+  useEffect(() => onThemeChange(() => setThemeVersion((n) => n + 1)), []);
 
   // The idle still: drawn once. The tones are built synchronously, so there is
   // nothing arriving late to redraw for.
   useEffect(() => {
     let alive = true;
-    const draw = () => {
-      if (!alive) return;
-      try {
-        setStill(snapshotThumb(template, THUMB_FRAME));
-      } catch (err) {
+    const key = `3d:${template.meta.id}:${THUMB_FRAME}:${frameColour()}`;
+    setStill(cachedThumb(key));
+    const scheduled = scheduleThumb(key, () => snapshotThumb(template, THUMB_FRAME));
+    scheduled.promise
+      .then((src) => { if (alive) setStill(src); })
+      .catch((err) => {
+        if (!alive) return;
         // Never silent, and never blank: a browser hands out a limited number of
         // GL contexts and this one can genuinely fail to get one (measured: five
         // catalogue pages open at once exhausts them). Say so, and let the parent
@@ -61,11 +68,12 @@ export default function TemplateThumb3D({
         // empty card is worse and tells the reader nothing.
         console.warn(`[thumb3d] ${template.meta.id} sem contexto 3D, caindo para 2D:`, err);
         onUnavailable?.();
-      }
-    };
-    draw();
-    return () => { alive = false; };
-  }, [template]);
+      });
+    return () => { alive = false; scheduled.cancel(); };
+  // `onUnavailable` is an inline fallback supplied by the parent. Depending on
+  // its identity would reschedule the still after every state update.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [template, themeVersion]);
 
   // Hover / focus / autoplay, same triggers as the 2D thumbnail.
   useEffect(() => {
@@ -160,6 +168,10 @@ export default function TemplateThumb3D({
       className={`tpl-thumb ${previewing ? 'is-previewing' : ''}`}
       aria-hidden="true"
     >
+      {/* Skeleton while the still is being rendered. Without it the box sits
+          empty — aspect-ratio holds its size, so what shows is a bare frame,
+          which reads as broken rather than as loading. */}
+      {!previewing && !still && <div className="tpl-thumb-skeleton" />}
       {!previewing && still && (
         <img
           src={still}

--- a/lib/thumbQueue.ts
+++ b/lib/thumbQueue.ts
@@ -1,0 +1,87 @@
+// One cooperative queue for every catalogue still. Both thumbnail engines move
+// a shared canvas between cards, so concurrent snapshots are both wasteful and
+// unsafe: one card can read the canvas after another card has already drawn.
+
+type Job = {
+  key: string;
+  priority: number;
+  task: () => string | null | Promise<string | null>;
+  resolve: (value: string | null) => void;
+  reject: (reason: unknown) => void;
+  cancelled: boolean;
+};
+
+const cache = new Map<string, string>();
+const pending = new Map<string, Promise<string | null>>();
+const jobs: Job[] = [];
+let draining = false;
+
+function idle(): Promise<void> {
+  return new Promise((resolve) => {
+    if ('requestIdleCallback' in window) {
+      window.requestIdleCallback(() => resolve(), { timeout: 120 });
+    } else {
+      globalThis.setTimeout(resolve, 0);
+    }
+  });
+}
+
+async function drain() {
+  if (draining) return;
+  draining = true;
+  try {
+    while (jobs.length) {
+      jobs.sort((a, b) => b.priority - a.priority);
+      const job = jobs.shift()!;
+      if (job.cancelled) continue;
+      await idle();
+      try {
+        const value = await job.task();
+        if (value) cache.set(job.key, value);
+        job.resolve(value);
+      } catch (error) {
+        job.reject(error);
+      } finally {
+        pending.delete(job.key);
+      }
+    }
+  } finally {
+    draining = false;
+  }
+}
+
+export function cachedThumb(key: string): string | null {
+  return cache.get(key) ?? null;
+}
+
+export function scheduleThumb(
+  key: string,
+  task: () => string | null | Promise<string | null>,
+  priority = 0,
+): { promise: Promise<string | null>; cancel: () => void } {
+  const hit = cache.get(key);
+  if (hit) return { promise: Promise.resolve(hit), cancel: () => {} };
+
+  const existing = pending.get(key);
+  if (existing) return { promise: existing, cancel: () => {} };
+
+  let job!: Job;
+  const promise = new Promise<string | null>((resolve, reject) => {
+    job = { key, priority, task, resolve, reject, cancelled: false };
+    jobs.push(job);
+  });
+  pending.set(key, promise);
+  void drain();
+  return {
+    promise,
+    cancel: () => {
+      job.cancelled = true;
+      pending.delete(key);
+      job.resolve(null);
+    },
+  };
+}
+
+export function clearThumbCache() {
+  cache.clear();
+}

--- a/lib/thumbScene2d.ts
+++ b/lib/thumbScene2d.ts
@@ -17,6 +17,7 @@ import type { LayerTransform, Template } from '@/lib/types';
 import { clamp } from '@/lib/motion';
 import { defaultsFor, easingFor, layerCountFor } from '@/templates';
 import { resolveEasing } from '@/lib/easing';
+import { stillFrom } from '@/lib/thumbStill';
 
 export const THUMB_W = 180;
 export const THUMB_H = 240;
@@ -98,6 +99,7 @@ export async function getShared2d(): Promise<Shared> {
       antialias: true,
       autoStart: false,          // drawn on demand, never on a ticker
       preference: 'webgl',
+      powerPreference: 'high-performance',
       resolution: 1,
       // Needed to read the canvas back for the idle still.
       preserveDrawingBuffer: true,
@@ -292,13 +294,7 @@ export function renderThumbFrame2d(ctx: Shared, template: Template, frame: numbe
 export async function snapshotThumb2d(template: Template, frame: number): Promise<string | null> {
   const ctx = await getShared2d();
   renderThumbFrame2d(ctx, template, frame);
-  const off = document.createElement('canvas');
-  off.width = THUMB_W;
-  off.height = THUMB_H;
-  const g = off.getContext('2d');
-  if (!g) return null;
-  g.drawImage(ctx.canvas, 0, 0);
-  return off.toDataURL('image/png');
+  return stillFrom(ctx.canvas, THUMB_W, THUMB_H);
 }
 
 export async function attachCanvas2d(host: HTMLElement) {

--- a/lib/thumbStill.ts
+++ b/lib/thumbStill.ts
@@ -1,0 +1,60 @@
+// Turning a rendered thumbnail canvas into the still the idle card shows.
+//
+// This is JPEG and not PNG, and the difference is not cosmetic. Measured in the
+// browser on a 180x240 canvas, encoding 34 stills — one search's worth:
+//
+//   toDataURL('image/png')          7.66 ms each   260 ms blocked
+//   toDataURL('image/jpeg', 0.85)   0.27 ms each     9 ms blocked
+//   toBlob(png) + objectURL        28.13 ms each   worse still
+//
+// PNG was costing 260ms of SYNCHRONOUS main-thread work every time a search
+// mounted its cards, and it showed: rAF fell from 38 to 29.6 fps just from
+// having the thumbnails mounted, with nothing hovered. The stage's own export
+// picks JPEG for the same reason.
+//
+// JPEG has no alpha, so the frame colour has to be painted underneath. That is
+// also what the .tpl-thumb box behind it is filled with, so the result is
+// identical — but it does mean a still baked in one theme is wrong in the other,
+// which is why `themeKey` exists for callers to watch.
+
+/** The thumb backdrop for the CURRENT theme, resolved from the token. */
+export function frameColour(): string {
+  if (typeof window === 'undefined') return '#0d0d0d';
+  const v = getComputedStyle(document.documentElement).getPropertyValue('--frame').trim();
+  return v || '#0d0d0d';
+}
+
+/**
+ * Changes when the theme does, so a component can regenerate its still.
+ * Reads the same `documentElement.dataset.theme` that useUIStore writes.
+ */
+export function themeKey(): string {
+  if (typeof window === 'undefined') return '';
+  return document.documentElement.dataset.theme ?? '';
+}
+
+/** Watch for theme changes. Returns an unsubscribe. */
+export function onThemeChange(fn: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const observer = new MutationObserver(() => fn());
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+  return () => observer.disconnect();
+}
+
+/**
+ * Read a rendered canvas into a still.
+ *
+ * The frame colour goes down first because the renderers clear to transparent
+ * and JPEG would otherwise flatten that to black.
+ */
+export function stillFrom(source: HTMLCanvasElement, w: number, h: number): string | null {
+  const off = document.createElement('canvas');
+  off.width = w;
+  off.height = h;
+  const g = off.getContext('2d');
+  if (!g) return null;
+  g.fillStyle = frameColour();
+  g.fillRect(0, 0, w, h);
+  g.drawImage(source, 0, 0);
+  return off.toDataURL('image/jpeg', 0.85);
+}

--- a/three3d/thumbScene.ts
+++ b/three3d/thumbScene.ts
@@ -22,6 +22,7 @@ import type { CameraPose, LayerTransform3D, Template } from '@/lib/types';
 import { clamp } from '@/lib/motion';
 import { defaultsFor, easingFor, layerCountFor } from '@/templates';
 import { resolveEasing } from '@/lib/easing';
+import { stillFrom } from '@/lib/thumbStill';
 import {
   makeBentPlaneGeometry,
   makeCornerPeelGeometry,
@@ -101,6 +102,7 @@ export function getShared(): Shared {
     canvas,
     antialias: true,
     alpha: true,
+    powerPreference: 'high-performance',
     // Needed to read the canvas back for the idle still.
     preserveDrawingBuffer: true,
   });
@@ -318,14 +320,7 @@ export function renderThumbFrame(template: Template, frame: number): boolean {
 /** Draw one frame and read it back as a still, for the idle thumbnail. */
 export function snapshotThumb(template: Template, frame: number): string | null {
   if (!renderThumbFrame(template, frame)) return null;
-  const ctx = getShared();
-  const off = document.createElement('canvas');
-  off.width = THUMB_W;
-  off.height = THUMB_H;
-  const g = off.getContext('2d');
-  if (!g) return null;
-  g.drawImage(ctx.canvas, 0, 0);
-  return off.toDataURL('image/png');
+  return stillFrom(getShared().canvas, THUMB_W, THUMB_H);
 }
 
 /** Move the shared canvas into this container (previewing starts). */


### PR DESCRIPTION
## What changed
- preserve card dimensions with a skeleton while thumbnails load
- serialize and reuse still generation through a shared queue and cache
- encode only the idle thumbnail still as JPEG at 0.85 quality
- regenerate cached stills when the theme changes
- request the high-performance GPU for thumbnail renderers

## What did not change
- live PixiJS/Three.js animation
- stage rendering and exports
- effects and preset behavior

## Validation
- npm test
- npx tsc --noEmit
- npm run build

This PR is intentionally separate from new effects work.