### PR TITLE
feat(gradients): unify advanced editor across 2D and 3D

### DIFF
--- a/GRADIENTS.md
+++ b/GRADIENTS.md
@@ -1,0 +1,69 @@
+# Unified gradient system
+
+The 2D canvas, WebGL canvas, Cartoon background, Mockup background and 3D part
+fills all consume `GradientSpec` from `lib/gradient.ts`. Renderers may use a
+native canvas gradient for Basic mode or the shared procedural rasterizer for
+Advanced mode, but they must not define their own gradient document shape.
+
+## Document contract
+
+- Version: `2`.
+- Modes: `basic`, `advanced`.
+- Shapes: `linear`, `radial`, `conic`, `mesh`, `warped-field`, `twin-radial`.
+- Stops: sorted for rendering, minimum 2, maximum 8, stable IDs.
+- Angle convention: `0deg` runs left to right and increases clockwise in screen
+  space. Renderer-specific angle conventions are converted at the boundary.
+- Center, radius and 3D coordinates are normalized to `0..1`.
+- 3D mappings: UV, object and screen. Object currently falls back to normalized
+  object bounds; screen uses that same stable fallback for baked vertex fills.
+
+Advanced ranges mirror the researched Pryzm controls:
+
+| Control | Range | Meaning |
+| --- | ---: | --- |
+| Warp | 0–2 | Domain distortion |
+| Flow | 0–1 | Seamless orbital drift over one clip |
+| Scale | 0.4–4 | Procedural texture zoom |
+| Detail | 0–6 | Noise octaves / fine structure |
+| Contrast | 0.5–3 | Color transition sharpness |
+
+## Backward compatibility
+
+Old 2D scenes keep `background.gradient`, `color` and `color2`. Old 3D scenes
+keep `FillSpec.type`, `c1` and `c2`. Hydration converts those fields into a v2
+gradient in memory. Every v2 editor write mirrors its first/last stops and
+linear/radial type back into the legacy fields, so older preview and project
+code can still read a useful fallback.
+
+No bulk rewrite runs when a project opens. The richer value is persisted only
+through the normal autosave path after an edit.
+
+## Editor behavior
+
+- Basic exposes Linear and Radial.
+- Advanced exposes every shape and the five procedural controls.
+- Clicking the ramp adds an interpolated stop at that position.
+- `+ Stop` splits the largest gap and interpolates its initial color.
+- Stops drag horizontally, render in position order and retain their IDs.
+- Reverse maps each stop position to `1 - position`.
+- Presets replace the palette but never alter unrelated canvas/model settings.
+- Part gradients stay collapsed until their preview swatch is opened; the
+  background editor remains visible because it is the primary fill.
+
+## Rendering and performance
+
+Basic Linear/Radial uses native Canvas 2D interpolation at up to the logical
+canvas resolution. Advanced fields use a 384px long-edge procedural texture and
+are scaled by the GPU. Static gradients are signature-cached; only a non-zero
+Flow value invalidates the texture as the timeline advances.
+
+Flow follows a circular time path, so phase `0` and `1` are identical and video
+loops do not jump. Grain remains a separate post-effect concern rather than a
+field in the gradient document.
+
+## Verification
+
+`scripts/verify-gradients.cjs` pins legacy migration, stop bounds/order,
+interpolation, radial endpoints, seamless Flow and legacy mirror fields. Run it
+through `npm test`; production type/render integration is covered by
+`npm run build` and browser checks on `/`, `/mockup` and `/3d`.

--- a/app/globals.css
+++ b/app/globals.css
@@ -2004,28 +2004,86 @@ select.field { padding-right: 26px; }
 .sc-asset-x:hover { color: var(--fg); }
 
 /* ---- 3D Model Colors (per-part) ---- */
-.mc-colors { display: flex; flex-direction: column; gap: 6px; }
-.mc-colors-hint { font-size: var(--fs-label); color: var(--fg-muted); margin-bottom: 4px; }
+.mc-colors { display: flex; flex-direction: column; gap: var(--gap-tight); }
+.mc-colors-hint { font-size: var(--fs-label); color: var(--fg-muted); }
 .mc-color-row {
-  display: flex; align-items: center; gap: 8px; padding: 4px 6px; border-radius: var(--r-ctrl);
+  display: flex; align-items: center; gap: var(--gap-tight); padding: calc(var(--gap-tight) / 2); border-radius: var(--r-ctrl);
   cursor: default; transition: background var(--t-fast);
 }
 .mc-color-row.sel { background: var(--card-inset); }
 .mc-color-name { flex: 1; font-size: var(--fs-ui); color: var(--fg-body); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mc-color-row input[type=color] {
-  width: 28px; height: 22px; padding: 0; border: 1px solid var(--line); border-radius: 5px;
+  width: var(--ctl-h); height: var(--ctl-h); padding: 0; border: 1px solid var(--line); border-radius: var(--r-ctrl);
   background: none; cursor: pointer; flex: 0 0 auto;
 }
 .mc-color-clear {
-  width: 20px; height: 20px; display: grid; place-items: center; border: 0; border-radius: 5px;
-  background: var(--card-inset); color: var(--fg-muted); cursor: pointer; font-size: 13px; line-height: 1;
+  width: var(--ctl-h); height: var(--ctl-h); display: grid; place-items: center; border: 0; border-radius: var(--r-ctrl);
+  background: var(--card-inset); color: var(--fg-muted); cursor: pointer; font-size: var(--fs-label); line-height: 1;
 }
 .mc-color-clear:hover:not(:disabled) { color: var(--fg); background: var(--card-thumb); }
 .mc-color-clear:disabled { opacity: 0.3; cursor: default; }
 .mc-fill-type {
-  flex: 0 0 auto; height: 22px; border-radius: 5px; border: 1px solid var(--line);
-  background: var(--card-inset); color: var(--fg-body); font-size: 11px; padding: 0 4px; cursor: pointer;
+  flex: 0 0 auto; height: var(--ctl-h); border-radius: var(--r-ctrl); border: 0;
+  background-color: var(--card-inset); color: var(--fg-body); font-size: var(--fs-ui); padding: 0 var(--gap-tight); cursor: pointer;
 }
+.mc-gradient-preview {
+  width: var(--ctl-h); height: var(--ctl-h); flex: 0 0 auto; padding: 0;
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+  box-shadow: 0 0 0 0 var(--fg); transition: box-shadow var(--t-fast);
+}
+.mc-gradient-preview.active { box-shadow: 0 0 0 2px var(--fg); }
+
+/* ---- Shared 2D / 3D gradient editor ---- */
+.mc-fill-block { border-radius: var(--r-ctrl); transition: background var(--t-fast); }
+.mc-fill-block.sel { background: var(--card-inset); }
+.gradient-editor {
+  display: flex; flex-direction: column; gap: var(--gap-row); min-width: 0;
+}
+.mc-fill-block > .gradient-editor { padding: 0 var(--gap-tight) var(--gap-tight); }
+.mc-fill-system { display: flex; flex-direction: column; gap: var(--gap-row); }
+.mc-fill-system > .gradient-editor { padding: 0; }
+.gradient-presets { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: var(--gap-tight); width: 100%; }
+.gradient-presets button {
+  height: var(--ctl-h); min-width: 0; border-radius: var(--r-ctrl); border: 1px solid var(--line);
+  transition: border-color var(--t-fast), opacity var(--t-fast);
+}
+.gradient-presets button:hover { border-color: var(--handle); opacity: .9; }
+.gradient-row-label,
+.gradient-stop-heading { display: flex; align-items: center; justify-content: space-between; gap: var(--gap-tight); }
+.gradient-row-label span { color: var(--fg-faint); font-size: var(--fs-meta); font-variant-numeric: tabular-nums; }
+.gradient-stops-row { gap: var(--gap-tight); }
+.gradient-ramp {
+  position: relative; height: var(--ctl-h); margin: 0 calc(var(--gap-tight) / 2) var(--ctl-h);
+  border-radius: var(--r-ctrl); border: 1px solid var(--line); cursor: copy;
+}
+.gradient-stop {
+  position: absolute; bottom: calc(var(--ctl-h) * -1); width: calc(var(--ctl-h) - var(--gap-tight)); height: calc(var(--ctl-h) - var(--gap-tight));
+  padding: 0; border-radius: var(--r-ctrl); border: 1px solid var(--line);
+  box-shadow: inset 0 0 0 1px var(--card); transform: translateX(-50%);
+  cursor: ew-resize; touch-action: none;
+  transition: border-color var(--t-fast), box-shadow var(--t-fast), transform var(--t-fast);
+}
+.gradient-stop:hover { border-color: var(--handle); transform: translateX(-50%) translateY(-1px); }
+.gradient-stop.selected {
+  border-color: var(--fg);
+  box-shadow: 0 0 0 1px var(--card), 0 0 0 2px var(--fg), inset 0 0 0 1px var(--card);
+}
+.gradient-ramp-actions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--gap-tight); }
+.gradient-ramp-actions .btn:disabled,
+.gradient-stop-heading .link-btn:disabled { opacity: .35; cursor: default; }
+.gradient-stop-editor,
+.gradient-advanced { border-top: 1px solid var(--line); padding-top: var(--gap-tight); }
+.gradient-stop-editor { display: flex; flex-direction: column; gap: var(--gap-row); }
+.gradient-stop-heading .ctl-section-title { margin-bottom: 0; }
+.gradient-stop-color .field { min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; }
+.gradient-stop-color input[type=color]::-webkit-color-swatch-wrapper { padding: 0; }
+.gradient-stop-color input[type=color]::-webkit-color-swatch {
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+}
+.gradient-stop-color input[type=color]::-moz-color-swatch {
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+}
+.gradient-advanced { display: flex; flex-direction: column; gap: var(--gap-row); }
 /* Neutral SSR/hydration gate. The desktop editor is never rendered until the
    browser has resolved the responsive breakpoint. */
 .editor-loading {
@@ -2060,29 +2118,29 @@ select.field { padding-right: 26px; }
 .editor-loading .ld-cards { margin-top: 0; }
 .ctl-section + .ctl-section { margin-top: 14px; }
 .ctl-section-title {
-  margin: 0 0 7px;
-  color: var(--muted);
-  font-size: 9px;
+  margin: 0 0 var(--gap-tight);
+  color: var(--fg-muted);
+  font-size: var(--fs-micro);
   font-weight: 650;
   letter-spacing: .13em;
   text-transform: uppercase;
 }
-.strack:focus-visible { outline: 1px solid var(--ink); outline-offset: 2px; }
+.strack:focus-visible { outline: 1px solid var(--fg); outline-offset: 2px; }
 .szero {
   position: absolute;
   top: 7px;
   width: 1px;
   height: 20px;
-  background: color-mix(in srgb, var(--ink) 22%, transparent);
+  background: color-mix(in srgb, var(--fg) 22%, transparent);
   pointer-events: none;
 }
 .ctl-advanced { margin-top: 12px; border-top: 1px solid var(--line); padding-top: 8px; }
 .ctl-advanced-toggle {
   width: 100%; display: flex; align-items: center; justify-content: space-between;
-  padding: 7px 0; border: 0; background: transparent; color: var(--muted);
+  padding: 7px 0; border: 0; background: transparent; color: var(--fg-muted);
   font: inherit; font-size: 11px; cursor: pointer;
 }
-.ctl-advanced-toggle:hover { color: var(--text); }
+.ctl-advanced-toggle:hover { color: var(--fg-body); }
 
 /* ---- Strata loader: the brand mark's layers, shuffling ---- */
 /* This IS the logo (app/icon.svg, components/IconRail.tsx) put in motion. Its

--- a/components/BackgroundFill.tsx
+++ b/components/BackgroundFill.tsx
@@ -5,6 +5,7 @@ import { use3DStore } from '@/store/use3DStore';
 import { ControlRow } from './Controls';
 import FillRow from './FillRow';
 import type { ControlDef } from '@/lib/types';
+import { fillPatchForGradient, gradientFromFill } from '@/lib/gradient';
 
 const amtDef: ControlDef = { key: 'a', label: 'Texture Amount', type: 'slider', min: 0, max: 100, step: 1, default: 0 };
 const scaleDef: ControlDef = { key: 's', label: 'Texture Scale', type: 'slider', min: 0.5, max: 10, step: 0.1, default: 3 };
@@ -45,10 +46,18 @@ export default function BackgroundFill({ hideTexture }: { hideTexture?: boolean 
       <div className="section-head"><span className="eyebrow">Background</span></div>
       <div className="section-body mc-colors">
         <FillRow
-          label="Background"
+          label="Fill"
           fill={bgFill}
-          onType={(t) => setBgFill({ type: t === 'none' ? 'solid' : t })}
+          showEditor
+          onType={(t) => {
+            const type = t === 'none' ? 'solid' : t;
+            if (type === 'linear' || type === 'radial') {
+              const gradient = gradientFromFill(bgFill);
+              setBgFill({ ...fillPatchForGradient({ ...gradient, shape: type }), type });
+            } else setBgFill({ type });
+          }}
           onColor={(which, hex) => setBgFill({ [which]: hex })}
+          onGradient={(gradient) => setBgFill(fillPatchForGradient(gradient))}
         />
         {!hideTexture && <ControlRow def={amtDef} value={bgTexAmount} onChange={(v) => setBgTexAmount(v)} />}
         {!hideTexture && <ControlRow def={scaleDef} value={bgTexScale} onChange={(v) => setBgTexScale(v)} />}

--- a/components/CanvasPanel.tsx
+++ b/components/CanvasPanel.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import { useSceneStore, ASPECTS } from '@/store/useSceneStore';
 import { ControlRow } from './Controls';
+import GradientEditor from './GradientEditor';
+import { normalizeGradientSpec } from '@/lib/gradient';
 
 const FPS_OPTIONS = [15, 25, 30, 60] as const;
 const BG_SOURCES: { id: 'color' | 'image' | 'card'; label: string }[] = [
@@ -82,6 +84,7 @@ export default function CanvasPanel({ is3DMode = false }: { is3DMode?: boolean }
     || activeTemplateId.startsWith('spinner-')
     || activeTemplateId.startsWith('hinge-')
     || activeTemplateId.startsWith('fan-');
+  const backgroundGradient = normalizeGradientSpec(background.gradientSpec, background.color, background.color2);
 
   return (
     <>
@@ -158,17 +161,15 @@ export default function CanvasPanel({ is3DMode = false }: { is3DMode?: boolean }
 
           {background.source === 'color' && (
             <>
-              <ControlRow def={{ key: 'bgc', label: 'Colour', type: 'color', default: '' }} value={background.color} onChange={(v) => setBackground({ color: v })} />
               <div className="ctl-row">
-                <label className="ctl-label">Gradient</label>
+                <label className="ctl-label">Fill</label>
                 <div className="segmented">
-                  <button className={`seg ${!background.gradient ? 'active' : ''}`} onClick={() => setBackground({ gradient: false })}>Off</button>
-                  <button className={`seg ${background.gradient ? 'active' : ''}`} onClick={() => setBackground({ gradient: true })}>On</button>
+                  <button className={`seg ${!background.gradient ? 'active' : ''}`} onClick={() => setBackground({ gradient: false })}>Solid</button>
+                  <button className={`seg ${background.gradient ? 'active' : ''}`} onClick={() => setBackground({ source: 'color', gradient: true, gradientSpec: backgroundGradient })}>Gradient</button>
                 </div>
               </div>
-              {background.gradient && (
-                <ControlRow def={{ key: 'bgc2', label: 'Colour 2', type: 'color', default: '' }} value={background.color2} onChange={(v) => setBackground({ color2: v })} />
-              )}
+              {!background.gradient && <ControlRow def={{ key: 'bgc', label: 'Colour', type: 'color', default: '' }} value={background.color} onChange={(v) => setBackground({ color: v })} />}
+              {background.gradient && <GradientEditor value={backgroundGradient} onChange={(gradientSpec) => setBackground({ source: 'color', gradient: true, gradientSpec })} />}
             </>
           )}
 

--- a/components/FillRow.tsx
+++ b/components/FillRow.tsx
@@ -1,6 +1,13 @@
 'use client';
 
+import { useState } from 'react';
 import type { FillSpec } from '@/store/use3DStore';
+import GradientEditor from './GradientEditor';
+import { gradientCss, gradientFromFill, type GradientSpec } from '@/lib/gradient';
+import { ControlRow } from './Controls';
+import type { ControlDef } from '@/lib/types';
+
+const solidColorDef: ControlDef = { key: 'fill-colour', label: 'Colour', type: 'color', default: '#cccccc' };
 
 // One colour/fill row — the single shared pattern for BOTH model parts and the
 // background. Type (Original / Solid / Linear / Radial) + start/centre colour +
@@ -12,37 +19,76 @@ export interface FillRowProps {
   allowNone?: boolean;
   onType: (type: 'none' | 'solid' | 'linear' | 'radial') => void;
   onColor: (which: 'c1' | 'c2', hex: string) => void;
+  onGradient?: (gradient: GradientSpec) => void;
+  showEditor?: boolean;
+  collapsibleEditor?: boolean;
   selected?: boolean;
   onEnter?: () => void;
   onLeave?: () => void;
 }
 
-export default function FillRow({ label, fill, allowNone, onType, onColor, selected, onEnter, onLeave }: FillRowProps) {
+export default function FillRow({ label, fill, allowNone, onType, onColor, onGradient, showEditor, collapsibleEditor, selected, onEnter, onLeave }: FillRowProps) {
+  const [editorOpen, setEditorOpen] = useState(false);
   const type: string = fill ? fill.type : 'none';
   const c1 = fill?.c1 ?? '#cccccc';
   const c2 = fill?.c2 ?? '#ffffff';
   const isGrad = type === 'linear' || type === 'radial';
+  const displayType = isGrad ? 'gradient' : type;
+  const setDisplayType = (next: string) => {
+    onType(next === 'gradient' ? (isGrad ? type as 'linear' | 'radial' : 'linear') : next as 'none' | 'solid');
+  };
+
+  // Background fills are regular panel controls, so they use exactly the same
+  // primitives and metrics as the 2D canvas panel. Model parts use the compact
+  // list below because several material groups can be visible at once.
+  if (!allowNone) {
+    return (
+      <div className="mc-fill-block mc-fill-system">
+        <div className="ctl-row">
+          <label className="ctl-label">{label}</label>
+          <div className="ctl-input">
+            <div className="segmented">
+              <button type="button" className={`seg ${type === 'solid' ? 'active' : ''}`} onClick={() => setDisplayType('solid')}>Solid</button>
+              <button type="button" className={`seg ${isGrad ? 'active' : ''}`} onClick={() => setDisplayType('gradient')}>Gradient</button>
+            </div>
+          </div>
+        </div>
+        {type === 'solid' && <ControlRow def={solidColorDef} value={c1} onChange={(hex) => onColor('c1', hex)} />}
+        {isGrad && showEditor && fill && onGradient && (
+          <GradientEditor value={gradientFromFill(fill)} onChange={onGradient} />
+        )}
+      </div>
+    );
+  }
 
   return (
-    <div
-      className={`mc-color-row ${selected ? 'sel' : ''}`}
-      onMouseEnter={onEnter}
-      onMouseLeave={onLeave}
-    >
-      <span className="mc-color-name" title={label}>{label}</span>
-      <select className="mc-fill-type" value={type} onChange={(e) => onType(e.target.value as any)}>
-        {allowNone && <option value="none">Original</option>}
-        <option value="solid">Solid</option>
-        <option value="linear">Linear</option>
-        <option value="radial">Radial</option>
-      </select>
-      {type !== 'none' && (
-        <input type="color" value={c1} title={isGrad ? 'Start / centre' : 'Color'}
-          onChange={(e) => onColor('c1', e.target.value)} />
-      )}
-      {isGrad && (
-        <input type="color" value={c2} title="End / edge"
-          onChange={(e) => onColor('c2', e.target.value)} />
+    <div className={`mc-fill-block ${selected ? 'sel' : ''}`} onMouseEnter={onEnter} onMouseLeave={onLeave}>
+      <div className="mc-color-row">
+        <span className="mc-color-name" title={label}>{label}</span>
+        <select className="mc-fill-type" value={displayType} onChange={(e) => setDisplayType(e.target.value)}>
+          {allowNone && <option value="none">Original</option>}
+          <option value="solid">Solid</option>
+          <option value="gradient">Gradient</option>
+        </select>
+        {type !== 'none' && (!isGrad || !showEditor) && (
+          <input type="color" value={c1} title={isGrad ? 'Start / centre' : 'Color'} onChange={(e) => onColor('c1', e.target.value)} />
+        )}
+        {isGrad && !showEditor && (
+          <input type="color" value={c2} title="End / edge" onChange={(e) => onColor('c2', e.target.value)} />
+        )}
+        {isGrad && showEditor && collapsibleEditor && fill && (
+          <button
+            type="button"
+            className={`mc-gradient-preview ${editorOpen ? 'active' : ''}`}
+            title={editorOpen ? 'Close gradient editor' : 'Edit gradient'}
+            aria-label={`${editorOpen ? 'Close' : 'Edit'} ${label} gradient`}
+            style={{ background: gradientCss(gradientFromFill(fill)) }}
+            onClick={() => setEditorOpen((open) => !open)}
+          />
+        )}
+      </div>
+      {isGrad && showEditor && fill && onGradient && (!collapsibleEditor || editorOpen) && (
+        <GradientEditor value={gradientFromFill(fill)} onChange={onGradient} showMapping={allowNone} />
       )}
     </div>
   );

--- a/components/GradientEditor.tsx
+++ b/components/GradientEditor.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ControlRow } from './Controls';
+import type { ControlDef } from '@/lib/types';
+import {
+  MAX_GRADIENT_STOPS,
+  gradientCss,
+  normalizeGradientSpec,
+  sampleGradientRGB,
+  sortedStops,
+  type GradientShape,
+  type GradientSpec,
+  type GradientStop,
+} from '@/lib/gradient';
+
+interface GradientEditorProps {
+  value: GradientSpec;
+  onChange: (value: GradientSpec) => void;
+  showMapping?: boolean;
+}
+
+const PRESETS: Array<{ name: string; colors: string[]; angle?: number; shape?: GradientShape }> = [
+  { name: 'Dusk', colors: ['#2b1055', '#7597de'], angle: 315 },
+  { name: 'Ember', colors: ['#f12711', '#f5af19'], angle: 315 },
+  { name: 'Lagoon', colors: ['#021c19', '#098274', '#37e2ca'], angle: 135 },
+  { name: 'Grape', colors: ['#41295a', '#2f0743'], angle: 315 },
+  { name: 'Peach', colors: ['#ee9ca7', '#ffdde1'], angle: 315 },
+  { name: 'Halo', colors: ['#3a3a5a', '#0d0d14'], shape: 'radial' },
+];
+
+const BASIC_SHAPES: Array<[GradientShape, string]> = [['linear', 'Linear'], ['radial', 'Radial']];
+const ADVANCED_SHAPES: Array<[GradientShape, string]> = [
+  ...BASIC_SHAPES,
+  ['conic', 'Conic'],
+  ['mesh', 'Mesh'],
+  ['warped-field', 'Warped Field'],
+  ['twin-radial', 'Twin Radial'],
+];
+
+const angleDef: ControlDef = { key: 'gradient-angle', label: 'Angle', type: 'slider', min: 0, max: 360, step: 1, default: 90, unit: '°' };
+const centerXDef: ControlDef = { key: 'gradient-center-x', label: 'Center X', type: 'slider', min: 0, max: 1, step: 0.01, precision: 2, default: 0.5 };
+const centerYDef: ControlDef = { key: 'gradient-center-y', label: 'Center Y', type: 'slider', min: 0, max: 1, step: 0.01, precision: 2, default: 0.5 };
+const radiusDef: ControlDef = { key: 'gradient-radius', label: 'Radius', type: 'slider', min: 0.05, max: 2, step: 0.01, precision: 2, default: 0.7 };
+const stopPositionDef: ControlDef = { key: 'gradient-stop-position', label: 'Position', type: 'slider', min: 0, max: 100, step: 1, default: 0, unit: '%' };
+const warpDef: ControlDef = { key: 'gradient-warp', label: 'Warp', type: 'slider', min: 0, max: 2, step: 0.01, precision: 2, default: 0 };
+const flowDef: ControlDef = { key: 'gradient-flow', label: 'Flow', type: 'slider', min: 0, max: 1, step: 0.01, precision: 2, default: 0 };
+const scaleDef: ControlDef = { key: 'gradient-scale', label: 'Scale', type: 'slider', min: 0.4, max: 4, step: 0.01, precision: 2, default: 1 };
+const detailDef: ControlDef = { key: 'gradient-detail', label: 'Detail', type: 'slider', min: 0, max: 6, step: 1, default: 1 };
+const contrastDef: ControlDef = { key: 'gradient-contrast', label: 'Contrast', type: 'slider', min: 0.5, max: 3, step: 0.01, precision: 2, default: 1 };
+
+let stopCounter = 0;
+const nextStopId = () => `stop-${Date.now().toString(36)}-${++stopCounter}`;
+const clamp = (v: number, lo = 0, hi = 1) => Math.max(lo, Math.min(hi, Number.isFinite(v) ? v : lo));
+
+function rgbHex(rgb: [number, number, number, number]) {
+  return `#${rgb.slice(0, 3).map((v) => Math.round(v).toString(16).padStart(2, '0')).join('')}`;
+}
+
+function presetSpec(current: GradientSpec, preset: (typeof PRESETS)[number]): GradientSpec {
+  const colors = preset.colors;
+  return normalizeGradientSpec({
+    ...current,
+    mode: 'basic',
+    shape: preset.shape ?? 'linear',
+    angle: preset.angle ?? current.angle,
+    stops: colors.map((color, i) => ({ id: `preset-${preset.name.toLowerCase()}-${i}`, color, position: i / Math.max(1, colors.length - 1), opacity: 1 })),
+  });
+}
+
+function StopColor({ stop, onColor }: { stop: GradientStop; onColor: (color: string) => void }) {
+  const [text, setText] = useState(stop.color.slice(1));
+  useEffect(() => setText(stop.color.slice(1)), [stop.color]);
+  const commit = () => {
+    if (/^[0-9a-f]{6}$/i.test(text)) onColor(`#${text}`);
+    else setText(stop.color.slice(1));
+  };
+  return (
+    <div className="ctl-row">
+      <label className="ctl-label">Colour</label>
+      <div className="ctl-input">
+        <div className="color gradient-stop-color">
+          <input type="color" aria-label="Stop colour" value={stop.color} onChange={(e) => onColor(e.target.value)} />
+          <input
+            className="field"
+            aria-label="Stop hex"
+            value={`#${text}`}
+            maxLength={7}
+            onChange={(e) => setText(e.target.value.replace(/^#/, ''))}
+            onBlur={commit}
+            onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function GradientEditor({ value, onChange, showMapping = false }: GradientEditorProps) {
+  const spec = useMemo(() => normalizeGradientSpec(value), [value]);
+  const stops = useMemo(() => sortedStops(spec), [spec]);
+  const [selectedId, setSelectedId] = useState(stops[0]?.id ?? '');
+  const barRef = useRef<HTMLDivElement>(null);
+  const selected = stops.find((stop) => stop.id === selectedId) ?? stops[0];
+
+  useEffect(() => {
+    if (!stops.some((stop) => stop.id === selectedId)) setSelectedId(stops[0]?.id ?? '');
+  }, [selectedId, stops]);
+
+  const emit = (patch: Partial<GradientSpec>) => onChange(normalizeGradientSpec({ ...spec, ...patch }));
+  const replaceStop = (id: string, patch: Partial<GradientStop>) => {
+    emit({ stops: spec.stops.map((stop) => stop.id === id ? { ...stop, ...patch } : stop) });
+  };
+  const addStopAt = (position: number) => {
+    if (stops.length >= MAX_GRADIENT_STOPS) return;
+    const pos = clamp(position);
+    const stop = { id: nextStopId(), position: pos, color: rgbHex(sampleGradientRGB(spec, pos)), opacity: 1 };
+    setSelectedId(stop.id);
+    emit({ stops: [...spec.stops, stop] });
+  };
+  const addLargestGap = () => {
+    let position = 0.5, gap = -1;
+    for (let i = 1; i < stops.length; i++) {
+      const nextGap = stops[i].position - stops[i - 1].position;
+      if (nextGap > gap) { gap = nextGap; position = (stops[i].position + stops[i - 1].position) / 2; }
+    }
+    addStopAt(position);
+  };
+  const removeSelected = () => {
+    if (!selected || stops.length <= 2) return;
+    const index = stops.findIndex((s) => s.id === selected.id);
+    const next = stops.filter((s) => s.id !== selected.id);
+    setSelectedId(next[Math.max(0, index - 1)]?.id ?? next[0].id);
+    emit({ stops: next });
+  };
+  const barPosition = (clientX: number) => {
+    const rect = barRef.current?.getBoundingClientRect();
+    return rect ? clamp((clientX - rect.left) / Math.max(1, rect.width)) : 0.5;
+  };
+
+  const shapes = spec.mode === 'advanced' ? ADVANCED_SHAPES : BASIC_SHAPES;
+  const needsCenter = spec.shape === 'radial' || spec.shape === 'conic' || spec.shape === 'twin-radial';
+  const needsRadius = spec.shape === 'radial' || spec.shape === 'twin-radial';
+
+  return (
+    <div className="gradient-editor">
+      <div className="ctl-row">
+        <label className="ctl-label">Gradient mode</label>
+        <div className="ctl-input">
+          <div className="segmented">
+            <button className={`seg ${spec.mode === 'basic' ? 'active' : ''}`} onClick={() => emit({
+              mode: 'basic',
+              shape: BASIC_SHAPES.some(([shape]) => shape === spec.shape) ? spec.shape : 'linear',
+            })}>Basic</button>
+            <button className={`seg ${spec.mode === 'advanced' ? 'active' : ''}`} onClick={() => emit({ mode: 'advanced' })}>Advanced</button>
+          </div>
+        </div>
+      </div>
+
+      <div className="ctl-row">
+        <label className="ctl-label">Presets</label>
+        <div className="gradient-presets" aria-label="Gradient presets">
+          {PRESETS.map((preset) => {
+            const preview = presetSpec(spec, preset);
+            return <button key={preset.name} title={preset.name} aria-label={preset.name}
+              style={{ background: gradientCss(preview) }} onClick={() => onChange(preview)} />;
+          })}
+        </div>
+      </div>
+
+      <div className="ctl-row gradient-stops-row">
+        <div className="gradient-row-label">
+          <label className="ctl-label">Stops</label>
+          <span>{stops.length} / {MAX_GRADIENT_STOPS}</span>
+        </div>
+        <div
+          ref={barRef}
+          className="gradient-ramp"
+          role="presentation"
+          style={{ background: gradientCss({ ...spec, mode: 'basic', shape: spec.shape === 'radial' ? 'radial' : 'linear' }) }}
+          onPointerDown={(e) => { if (e.target === e.currentTarget) addStopAt(barPosition(e.clientX)); }}
+        >
+          {stops.map((stop) => (
+            <button
+              key={stop.id}
+              type="button"
+              className={`gradient-stop ${selected?.id === stop.id ? 'selected' : ''}`}
+              style={{ left: `${stop.position * 100}%`, background: stop.color }}
+              aria-label={`Colour stop ${Math.round(stop.position * 100)}%`}
+              onClick={(e) => { e.stopPropagation(); setSelectedId(stop.id); }}
+              onPointerDown={(e) => {
+                e.stopPropagation();
+                setSelectedId(stop.id);
+                e.currentTarget.setPointerCapture(e.pointerId);
+              }}
+              onPointerMove={(e) => {
+                if (e.currentTarget.hasPointerCapture(e.pointerId)) replaceStop(stop.id, { position: barPosition(e.clientX) });
+              }}
+            />
+          ))}
+        </div>
+        <div className="gradient-ramp-actions">
+          <button className="btn" type="button" onClick={() => emit({ stops: spec.stops.map((stop) => ({ ...stop, position: 1 - stop.position })) })}>Reverse</button>
+          <button className="btn" type="button" disabled={stops.length >= MAX_GRADIENT_STOPS} onClick={addLargestGap}>Add stop</button>
+        </div>
+      </div>
+
+      {selected && (
+        <div className="gradient-stop-editor ctl-section">
+          <div className="gradient-stop-heading">
+            <h4 className="ctl-section-title">Selected stop</h4>
+            <button className="link-btn" type="button" disabled={stops.length <= 2} onClick={removeSelected}>Remove</button>
+          </div>
+          <StopColor stop={selected} onColor={(color) => replaceStop(selected.id, { color })} />
+          <ControlRow def={stopPositionDef} value={Math.round(selected.position * 100)}
+            onChange={(position) => replaceStop(selected.id, { position: clamp(Number(position) / 100) })} />
+        </div>
+      )}
+
+      <div className="ctl-row">
+        <label className="ctl-label">Shape</label>
+        <div className="ctl-input">
+          <select className="field" value={spec.shape} onChange={(e) => emit({ shape: e.target.value as GradientShape })}>
+            {shapes.map(([shape, label]) => <option key={shape} value={shape}>{label}</option>)}
+          </select>
+        </div>
+      </div>
+
+      {spec.shape === 'linear' && <ControlRow def={angleDef} value={spec.angle} onChange={(angle) => emit({ angle: Number(angle) })} />}
+      {needsCenter && <>
+        <ControlRow def={{ ...centerXDef, label: spec.shape === 'twin-radial' ? 'Orb X' : 'Center X' }} value={spec.center.x}
+          onChange={(x) => emit({ center: { ...spec.center, x: Number(x) } })} />
+        <ControlRow def={{ ...centerYDef, label: spec.shape === 'twin-radial' ? 'Orb Y' : 'Center Y' }} value={spec.center.y}
+          onChange={(y) => emit({ center: { ...spec.center, y: Number(y) } })} />
+      </>}
+      {needsRadius && <ControlRow def={radiusDef} value={spec.radius} onChange={(radius) => emit({ radius: Number(radius) })} />}
+
+      {spec.mode === 'advanced' && <div className="gradient-advanced ctl-section">
+        <h4 className="ctl-section-title">Advanced</h4>
+        <ControlRow def={warpDef} value={spec.advanced.warp}
+          onChange={(warp) => emit({ advanced: { ...spec.advanced, warp: Number(warp) } })} />
+        <ControlRow def={flowDef} value={spec.advanced.flow}
+          onChange={(flow) => emit({ advanced: { ...spec.advanced, flow: Number(flow) } })} />
+        <ControlRow def={scaleDef} value={spec.advanced.scale}
+          onChange={(scale) => emit({ advanced: { ...spec.advanced, scale: Number(scale) } })} />
+        <ControlRow def={detailDef} value={spec.advanced.detail}
+          onChange={(detail) => emit({ advanced: { ...spec.advanced, detail: Number(detail) } })} />
+        <ControlRow def={contrastDef} value={spec.advanced.contrast}
+          onChange={(contrast) => emit({ advanced: { ...spec.advanced, contrast: Number(contrast) } })} />
+      </div>}
+
+      {showMapping && (
+        <div className="ctl-row">
+          <label className="ctl-label">3D mapping</label>
+          <div className="ctl-input">
+            <select className="field" value={spec.mapping3d} onChange={(e) => emit({ mapping3d: e.target.value as GradientSpec['mapping3d'] })}>
+              <option value="uv">UV</option>
+              <option value="object">Object</option>
+              <option value="screen">Screen</option>
+            </select>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ModelColors.tsx
+++ b/components/ModelColors.tsx
@@ -3,6 +3,7 @@
 import { use3DStore, defaultModelFor } from '@/store/use3DStore';
 import { findDevice } from '@/three3d/devices';
 import FillRow from './FillRow';
+import { fillPatchForGradient, gradientFromFill } from '@/lib/gradient';
 
 // Friendly display names for the bundled daisy groups (keys stay unchanged).
 const PART_LABELS: Record<string, string> = { Cube: 'Center', Cylinder: 'Stem', Plane: 'Petals' };
@@ -79,11 +80,21 @@ export default function ModelColors() {
                 label={PART_LABELS[key] ?? key}
                 fill={partFills[key]}
                 allowNone
+                showEditor
+                collapsibleEditor
                 selected={selected === key}
                 onEnter={() => selectPart(key)}
                 onLeave={() => selected === key && selectPart(null)}
-                onType={(t) => (t === 'none' ? clearPartFill(key) : setPartFill(key, { type: t }))}
+                onType={(t) => {
+                  if (t === 'none') { clearPartFill(key); return; }
+                  if (t === 'linear' || t === 'radial') {
+                    const current = partFills[key] ?? { type: t, c1: '#cccccc', c2: '#ffffff' };
+                    const gradient = gradientFromFill(current);
+                    setPartFill(key, { ...fillPatchForGradient({ ...gradient, shape: t }), type: t });
+                  } else setPartFill(key, { type: t });
+                }}
                 onColor={(which, hex) => setPartFill(key, { [which]: hex })}
+                onGradient={(gradient) => setPartFill(key, fillPatchForGradient(gradient))}
               />
             ))}
           </>

--- a/components/ThreeStage3D.tsx
+++ b/components/ThreeStage3D.tsx
@@ -9,6 +9,7 @@ import { findDevice } from '@/three3d/devices';
 import type { CameraRig } from '@/three3d/cameraRig';
 import { setRendererInstance } from '@/lib/rendererInstance';
 import type { IRenderer } from '@/lib/rendererTypes';
+import { gradientCss, gradientFromFill } from '@/lib/gradient';
 import ViewGizmo from './ViewGizmo';
 
 // 3D preview stage. Renders the active 3D effect into a canvas, then layers CSS
@@ -184,8 +185,7 @@ export default function ThreeStage3D({ effectId: forcedEffectId }: { effectId?: 
 
   const bgFill = use3DStore((s) => s.bgFill);
   const background =
-    bgFill.type === 'linear' ? `linear-gradient(to top, ${bgFill.c1} 0%, ${bgFill.c2} 100%)`
-    : bgFill.type === 'radial' ? `radial-gradient(130% 130% at 50% 50%, ${bgFill.c1} 0%, ${bgFill.c2} 100%)`
+    bgFill.type === 'linear' || bgFill.type === 'radial' ? gradientCss(gradientFromFill(bgFill))
     : bgFill.c1;
   const stageStyle: React.CSSProperties = { background };
 

--- a/lib/gradient.ts
+++ b/lib/gradient.ts
@@ -1,0 +1,410 @@
+// Shared gradient document + renderer used by the 2D canvas, WebGL scenes and
+// 3D fills. The document is deliberately renderer-agnostic: old two-colour
+// fields remain valid, while every new editor writes this richer v2 shape.
+
+export const GRADIENT_VERSION = 2 as const;
+export const MIN_GRADIENT_STOPS = 2;
+export const MAX_GRADIENT_STOPS = 8;
+
+export type GradientMode = 'basic' | 'advanced';
+export type GradientShape = 'linear' | 'radial' | 'conic' | 'mesh' | 'warped-field' | 'twin-radial';
+export type GradientMapping3D = 'uv' | 'object' | 'screen';
+
+export interface GradientStop {
+  id: string;
+  color: string;
+  position: number; // normalized 0..1
+  opacity?: number;
+}
+
+export interface GradientAdvanced {
+  warp: number;     // 0..2
+  flow: number;     // 0..1
+  scale: number;    // 0.4..4
+  detail: number;   // 0..6
+  contrast: number; // 0.5..3
+}
+
+export interface GradientSpec {
+  version: typeof GRADIENT_VERSION;
+  mode: GradientMode;
+  shape: GradientShape;
+  stops: GradientStop[];
+  angle: number; // 0deg = left to right; clockwise in screen space
+  center: { x: number; y: number };
+  radius: number;
+  advanced: GradientAdvanced;
+  mapping3d: GradientMapping3D;
+}
+
+export const DEFAULT_GRADIENT_ADVANCED: GradientAdvanced = {
+  warp: 0.3,
+  flow: 0,
+  scale: 1.3,
+  detail: 1,
+  contrast: 1.1,
+};
+
+const SHAPES: GradientShape[] = ['linear', 'radial', 'conic', 'mesh', 'warped-field', 'twin-radial'];
+const MODES: GradientMode[] = ['basic', 'advanced'];
+const MAPPINGS: GradientMapping3D[] = ['uv', 'object', 'screen'];
+
+const clamp = (v: number, lo = 0, hi = 1) => Math.max(lo, Math.min(hi, Number.isFinite(v) ? v : lo));
+const finite = (v: unknown, fallback: number) => Number.isFinite(Number(v)) ? Number(v) : fallback;
+
+function cleanHex(value: unknown, fallback = '#000000'): string {
+  const raw = String(value ?? '').trim();
+  const short = /^#?([0-9a-f]{3})$/i.exec(raw);
+  if (short) return `#${short[1].split('').map((c) => c + c).join('')}`.toLowerCase();
+  const full = /^#?([0-9a-f]{6})$/i.exec(raw);
+  return full ? `#${full[1].toLowerCase()}` : fallback;
+}
+
+export function createGradientSpec(
+  c1 = '#2b1055',
+  c2 = '#7597de',
+  shape: GradientShape = 'linear',
+): GradientSpec {
+  return {
+    version: GRADIENT_VERSION,
+    mode: 'basic',
+    shape,
+    stops: [
+      { id: 'stop-0', color: cleanHex(c1, '#2b1055'), position: 0, opacity: 1 },
+      { id: 'stop-1', color: cleanHex(c2, '#7597de'), position: 1, opacity: 1 },
+    ],
+    angle: 90,
+    center: { x: 0.5, y: 0.5 },
+    radius: 0.72,
+    advanced: { ...DEFAULT_GRADIENT_ADVANCED },
+    mapping3d: 'uv',
+  };
+}
+
+export function normalizeGradientSpec(
+  input: Partial<GradientSpec> | null | undefined,
+  c1 = '#2b1055',
+  c2 = '#7597de',
+  legacyShape: GradientShape = 'linear',
+): GradientSpec {
+  const base = createGradientSpec(c1, c2, legacyShape);
+  const rawStops = Array.isArray(input?.stops) ? input!.stops : base.stops;
+  const stops = rawStops
+    .slice(0, MAX_GRADIENT_STOPS)
+    .map((stop, i) => ({
+      id: typeof stop?.id === 'string' && stop.id ? stop.id : `stop-${i}`,
+      color: cleanHex(stop?.color, i ? cleanHex(c2) : cleanHex(c1)),
+      position: clamp(finite(stop?.position, i / Math.max(1, rawStops.length - 1))),
+      opacity: clamp(finite(stop?.opacity, 1)),
+    }))
+    .sort((a, b) => a.position - b.position || a.id.localeCompare(b.id));
+
+  while (stops.length < MIN_GRADIENT_STOPS) {
+    const i = stops.length;
+    stops.push({ id: `stop-${i}`, color: i ? cleanHex(c2) : cleanHex(c1), position: i, opacity: 1 });
+  }
+
+  const adv = input?.advanced;
+  return {
+    version: GRADIENT_VERSION,
+    mode: MODES.includes(input?.mode as GradientMode) ? input!.mode! : base.mode,
+    shape: SHAPES.includes(input?.shape as GradientShape) ? input!.shape! : legacyShape,
+    stops,
+    angle: ((finite(input?.angle, base.angle) % 360) + 360) % 360,
+    center: {
+      x: clamp(finite(input?.center?.x, base.center.x)),
+      y: clamp(finite(input?.center?.y, base.center.y)),
+    },
+    radius: clamp(finite(input?.radius, base.radius), 0.05, 2),
+    advanced: {
+      warp: clamp(finite(adv?.warp, base.advanced.warp), 0, 2),
+      flow: clamp(finite(adv?.flow, base.advanced.flow), 0, 1),
+      scale: clamp(finite(adv?.scale, base.advanced.scale), 0.4, 4),
+      detail: Math.round(clamp(finite(adv?.detail, base.advanced.detail), 0, 6)),
+      contrast: clamp(finite(adv?.contrast, base.advanced.contrast), 0.5, 3),
+    },
+    mapping3d: MAPPINGS.includes(input?.mapping3d as GradientMapping3D) ? input!.mapping3d! : base.mapping3d,
+  };
+}
+
+export function sortedStops(spec: GradientSpec): GradientStop[] {
+  return spec.stops.slice().sort((a, b) => a.position - b.position || a.id.localeCompare(b.id));
+}
+
+export function legacyColorsForGradient(spec: GradientSpec) {
+  const stops = sortedStops(spec);
+  return {
+    c1: stops[0]?.color ?? '#000000',
+    c2: stops[stops.length - 1]?.color ?? '#ffffff',
+    type: spec.shape === 'radial' || spec.shape === 'twin-radial' ? 'radial' as const : 'linear' as const,
+  };
+}
+
+export interface GradientFillLike {
+  type: string;
+  c1: string;
+  c2: string;
+  gradient?: Partial<GradientSpec>;
+}
+
+export function gradientFromFill(fill: GradientFillLike): GradientSpec {
+  const legacyShape: GradientShape = fill.type === 'radial' ? 'radial' : 'linear';
+  return normalizeGradientSpec(fill.gradient, fill.c1, fill.c2, legacyShape);
+}
+
+export function fillPatchForGradient(specInput: GradientSpec) {
+  const gradient = normalizeGradientSpec(specInput);
+  const legacy = legacyColorsForGradient(gradient);
+  return { ...legacy, gradient };
+}
+
+export function gradientSignature(spec: GradientSpec, phase = 0): string {
+  const moving = spec.mode === 'advanced' && spec.advanced.flow > 0;
+  // A long scene advances phase by tiny fractions on every RAF. Keying the
+  // raster to all of them forced a full procedural repaint at monitor rate,
+  // even when several consecutive images were visually indistinguishable.
+  // 480 samples per seamless loop keeps an 8 s scene at 60 fps and naturally
+  // settles near 24 fps for a 20 s scene.
+  const sampledPhase = Math.round((((phase % 1) + 1) % 1) * 480) / 480;
+  return JSON.stringify(spec) + (moving ? `|${sampledPhase.toFixed(4)}` : '');
+}
+
+export function gradientCss(specInput: GradientSpec): string {
+  const spec = normalizeGradientSpec(specInput);
+  const stops = sortedStops(spec).map((s) => `${s.color} ${Math.round(s.position * 1000) / 10}%`).join(', ');
+  const cx = Math.round(spec.center.x * 1000) / 10;
+  const cy = Math.round(spec.center.y * 1000) / 10;
+  if (spec.shape === 'radial') return `radial-gradient(circle at ${cx}% ${cy}%, ${stops})`;
+  if (spec.shape === 'conic') return `conic-gradient(from ${spec.angle}deg at ${cx}% ${cy}%, ${stops})`;
+  if (spec.shape === 'twin-radial') {
+    const rx = Math.round((1 - spec.center.x) * 1000) / 10;
+    const colors = sortedStops(spec);
+    const inner = colors[0]?.color ?? '#000';
+    const outer = colors[colors.length - 1]?.color ?? '#fff';
+    return `radial-gradient(circle at ${cx}% ${cy}%, ${inner}, transparent 58%), radial-gradient(circle at ${rx}% ${cy}%, ${inner}, ${outer} 72%)`;
+  }
+  // Mesh and procedural fields need the canvas/WebGL renderer. This linear
+  // expression is only a CSS fallback behind the real canvas during startup.
+  return `linear-gradient(${spec.angle + 90}deg, ${stops})`;
+}
+
+type RGB = [number, number, number, number];
+type PreparedStop = { position: number; color: RGB };
+
+function parseColor(hex: string, alpha = 1): RGB {
+  const h = cleanHex(hex).slice(1);
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16), clamp(alpha) * 255];
+}
+
+function mixColor(a: RGB, b: RGB, t: number): RGB {
+  const k = clamp(t);
+  return [
+    a[0] + (b[0] - a[0]) * k,
+    a[1] + (b[1] - a[1]) * k,
+    a[2] + (b[2] - a[2]) * k,
+    a[3] + (b[3] - a[3]) * k,
+  ];
+}
+
+function prepareStops(spec: GradientSpec): PreparedStop[] {
+  return sortedStops(spec).map((stop) => ({
+    position: stop.position,
+    color: parseColor(stop.color, stop.opacity),
+  }));
+}
+
+function samplePreparedStops(stops: PreparedStop[], t: number): RGB {
+  const x = clamp(t);
+  if (x <= stops[0].position) return stops[0].color;
+  for (let i = 1; i < stops.length; i++) {
+    const right = stops[i];
+    if (x <= right.position) {
+      const left = stops[i - 1];
+      const span = Math.max(1e-6, right.position - left.position);
+      return mixColor(left.color, right.color, (x - left.position) / span);
+    }
+  }
+  return stops[stops.length - 1].color;
+}
+
+export function sampleGradientRGB(specInput: GradientSpec, t: number): RGB {
+  const spec = normalizeGradientSpec(specInput);
+  return samplePreparedStops(prepareStops(spec), t);
+}
+
+function hash2(x: number, y: number): number {
+  const n = Math.sin(x * 127.1 + y * 311.7) * 43758.5453123;
+  return n - Math.floor(n);
+}
+
+function noise2(x: number, y: number): number {
+  const ix = Math.floor(x), iy = Math.floor(y);
+  const fx = x - ix, fy = y - iy;
+  const ux = fx * fx * (3 - 2 * fx), uy = fy * fy * (3 - 2 * fy);
+  const a = hash2(ix, iy), b = hash2(ix + 1, iy);
+  const c = hash2(ix, iy + 1), d = hash2(ix + 1, iy + 1);
+  return (a + (b - a) * ux) + ((c + (d - c) * ux) - (a + (b - a) * ux)) * uy;
+}
+
+function fbm(x: number, y: number, detail: number): number {
+  let sum = 0, amp = 0.55, freq = 1, norm = 0;
+  const octaves = Math.max(1, Math.min(7, 1 + Math.round(detail)));
+  for (let i = 0; i < octaves; i++) {
+    sum += noise2(x * freq, y * freq) * amp;
+    norm += amp;
+    amp *= 0.5;
+    freq *= 2.03;
+  }
+  return sum / Math.max(1e-6, norm);
+}
+
+function prepareMeshPalette(stops: PreparedStop[]): RGB[] {
+  return Array.from({ length: 5 }, (_, i) => stops[Math.min(i, stops.length - 1)].color);
+}
+
+function meshColor(spec: GradientSpec, colors: RGB[], stopCount: number, x: number, y: number): RGB {
+  const top = mixColor(colors[0], colors[1], x);
+  const bottom = mixColor(colors[3], colors[2], x);
+  let result = mixColor(top, bottom, y);
+  if (stopCount >= 5) {
+    const dx = x - spec.center.x, dy = y - spec.center.y;
+    const pool = Math.exp(-(dx * dx + dy * dy) / 0.075);
+    result = mixColor(result, colors[4], pool * 0.82);
+  }
+  return result;
+}
+
+function samplePreparedGradientPoint(
+  spec: GradientSpec,
+  stops: PreparedStop[],
+  x: number,
+  y: number,
+  phase = 0,
+  meshPalette?: RGB[],
+): RGB {
+  let px = x, py = y;
+  const advanced = spec.mode === 'advanced';
+  const { warp, flow, scale, detail, contrast } = spec.advanced;
+
+  if (advanced) {
+    const a = phase * Math.PI * 2;
+    const driftX = Math.cos(a) * flow * 0.75;
+    const driftY = Math.sin(a) * flow * 0.75;
+    const sx = (px - 0.5) * scale + 0.5;
+    const sy = (py - 0.5) * scale + 0.5;
+    const amplitude = warp * 0.16 + (spec.shape === 'warped-field' ? 0.16 : 0);
+    if (amplitude > 0) {
+      const nx = fbm(sx * 2.2 + 7.4 + driftX, sy * 2.2 + driftY, detail);
+      const ny = fbm(sx * 2.2 - 4.7 - driftY, sy * 2.2 + 9.1 + driftX, detail);
+      px += (nx - 0.5) * amplitude;
+      py += (ny - 0.5) * amplitude;
+    }
+  }
+
+  if (spec.shape === 'mesh') return meshColor(spec, meshPalette ?? prepareMeshPalette(stops), stops.length, clamp(px), clamp(py));
+
+  let t = 0;
+  const dx = px - spec.center.x, dy = py - spec.center.y;
+  if (spec.shape === 'radial') {
+    t = Math.hypot(dx, dy) / Math.max(0.05, spec.radius);
+  } else if (spec.shape === 'twin-radial') {
+    const d1 = Math.hypot(px - spec.center.x, py - spec.center.y);
+    const d2 = Math.hypot(px - (1 - spec.center.x), py - spec.center.y);
+    t = Math.min(d1, d2) / Math.max(0.05, spec.radius);
+  } else if (spec.shape === 'conic') {
+    t = ((Math.atan2(dy, dx) / (Math.PI * 2)) + spec.angle / 360 + 1) % 1;
+  } else if (spec.shape === 'warped-field') {
+    const a = phase * Math.PI * 2;
+    const n = fbm((px * spec.advanced.scale + Math.cos(a) * spec.advanced.flow) * 2.6,
+      (py * spec.advanced.scale + Math.sin(a) * spec.advanced.flow) * 2.6, spec.advanced.detail + 1);
+    t = 0.18 + n * 0.72 + (px - 0.5) * 0.16;
+  } else {
+    const rad = spec.angle * Math.PI / 180;
+    const vx = Math.cos(rad), vy = Math.sin(rad);
+    const cover = Math.max(1e-5, Math.abs(vx) + Math.abs(vy));
+    t = 0.5 + ((px - 0.5) * vx + (py - 0.5) * vy) / cover;
+  }
+
+  if (advanced) t = 0.5 + (t - 0.5) * contrast;
+  return samplePreparedStops(stops, clamp(t));
+}
+
+export function sampleGradientPoint(specInput: GradientSpec, x: number, y: number, phase = 0): RGB {
+  const spec = normalizeGradientSpec(specInput);
+  return samplePreparedGradientPoint(spec, prepareStops(spec), x, y, phase);
+}
+
+function addNativeStops(gradient: CanvasGradient, spec: GradientSpec) {
+  for (const stop of sortedStops(spec)) gradient.addColorStop(stop.position, stop.color);
+}
+
+export function paintGradientCanvas(
+  canvas: HTMLCanvasElement,
+  specInput: GradientSpec,
+  width: number,
+  height: number,
+  phase = 0,
+): void {
+  const spec = normalizeGradientSpec(specInput);
+  const w = Math.max(2, Math.round(width));
+  const h = Math.max(2, Math.round(height));
+  if (canvas.width !== w) canvas.width = w;
+  if (canvas.height !== h) canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  // Basic gradients use the browser's native, high-resolution interpolation.
+  if (spec.mode === 'basic' && (spec.shape === 'linear' || spec.shape === 'radial')) {
+    let gradient: CanvasGradient;
+    if (spec.shape === 'radial') {
+      const cx = spec.center.x * w, cy = spec.center.y * h;
+      gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, Math.max(w, h) * spec.radius);
+    } else {
+      const rad = spec.angle * Math.PI / 180;
+      const vx = Math.cos(rad), vy = Math.sin(rad);
+      const half = (Math.abs(vx) * w + Math.abs(vy) * h) / 2;
+      const cx = w / 2, cy = h / 2;
+      gradient = ctx.createLinearGradient(cx - vx * half, cy - vy * half, cx + vx * half, cy + vy * half);
+    }
+    addNativeStops(gradient, spec);
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, w, h);
+    return;
+  }
+
+  const image = ctx.createImageData(w, h);
+  const data = image.data;
+  // Normalisation, sorting, hex parsing and opacity composition are invariant
+  // across this raster. Preparing once here removes hundreds of thousands of
+  // object allocations from every Advanced frame.
+  const preparedStops = prepareStops(spec);
+  const meshPalette = spec.shape === 'mesh' ? prepareMeshPalette(preparedStops) : undefined;
+  for (let py = 0; py < h; py++) {
+    for (let px = 0; px < w; px++) {
+      const c = samplePreparedGradientPoint(spec, preparedStops, (px + 0.5) / w, (py + 0.5) / h, phase, meshPalette);
+      const i = (py * w + px) * 4;
+      data[i] = Math.round(c[0]); data[i + 1] = Math.round(c[1]);
+      data[i + 2] = Math.round(c[2]); data[i + 3] = Math.round(c[3]);
+    }
+  }
+  ctx.putImageData(image, 0, 0);
+}
+
+export function advancedRasterSize(width: number, height: number, maxEdge = 384): [number, number] {
+  const scale = Math.min(1, maxEdge / Math.max(1, width, height));
+  return [Math.max(2, Math.round(width * scale)), Math.max(2, Math.round(height * scale))];
+}
+
+export function gradientRasterMaxEdge(specInput: GradientSpec): number {
+  const spec = normalizeGradientSpec(specInput);
+  if (spec.mode === 'basic' && (spec.shape === 'linear' || spec.shape === 'radial')) return 1080;
+  // Animated procedural fields are deliberately lower resolution: they are
+  // smooth colour fields, so canvas interpolation hides the difference while
+  // the 7–8× lower pixel count keeps timeline playback and sliders responsive.
+  if (spec.advanced.flow <= 0) return 288;
+  if (spec.shape === 'warped-field' || spec.shape === 'mesh') return 160;
+  // Conic has a hard seam/edge and needs more samples than the soft fields to
+  // avoid visible stair-stepping when the canvas is scaled to the stage.
+  if (spec.shape === 'conic') return 224;
+  return 176;
+}

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -10,6 +10,7 @@ import { resolveTrackTime, trackAssetIndices, type MotionTrack } from '@/lib/tra
 import { cardAspectFor, coverCrop, cropKey } from '@/lib/crop';
 import { advanceVideoForExport, createCardVideo, isVideoSource, prepareVideoForSequentialExport, useVideoProxies, whenVideoReady } from '@/lib/videoTexture';
 import { BASE_PATH, IS_STATIC_EXPORT } from '@/lib/paths';
+import { advancedRasterSize, gradientRasterMaxEdge, gradientSignature, normalizeGradientSpec, paintGradientCanvas } from '@/lib/gradient';
 
 // Reference base long-edge (px) shared with templates (carousel BASE = 340),
 // so control values read directly in on-screen pixels.
@@ -87,6 +88,7 @@ export class SceneRenderer {
   onDirty?: () => void;   // preview loop hooks this to redraw once after async loads
   private content = new PIXI.Container();       // bg + motion (effects applied here)
   private bg = new PIXI.Graphics();
+  private gradientSprite = new PIXI.Sprite();
   private bgSprite = new PIXI.Sprite();          // image / card-reflected background
   private bgBlur = new PIXI.BlurFilter({ strength: 28, quality: 4 });
   private motion = new PIXI.Container();         // card sprites
@@ -109,6 +111,9 @@ export class SceneRenderer {
   private lastFxSig = '';
   private bgImageUrl = '';                        // last-loaded uploaded bg url
   private bgImageTex: PIXI.Texture | null = null;
+  private gradientCanvas: HTMLCanvasElement | null = null;
+  private gradientTexture: PIXI.Texture | null = null;
+  private gradientKey = '';
 
   constructor() {
     this.app = new PIXI.Application();
@@ -131,9 +136,11 @@ export class SceneRenderer {
 
     this.motion.sortableChildren = true;
     this.bgSprite.anchor.set(0.5);
+    this.gradientSprite.anchor.set(0.5);
+    this.gradientSprite.visible = false;
     this.bgSprite.visible = false;
     this.bgSprite.filters = [this.bgBlur];
-    this.content.addChild(this.bg, this.bgSprite, this.motion);
+    this.content.addChild(this.bg, this.gradientSprite, this.bgSprite, this.motion);
     this.app.stage.addChild(this.content, this.overlay);
     this.overlay.addChild(this.safeGfx);
 
@@ -148,6 +155,7 @@ export class SceneRenderer {
     this.app.renderer.resize(width, height, resolution);
     this.motion.position.set(width / 2, height / 2);
     this.bgSprite.position.set(width / 2, height / 2);
+    this.gradientSprite.position.set(width / 2, height / 2);
     this.content.filterArea = new PIXI.Rectangle(0, 0, width, height);
     this.overlay.position.set(0, 0);
   }
@@ -505,12 +513,28 @@ export class SceneRenderer {
 
     // background
     this.bg.clear();
-    if (s.background.gradient) {
-      const grad = new PIXI.FillGradient(0, 0, 0, height);
-      grad.addColorStop(0, s.background.color);
-      grad.addColorStop(1, s.background.color2);
-      this.bg.rect(0, 0, width, height).fill(grad);
+    if (s.background.source === 'color' && s.background.gradient) {
+      const spec = normalizeGradientSpec(s.background.gradientSpec, s.background.color, s.background.color2);
+      const phase = ((s.frame / Math.max(1, s.duration * s.fps)) % 1 + 1) % 1;
+      const [rw, rh] = advancedRasterSize(width, height, gradientRasterMaxEdge(spec));
+      const key = `${rw}x${rh}|${gradientSignature(spec, phase)}`;
+      if (key !== this.gradientKey) {
+        this.gradientKey = key;
+        const resized = !this.gradientCanvas || this.gradientCanvas.width !== rw || this.gradientCanvas.height !== rh;
+        if (!this.gradientCanvas) this.gradientCanvas = document.createElement('canvas');
+        paintGradientCanvas(this.gradientCanvas, spec, rw, rh, phase);
+        if (!this.gradientTexture || resized) {
+          this.gradientTexture?.destroy(true);
+          this.gradientTexture = PIXI.Texture.from(this.gradientCanvas);
+          this.gradientSprite.texture = this.gradientTexture;
+        } else {
+          this.gradientTexture.source.update();
+        }
+      }
+      this.gradientSprite.visible = true;
+      this.gradientSprite.scale.set(width / rw, height / rh);
     } else {
+      this.gradientSprite.visible = false;
       this.bg.rect(0, 0, width, height).fill(s.background.color);
     }
 
@@ -805,6 +829,8 @@ export class SceneRenderer {
     this.texturePromises.clear();
     this.videoEls.forEach((v) => { try { v.pause(); v.removeAttribute('src'); v.load(); } catch { /* noop */ } });
     this.videoEls.clear();
+    this.gradientTexture?.destroy(true);
+    this.gradientTexture = null;
     try { this.app.destroy(true, { children: true, texture: false }); } catch { /* noop */ }
   }
 }

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -14,6 +14,7 @@ import type { IRenderer } from '@/lib/rendererTypes';
 import type { CameraPose, LayerTransform3D } from '@/lib/types';
 import { resolveTrackTime, trackAssetIndices, type MotionTrack } from '@/lib/tracks';
 import type { SceneState } from '@/store/useSceneStore';
+import { advancedRasterSize, gradientRasterMaxEdge, gradientSignature, normalizeGradientSpec, paintGradientCanvas } from '@/lib/gradient';
 
 // Shared with the Pixi renderer so control values read identically in px.
 const SPRITE_BASE = 340;
@@ -57,7 +58,6 @@ import {
   makeCornerAlphaMap,
   makeCornerPeelGeometry,
   makeCurlPlaneGeometry,
-  makeGradientTexture,
   makePlaceholderTexture,
   makeStickerRollGeometry,
 } from '@/three3d/cardMesh';
@@ -80,6 +80,7 @@ export class SceneRenderer3D implements IRenderer {
   private placeholders = new Map<number, THREE.CanvasTexture>();
   private cornerMaps = new Map<string, THREE.CanvasTexture>();
   private gradientTex: THREE.CanvasTexture | null = null;
+  private gradientCanvas: HTMLCanvasElement | null = null;
   private gradientSig = '';
   private backgroundTex: THREE.CanvasTexture | null = null;
   private backgroundSig = '';
@@ -623,10 +624,18 @@ export class SceneRenderer3D implements IRenderer {
     // Background parity with Pixi: solid, gradient, uploaded image, or an
     // asset reflected from the active motion layer.
     if (s.background.source === 'color' && s.background.gradient) {
-      const sig = s.background.color + '|' + s.background.color2;
+      const spec = normalizeGradientSpec(s.background.gradientSpec, s.background.color, s.background.color2);
+      const phase = ((s.frame / Math.max(1, s.duration * s.fps)) % 1 + 1) % 1;
+      const [rw, rh] = advancedRasterSize(this.width, this.height, gradientRasterMaxEdge(spec));
+      const sig = `${rw}x${rh}|${gradientSignature(spec, phase)}`;
       if (this.gradientSig !== sig) {
-        this.gradientTex?.dispose();
-        this.gradientTex = makeGradientTexture(s.background.color, s.background.color2);
+        if (!this.gradientCanvas) this.gradientCanvas = document.createElement('canvas');
+        paintGradientCanvas(this.gradientCanvas, spec, rw, rh, phase);
+        if (!this.gradientTex) {
+          this.gradientTex = new THREE.CanvasTexture(this.gradientCanvas);
+          this.gradientTex.colorSpace = THREE.SRGBColorSpace;
+        }
+        this.gradientTex.needsUpdate = true;
         this.gradientSig = sig;
       }
       this.scene.background = this.gradientTex;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Motion Studio — an open-source factory for quick videos and GIFs.",
   "main": "index.js",
   "scripts": {
-    "test": "node scripts/verify-tilt.cjs && node scripts/verify-catalogue.cjs && node scripts/verify-contexts.cjs && node scripts/verify-reference.cjs && node scripts/verify-effects.cjs",
+    "test": "node scripts/verify-tilt.cjs && node scripts/verify-catalogue.cjs && node scripts/verify-contexts.cjs && node scripts/verify-reference.cjs && node scripts/verify-effects.cjs && node scripts/verify-gradients.cjs",
     "dev": "next dev",
     "dev:network": "next dev -H 0.0.0.0",
     "build": "next build",

--- a/scripts/verify-gradients.cjs
+++ b/scripts/verify-gradients.cjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Shared-gradient invariants. These protect the migration seam: old scenes only
+// have two colours, while new 2D and 3D documents carry GradientSpec v2.
+
+require('sucrase/register');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  MAX_GRADIENT_STOPS,
+  createGradientSpec,
+  fillPatchForGradient,
+  gradientFromFill,
+  gradientRasterMaxEdge,
+  gradientSignature,
+  normalizeGradientSpec,
+  sampleGradientPoint,
+  sampleGradientRGB,
+} = require('../lib/gradient');
+
+let assertions = 0;
+const failures = [];
+const check = (condition, message) => { assertions++; if (!condition) failures.push(message); };
+const close = (a, b, epsilon = 1) => Math.abs(a - b) <= epsilon;
+const colorClose = (a, b, epsilon = 1) => a.slice(0, 3).every((v, i) => close(v, b[i], epsilon));
+
+const legacy = gradientFromFill({ type: 'radial', c1: '#112233', c2: '#ddeeff' });
+check(legacy.version === 2, 'legacy fill must migrate to GradientSpec v2');
+check(legacy.shape === 'radial', 'legacy radial fill must keep its shape');
+check(legacy.stops.length === 2, 'legacy fill must create two stops');
+check(legacy.stops[0].color === '#112233' && legacy.stops[1].color === '#ddeeff', 'legacy colours must survive migration');
+
+const crowded = normalizeGradientSpec({
+  ...createGradientSpec(),
+  stops: Array.from({ length: 12 }, (_, i) => ({ id: `s${i}`, color: '#abcdef', position: 1 - i / 11 })),
+});
+check(crowded.stops.length === MAX_GRADIENT_STOPS, 'stop count must be capped at eight');
+check(crowded.stops.every((stop, i, list) => i === 0 || list[i - 1].position <= stop.position), 'render stops must be sorted');
+
+const simple = createGradientSpec('#000000', '#ffffff');
+check(colorClose(sampleGradientRGB(simple, 0.5), [128, 128, 128, 255]), 'two-stop midpoint must interpolate');
+check(colorClose(sampleGradientPoint({ ...simple, angle: 0 }, 0, 0.5), [0, 0, 0, 255]), 'linear start must use first stop');
+check(colorClose(sampleGradientPoint({ ...simple, angle: 0 }, 1, 0.5), [255, 255, 255, 255]), 'linear end must use last stop');
+
+const radial = { ...simple, shape: 'radial', center: { x: 0.5, y: 0.5 }, radius: 0.5 };
+check(colorClose(sampleGradientPoint(radial, 0.5, 0.5), [0, 0, 0, 255]), 'radial centre must use first stop');
+check(colorClose(sampleGradientPoint(radial, 1, 0.5), [255, 255, 255, 255]), 'radial radius must reach last stop');
+
+const moving = normalizeGradientSpec({
+  ...simple,
+  mode: 'advanced',
+  shape: 'warped-field',
+  advanced: { warp: 1.2, flow: 0.8, scale: 1.4, detail: 3, contrast: 1.2 },
+});
+check(colorClose(sampleGradientPoint(moving, 0.31, 0.73, 0), sampleGradientPoint(moving, 0.31, 0.73, 1), 0.001), 'flow must loop seamlessly at phase 0/1');
+check(gradientRasterMaxEdge(simple) === 1080, 'basic native gradients must keep their high-resolution raster');
+check(gradientRasterMaxEdge(moving) === 160, 'animated procedural fields must use the responsive raster budget');
+check(gradientSignature(moving, 0.1) === gradientSignature(moving, 0.1005), 'near-identical animated phases must share a cached raster');
+
+const patch = fillPatchForGradient({ ...radial, stops: [
+  { id: 'a', color: '#123456', position: 0 },
+  { id: 'b', color: '#abcdef', position: 1 },
+] });
+check(patch.type === 'radial', 'v2 radial must mirror to the legacy radial type');
+check(patch.c1 === '#123456' && patch.c2 === '#abcdef', 'v2 endpoints must mirror into legacy colours');
+
+// UI contract: the shared editor must stay on the Motion Studio primitives and
+// token sheet. This catches the exact regression that previously introduced a
+// second visual language with native range inputs, local radii and local type.
+const root = path.resolve(__dirname, '..');
+const editorSource = fs.readFileSync(path.join(root, 'components', 'GradientEditor.tsx'), 'utf8');
+const cssSource = fs.readFileSync(path.join(root, 'app', 'globals.css'), 'utf8');
+const sceneStoreSource = fs.readFileSync(path.join(root, 'store', 'useSceneStore.ts'), 'utf8');
+const rendererSource = fs.readFileSync(path.join(root, 'lib', 'renderer.ts'), 'utf8');
+const gradientCssBlock = cssSource.split('/* ---- Shared 2D / 3D gradient editor ---- */')[1]
+  ?.split('/* Neutral SSR/hydration gate.')[0] ?? '';
+check(editorSource.includes("import { ControlRow } from './Controls'"), 'gradient sliders must use the shared ControlRow primitive');
+check(editorSource.includes('className="segmented"') && editorSource.includes('className="field"') && editorSource.includes('className="btn"'), 'gradient choices and actions must use shared control classes');
+check(!editorSource.includes('type="range"') && !editorSource.includes('gradient-number'), 'gradient editor must not introduce native parallel sliders');
+check(gradientCssBlock.includes('var(--ctl-h)') && gradientCssBlock.includes('var(--gap-row)') && gradientCssBlock.includes('var(--r-ctrl)'), 'gradient geometry must derive from tokens.css metrics');
+check(!/#[0-9a-f]{3,8}\b/i.test(gradientCssBlock), 'gradient UI CSS must not hardcode theme colours');
+check(!/font-size:\s*\d/.test(gradientCssBlock), 'gradient UI CSS must not hardcode typography');
+const gradientRadii = [...gradientCssBlock.matchAll(/border-radius:\s*([^;]+)/g)].map((match) => match[1].trim());
+check(gradientRadii.every((value) => value.startsWith('var(')), 'gradient UI CSS must keep every control, including stop handles, on the square radius tokens');
+check(/if \(patch\.gradientSpec\)[\s\S]*?source: 'color',[\s\S]*?gradient: true,/.test(sceneStoreSource), 'writing a gradient document must atomically activate the colour-gradient background');
+check(rendererSource.includes("s.background.source === 'color' && s.background.gradient"), '2D renderer must obey the same background source guard as 3D');
+
+if (failures.length) {
+  console.error(`Gradient verification failed (${failures.length}/${assertions})`);
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+console.log(`Gradient verification passed (${assertions} assertions).`);

--- a/store/use3DStore.ts
+++ b/store/use3DStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { idbDelete, idbGet, idbPut } from '@/lib/assetDb';
+import { createGradientSpec, fillPatchForGradient, normalizeGradientSpec, type GradientSpec } from '@/lib/gradient';
 
 // Model transform — cross-effect (applies to the 3D object itself, not the
 // ASCII look). The effect reads this live and drives a pivot around the model.
@@ -110,7 +111,12 @@ export interface ThreeDState {
 
 // A part's fill: solid, or a two-colour gradient (linear along Y bottom→top,
 // or radial centre→edge). c1 = start/centre, c2 = end/edge.
-export interface FillSpec { type: 'solid' | 'linear' | 'radial'; c1: string; c2: string; }
+export interface FillSpec {
+  type: 'solid' | 'linear' | 'radial';
+  c1: string;
+  c2: string;
+  gradient?: GradientSpec;
+}
 
 // Artwork on a device's screen. `url` is live-session only — a blob: string is
 // dead after a reload — so `id` keys the bytes in IndexedDB and the url is
@@ -127,12 +133,18 @@ const nid = (prefix: string) => `${prefix}_${Date.now().toString(36)}_${++_scree
 
 const DEF_FILL: FillSpec = { type: 'solid', c1: '#cccccc', c2: '#ffffff' };
 
+function migrateFill(fill: FillSpec): FillSpec {
+  if (fill.type === 'solid') return { ...fill };
+  const gradient = normalizeGradientSpec(fill.gradient, fill.c1, fill.c2, fill.type);
+  return { ...fill, ...fillPatchForGradient(gradient), type: gradient.shape === 'radial' || gradient.shape === 'twin-radial' ? 'radial' : 'linear' };
+}
+
 // Nice out-of-the-box fills for the bundled dayse groups (generic keys, still
 // applied only when those groups are present — other models fall back to none).
 const DEFAULT_FILLS: Record<string, FillSpec> = {
-  Cube:     { type: 'radial', c1: '#f4d21c', c2: '#e88a2a' }, // centres: yellow → orange edge
-  Cylinder: { type: 'linear', c1: '#1c5622', c2: '#63c24c' }, // stems: dark bottom → light tip
-  Plane:    { type: 'linear', c1: '#ffffff', c2: '#9a9a9a' }, // petals: white → grey
+  Cube:     { type: 'radial', c1: '#f4d21c', c2: '#e88a2a', gradient: createGradientSpec('#f4d21c', '#e88a2a', 'radial') },
+  Cylinder: { type: 'linear', c1: '#1c5622', c2: '#63c24c', gradient: createGradientSpec('#1c5622', '#63c24c') },
+  Plane:    { type: 'linear', c1: '#ffffff', c2: '#9a9a9a', gradient: createGradientSpec('#ffffff', '#9a9a9a') },
 };
 
 // Default nudge that centres the bundled dayse model in the stage.
@@ -190,7 +202,10 @@ function initial3DState(): ThreeDDoc {
     parts: [],
     partFills: {},
     selectedPart: null,
-    bgFill: { type: 'linear', c1: '#fbfbfc', c2: '#e6e8eb' },   // near-white → soft light grey
+    bgFill: {
+      type: 'linear', c1: '#fbfbfc', c2: '#e6e8eb',
+      gradient: createGradientSpec('#fbfbfc', '#e6e8eb'),
+    },
     bgTexAmount: 32,
     bgTexScale: 4.1,
     sunIntensity: 85,
@@ -304,7 +319,18 @@ export const use3DStore = create<ThreeDState>((set) => ({
   // Applied when a project opens. `parts` and `selectedPart` are deliberately
   // not restored: the effect reports its own colourable groups on load, and a
   // click-selection is session state, not a document.
-  hydrate3D: (partial) => set((s) => ({ ...s, ...partial, parts: [], selectedPart: null })),
+  hydrate3D: (partial) => set((s) => {
+    const rawBg = partial.bgFill ?? s.bgFill;
+    const rawParts = partial.partFills ?? s.partFills;
+    return {
+      ...s,
+      ...partial,
+      bgFill: migrateFill(rawBg),
+      partFills: Object.fromEntries(Object.entries(rawParts).map(([key, fill]) => [key, migrateFill(fill)])),
+      parts: [],
+      selectedPart: null,
+    };
+  }),
 
   // Drops the IndexedDB rows this project's screens were using: a new project
   // will never reference them again, and IndexedDB evicts nothing on its own.
@@ -353,16 +379,20 @@ export const use3DStore = create<ThreeDState>((set) => ({
     for (const k of keys) if (DEFAULT_FILLS[k]) fills[k] = { ...DEFAULT_FILLS[k] };
     return { parts: keys, partFills: fills, selectedPart: null };
   }),
-  setPartFill: (key, patch) => set((s) => ({
-    partFills: { ...s.partFills, [key]: { ...DEF_FILL, ...s.partFills[key], ...patch } },
-  })),
+  setPartFill: (key, patch) => set((s) => {
+    const next = { ...DEF_FILL, ...s.partFills[key], ...patch } as FillSpec;
+    return { partFills: { ...s.partFills, [key]: patch.gradient ? migrateFill(next) : next } };
+  }),
   clearPartFill: (key) => set((s) => {
     const pf = { ...s.partFills };
     delete pf[key];
     return { partFills: pf };
   }),
   selectPart: (key) => set({ selectedPart: key }),
-  setBgFill: (patch) => set((s) => ({ bgFill: { ...s.bgFill, ...patch } })),
+  setBgFill: (patch) => set((s) => {
+    const next = { ...s.bgFill, ...patch } as FillSpec;
+    return { bgFill: patch.gradient ? migrateFill(next) : next };
+  }),
   setBgTexAmount: (v) => set({ bgTexAmount: v }),
   setBgTexScale: (v) => set({ bgTexScale: v }),
   setSunIntensity: (v) => set({ sunIntensity: v }),

--- a/store/useSceneStore.ts
+++ b/store/useSceneStore.ts
@@ -5,6 +5,7 @@ import type { CropFocus } from '@/lib/crop';
 import { DEMO_ASSETS, demoSourceForSlot, isDemoAssetSource } from '@/lib/demoAssets';
 import { idbPut, idbGet, idbDelete } from '@/lib/assetDb';
 import { DEFAULT_TRACK_TRANSFORM, TRACK_END, type BlendMode, type MotionTrack } from '@/lib/tracks';
+import { createGradientSpec, legacyColorsForGradient, normalizeGradientSpec, type GradientSpec } from '@/lib/gradient';
 
 // ---------- canvas dimension helpers ----------
 export const ASPECTS: Record<string, [number, number]> = {
@@ -50,6 +51,7 @@ export interface BackgroundSettings {
   color: string;
   gradient: boolean;
   color2: string;
+  gradientSpec?: GradientSpec;           // v2; legacy color/gradient fields remain readable
   imageUrl: string | null;            // for source: 'image'
   blur: number;                       // px blur for image/card backgrounds
   userSet?: boolean;                  // preserve an explicit choice across template switches
@@ -312,7 +314,15 @@ function initialSceneState() {
     customW: initDims.width,
     customH: initDims.height,
     safeArea: false,
-    background: { source: 'color' as const, color: '#0d0d0d', gradient: false, color2: '#1f1f1f', imageUrl: null, blur: 28 },
+    background: {
+      source: 'color' as const,
+      color: '#0d0d0d',
+      gradient: false,
+      color2: '#1f1f1f',
+      gradientSpec: createGradientSpec('#0d0d0d', '#1f1f1f'),
+      imageUrl: null,
+      blur: 28,
+    },
     logo: { url: null, position: 'br' as const, size: 96 },
     audioUrl: null,
 
@@ -630,9 +640,29 @@ export const useSceneStore = create<SceneState>((set, get) => ({
     }),
   setDuration: (d) => set(() => ({ duration: d })),
   toggleSafeArea: () => set((s) => ({ safeArea: !s.safeArea })),
-  setBackground: (patch) => set((s) => ({
-    background: { ...s.background, ...patch, userSet: true },
-  })),
+  setBackground: (patch) => set((s) => {
+    if (patch.gradientSpec) {
+      const gradientSpec = normalizeGradientSpec(patch.gradientSpec, s.background.color, s.background.color2);
+      const legacy = legacyColorsForGradient(gradientSpec);
+      // A gradient document is an applied background, not a detached draft.
+      // Keep source + mode atomic so a hydrated legacy project cannot update
+      // the ramp while the renderer still believes it should paint a solid,
+      // uploaded image or reflected card.
+      return {
+        background: {
+          ...s.background,
+          ...patch,
+          source: 'color',
+          gradient: true,
+          color: legacy.c1,
+          color2: legacy.c2,
+          gradientSpec,
+          userSet: true,
+        },
+      };
+    }
+    return { background: { ...s.background, ...patch, userSet: true } };
+  }),
   setLogo: (patch) => set((s) => ({ logo: { ...s.logo, ...patch } })),
   setAudioUrl: (url) => set(() => ({ audioUrl: url })),
 
@@ -770,9 +800,20 @@ export const useSceneStore = create<SceneState>((set, get) => ({
           ? partial.activeTrackId!
           : safeTracks[0].id;
 
+      const rawBackground = partial.background ?? s.background;
+      const background = {
+        ...rawBackground,
+        gradientSpec: normalizeGradientSpec(
+          rawBackground.gradientSpec,
+          rawBackground.color,
+          rawBackground.color2,
+        ),
+      };
+
       return {
         ...s,
         ...partial,
+        background,
         assets,
         ...projectActive(safeTracks, activeId),
         frame: 0, // always start at the clip head

--- a/three3d/cartoon.ts
+++ b/three3d/cartoon.ts
@@ -9,6 +9,14 @@ import { makeCameraRig } from './cameraRig';
 import { use3DStore } from '../store/use3DStore';
 import { useSceneStore } from '../store/useSceneStore';
 import { apply3DAnimation } from './animations';
+import {
+  advancedRasterSize,
+  gradientFromFill,
+  gradientRasterMaxEdge,
+  gradientSignature,
+  paintGradientCanvas,
+  sampleGradientPoint,
+} from '@/lib/gradient';
 
 // ── Cartoon (toon) 3D effect ────────────────────────────────────────────────
 // Renders the model with THREE.MeshToonMaterial straight to the (WebGL) canvas.
@@ -74,6 +82,7 @@ export function initCartoon(
   // GLSL helpers shared by the wall material (stochastic paint tiling).
   const PAINT_GLSL = `
 uniform int uType; uniform vec3 uC1; uniform vec3 uC2; uniform float uAmount; uniform float uScale;
+uniform sampler2D uGradientTex; uniform float uUseGradientTex;
 varying vec2 vWallUv;
 vec2 pHash(vec2 p){ p=vec2(dot(p,vec2(127.1,311.7)),dot(p,vec2(269.5,183.3))); return fract(sin(p)*43758.5453); }
 float stochGrey(sampler2D tex, vec2 uv){
@@ -103,6 +112,24 @@ vec4 stochNormalW(sampler2D tex, vec2 uv){
   // ── Background wall: a real 3D plane behind the model (receives shadows). ──
   // Painterly gradient + strokes injected via onBeforeCompile; MeshToonMaterial
   // so it takes toon-banded cast shadows from the sun.
+  const wallGradientCanvas = document.createElement('canvas');
+  wallGradientCanvas.width = wallGradientCanvas.height = 2;
+  const wallGradientTex = new THREE.CanvasTexture(wallGradientCanvas);
+  wallGradientTex.colorSpace = THREE.SRGBColorSpace;
+  let wallGradientKey = '';
+  function syncWallGradient(spec: { type: string; c1: string; c2: string; gradient?: any }) {
+    if (spec.type === 'solid') return;
+    const sceneState = useSceneStore.getState();
+    const phase = ((sceneState.frame / Math.max(1, sceneState.duration * sceneState.fps)) % 1 + 1) % 1;
+    const gradient = gradientFromFill(spec);
+    const [rw, rh] = advancedRasterSize(sceneState.width, sceneState.height, gradientRasterMaxEdge(gradient));
+    const key = `${rw}x${rh}|${gradientSignature(gradient, phase)}`;
+    if (key === wallGradientKey) return;
+    wallGradientKey = key;
+    paintGradientCanvas(wallGradientCanvas, gradient, rw, rh, phase);
+    wallGradientTex.needsUpdate = true;
+  }
+
   const wallMat = new THREE.MeshToonMaterial({ color: 0xffffff, map: paintGrey, normalMap: paintNormal });
   wallMat.gradientMap = makeGradient(3);
   wallMat.onBeforeCompile = (shader) => {
@@ -111,6 +138,8 @@ vec4 stochNormalW(sampler2D tex, vec2 uv){
     shader.uniforms.uC2 = { value: new THREE.Color(0, 0, 0) };
     shader.uniforms.uAmount = { value: 0 };
     shader.uniforms.uScale = { value: 3 };
+    shader.uniforms.uGradientTex = { value: wallGradientTex };
+    shader.uniforms.uUseGradientTex = { value: 0 };
     shader.vertexShader = 'varying vec2 vWallUv;\n' + shader.vertexShader.replace(
       '#include <begin_vertex>', '#include <begin_vertex>\n vWallUv = uv;');
     shader.fragmentShader = PAINT_GLSL + shader.fragmentShader;
@@ -121,6 +150,7 @@ vec4 stochNormalW(sampler2D tex, vec2 uv){
        {
          float t = (uType==2) ? clamp(length(vWallUv-vec2(0.5))*1.6,0.0,1.0) : vWallUv.y;
          vec3 grad = (uType==0) ? uC1 : mix(uC1, uC2, t);
+         if (uUseGradientTex > 0.5) grad = texture2D(uGradientTex, vWallUv).rgb;
          diffuseColor.rgb = mix(grad, mix(uC1, uC2, stochGrey(map, vWallUv*uScale)), uAmount);
        }
        #endif`);
@@ -262,11 +292,9 @@ vec4 stochNormalW(sampler2D tex, vec2 uv){
   }
 
   const _v = new THREE.Vector3();
-  const _c1 = new THREE.Color();
-  const _c2 = new THREE.Color();
   const _co = new THREE.Color();
   // Bake a fill (solid / linear-Y / radial) into a mesh's vertex colours.
-  function applyFill(mesh: THREE.Mesh, spec: { type: string; c1: string; c2: string }) {
+  function applyFill(mesh: THREE.Mesh, spec: { type: string; c1: string; c2: string; gradient?: any }, phase = 0) {
     const mat = mesh.material as THREE.MeshToonMaterial;
     if (spec.type === 'solid') {
       if (mat.vertexColors) { mat.vertexColors = false; mat.needsUpdate = true; }
@@ -281,15 +309,16 @@ vec4 stochNormalW(sampler2D tex, vec2 uv){
     const n = pos.count;
     let colAttr = geo.getAttribute('color') as THREE.BufferAttribute | undefined;
     if (!colAttr || colAttr.count !== n) { colAttr = new THREE.BufferAttribute(new Float32Array(n * 3), 3); geo.setAttribute('color', colAttr); }
-    _c1.set(spec.c1).convertSRGBToLinear();
-    _c2.set(spec.c2).convertSRGBToLinear();
+    const gradient = gradientFromFill(spec);
+    const spanX = Math.max(1e-4, gd.box.max.x - gd.box.min.x);
     const spanY = Math.max(1e-4, gd.box.max.y - gd.box.min.y);
+    const uv = geo.getAttribute('uv') as THREE.BufferAttribute | undefined;
     for (let i = 0; i < n; i++) {
       _v.fromBufferAttribute(pos, i).applyMatrix4(m2m);
-      const t = spec.type === 'radial'
-        ? Math.min(1, _v.distanceTo(gd.center) / gd.radius)
-        : Math.min(1, Math.max(0, (_v.y - gd.box.min.y) / spanY));
-      _co.copy(_c1).lerp(_c2, t);
+      const gx = gradient.mapping3d === 'uv' && uv ? uv.getX(i) : (_v.x - gd.box.min.x) / spanX;
+      const gy = gradient.mapping3d === 'uv' && uv ? 1 - uv.getY(i) : (_v.y - gd.box.min.y) / spanY;
+      const sampled = sampleGradientPoint(gradient, gx, gy, phase);
+      _co.setRGB(sampled[0] / 255, sampled[1] / 255, sampled[2] / 255).convertSRGBToLinear();
       colAttr.setXYZ(i, _co.r, _co.g, _co.b);
     }
     colAttr.needsUpdate = true;
@@ -471,6 +500,8 @@ vec4 stochNormal(sampler2D tex, vec2 uv){
     const op = Math.max(0, Math.min(1, Number(p.opacity ?? 100) / 100));
     tmpColor.set(String(p.color ?? '#e9e4d6'));
     const partFills = opts.getPartFills?.() ?? {};
+    const sceneStateForGradient = useSceneStore.getState();
+    const gradientPhase = ((sceneStateForGradient.frame / Math.max(1, sceneStateForGradient.duration * sceneStateForGradient.fps)) % 1 + 1) % 1;
     const selected = opts.getSelectedPart?.() ?? null;
     const emissiveHex = String(p.emissive ?? '#000000');
     // paint strokes (brush normal map)
@@ -490,8 +521,9 @@ vec4 stochNormal(sampler2D tex, vec2 uv){
 
       // per-part fill (solid / gradient → vertex colours) or model/uniform colour
       if (fill) {
-        const hash = `${fill.type}|${fill.c1}|${fill.c2}`;
-        if (m.userData.fillHash !== hash) { applyFill(mesh, fill); m.userData.fillHash = hash; }
+        const gradient = gradientFromFill(fill);
+        const hash = `${fill.type}|${gradientSignature(gradient, gradientPhase)}`;
+        if (m.userData.fillHash !== hash) { applyFill(mesh, fill, gradientPhase); m.userData.fillHash = hash; }
       } else {
         if (m.userData.fillHash !== undefined) {   // fill removed → restore
           if (m.vertexColors) { m.vertexColors = false; m.needsUpdate = true; }
@@ -580,9 +612,11 @@ vec4 stochNormal(sampler2D tex, vec2 uv){
     const wsh = wallMat.userData.shader as any;
     const bf = opts.getBgFill?.();
     if (wsh && bf) {
+      syncWallGradient(bf);
       wsh.uniforms.uType.value = bf.type === 'linear' ? 1 : bf.type === 'radial' ? 2 : 0;
       wsh.uniforms.uC1.value.set(bf.c1).convertSRGBToLinear();
       wsh.uniforms.uC2.value.set(bf.c2).convertSRGBToLinear();
+      wsh.uniforms.uUseGradientTex.value = bf.type === 'solid' ? 0 : 1;
       const bt = opts.getBgTex?.();
       if (bt) {
         const a = Math.max(0, Math.min(1, bt.amount / 100));
@@ -673,6 +707,7 @@ vec4 stochNormal(sampler2D tex, vec2 uv){
     paintGrey.dispose();
     paintAlpha.dispose();
     wallMat.dispose();
+    wallGradientTex.dispose();
     (wallMat.gradientMap as THREE.Texture | null)?.dispose();
     wall.geometry.dispose();
     for (const m of materials) m.dispose();

--- a/three3d/mockup.ts
+++ b/three3d/mockup.ts
@@ -12,6 +12,14 @@ import { use3DStore } from '../store/use3DStore';
 import { useSceneStore } from '../store/useSceneStore';
 import { apply3DAnimation } from './animations';
 import { createCardVideo, seekVideoToTime } from '@/lib/videoTexture';
+import {
+  advancedRasterSize,
+  gradientFromFill,
+  gradientRasterMaxEdge,
+  gradientSignature,
+  paintGradientCanvas,
+  sampleGradientPoint,
+} from '@/lib/gradient';
 
 // ── Device Mockup 3D effect ─────────────────────────────────────────────────
 // Realistic PBR render — the GLB's own materials (colour, metalness, roughness,
@@ -78,35 +86,31 @@ export function initMockup(
   //
   // Mirrors the CSS in ThreeStage3D exactly: `linear-gradient(to top, c1, c2)`
   // puts c1 at the BOTTOM, and the radial ends at 130% of the box.
-  const BG_RES = 256;
   const bgCanvas = document.createElement('canvas');
-  bgCanvas.width = bgCanvas.height = BG_RES;
-  const bgCtx = bgCanvas.getContext('2d')!;
+  bgCanvas.width = bgCanvas.height = 2;
   const bgTex = new THREE.CanvasTexture(bgCanvas);
   bgTex.colorSpace = THREE.SRGBColorSpace;
   scene.background = bgTex;
   let bgKey = '';
-  function paintBackground(spec: { type: string; c1: string; c2: string }) {
-    const key = `${spec.type}|${spec.c1}|${spec.c2}`;
+  function paintBackground(spec: { type: string; c1: string; c2: string; gradient?: any }) {
+    const sceneState = useSceneStore.getState();
+    const phase = ((sceneState.frame / Math.max(1, sceneState.duration * sceneState.fps)) % 1 + 1) % 1;
+    const gradient = gradientFromFill(spec);
+    const [rw, rh] = advancedRasterSize(sceneState.width, sceneState.height, gradientRasterMaxEdge(gradient));
+    const key = spec.type === 'solid'
+      ? `solid|${spec.c1}`
+      : `${rw}x${rh}|${gradientSignature(gradient, phase)}`;
     if (key === bgKey) return;
     bgKey = key;
-    const S = BG_RES;
-    if (spec.type === 'linear') {
-      // CanvasTexture keeps flipY, so canvas row 0 lands at the top of frame —
-      // c2 goes at y=0 and c1 at the bottom, matching `to top`.
-      const g = bgCtx.createLinearGradient(0, 0, 0, S);
-      g.addColorStop(0, spec.c2);
-      g.addColorStop(1, spec.c1);
-      bgCtx.fillStyle = g;
-    } else if (spec.type === 'radial') {
-      const g = bgCtx.createRadialGradient(S / 2, S / 2, 0, S / 2, S / 2, S * 0.65);
-      g.addColorStop(0, spec.c1);
-      g.addColorStop(1, spec.c2);
-      bgCtx.fillStyle = g;
+    if (spec.type === 'solid') {
+      if (bgCanvas.width !== 2) bgCanvas.width = 2;
+      if (bgCanvas.height !== 2) bgCanvas.height = 2;
+      const ctx = bgCanvas.getContext('2d')!;
+      ctx.fillStyle = spec.c1;
+      ctx.fillRect(0, 0, 2, 2);
     } else {
-      bgCtx.fillStyle = spec.c1;
+      paintGradientCanvas(bgCanvas, gradient, rw, rh, phase);
     }
-    bgCtx.fillRect(0, 0, S, S);
     bgTex.needsUpdate = true;
   }
   paintBackground(opts.getBgFill?.() ?? { type: 'linear', c1: '#fbfbfc', c2: '#e6e8eb' });
@@ -299,10 +303,8 @@ export function initMockup(
   }
 
   const _v = new THREE.Vector3();
-  const _c1 = new THREE.Color();
-  const _c2 = new THREE.Color();
   const _co = new THREE.Color();
-  function applyFill(mesh: THREE.Mesh, spec: { type: string; c1: string; c2: string }) {
+  function applyFill(mesh: THREE.Mesh, spec: { type: string; c1: string; c2: string; gradient?: any }, phase = 0) {
     const mat = mesh.material as any;
     if (spec.type === 'solid') {
       if (mat.vertexColors) { mat.vertexColors = false; mat.needsUpdate = true; }
@@ -317,15 +319,16 @@ export function initMockup(
     const n = pos.count;
     let colAttr = geo.getAttribute('color') as THREE.BufferAttribute | undefined;
     if (!colAttr || colAttr.count !== n) { colAttr = new THREE.BufferAttribute(new Float32Array(n * 3), 3); geo.setAttribute('color', colAttr); }
-    _c1.set(spec.c1).convertSRGBToLinear();
-    _c2.set(spec.c2).convertSRGBToLinear();
+    const gradient = gradientFromFill(spec);
+    const spanX = Math.max(1e-4, gd.box.max.x - gd.box.min.x);
     const spanY = Math.max(1e-4, gd.box.max.y - gd.box.min.y);
+    const uv = geo.getAttribute('uv') as THREE.BufferAttribute | undefined;
     for (let i = 0; i < n; i++) {
       _v.fromBufferAttribute(pos, i).applyMatrix4(m2m);
-      const t = spec.type === 'radial'
-        ? Math.min(1, _v.distanceTo(gd.center) / gd.radius)
-        : Math.min(1, Math.max(0, (_v.y - gd.box.min.y) / spanY));
-      _co.copy(_c1).lerp(_c2, t);
+      const gx = gradient.mapping3d === 'uv' && uv ? uv.getX(i) : (_v.x - gd.box.min.x) / spanX;
+      const gy = gradient.mapping3d === 'uv' && uv ? 1 - uv.getY(i) : (_v.y - gd.box.min.y) / spanY;
+      const sampled = sampleGradientPoint(gradient, gx, gy, phase);
+      _co.setRGB(sampled[0] / 255, sampled[1] / 255, sampled[2] / 255).convertSRGBToLinear();
       colAttr.setXYZ(i, _co.r, _co.g, _co.b);
     }
     colAttr.needsUpdate = true;
@@ -960,6 +963,7 @@ export function initMockup(
     const op = Math.max(0, Math.min(1, Number(p.opacity ?? 100) / 100));
     tmpColor.set(String(p.color ?? '#d8d8dc'));
     const partFills = opts.getPartFills?.() ?? {};
+    const gradientPhase = ((useSceneStore.getState().frame / Math.max(1, useSceneStore.getState().duration * useSceneStore.getState().fps)) % 1 + 1) % 1;
     const selected = opts.getSelectedPart?.() ?? null;
     const emissiveHex = String(p.emissive ?? '#000000');
     const emissiveIntensity = Number(p.emissiveIntensity ?? 1);
@@ -986,8 +990,9 @@ export function initMockup(
       const preservePhoneDetail = DEV?.slot === 'phone' && !m.userData.isEnclosure && !partFill;
 
       if (partFill) {
-        const hash = `${partFill.type}|${partFill.c1}|${partFill.c2}`;
-        if (m.userData.fillHash !== hash) { applyFill(mesh, partFill); m.userData.fillHash = hash; }
+        const gradient = gradientFromFill(partFill);
+        const hash = `${partFill.type}|${gradientSignature(gradient, gradientPhase)}`;
+        if (m.userData.fillHash !== hash) { applyFill(mesh, partFill, gradientPhase); m.userData.fillHash = hash; }
       } else {
         if (m.userData.fillHash !== undefined) {
           if (m.vertexColors) { m.vertexColors = false; m.needsUpdate = true; }


### PR DESCRIPTION
## Summary

This PR rebuilds the gradient system and unifies its behavior across the 2D Canvas, 3D, Mockup, and Cartoon renderers.

### Changes

- Introduces `GradientSpec` v2 as the shared gradient contract.
- Adds Basic and Advanced modes.
- Supports up to 8 color stops.
- Adds Linear, Radial, Conic, Mesh, Warped Field, and Twin Radial shapes.
- Adds Warp, Flow, Scale, Detail, and Contrast controls.
- Keeps gradients static by default with `Flow = 0`.
- Integrates gradients into 2D backgrounds, 3D backgrounds, and model materials.
- Fixes gradients not being applied to the background.
- Preserves compatibility with legacy projects.
- Optimizes procedural and animated gradients to prevent UI freezes.
- Uses the same editor across Canvas, 3D, and Mockup.
- Aligns the editor with `tokens.css`.
- Replaces circular handles with square color stops.
- Supports both light and dark themes.
- Adds technical documentation and regression tests.

## Validation

- `npm test`
- `npm run build`
- Visual and interactive validation in 2D, 3D, and Mockup.
- Tested adding, selecting, moving, and removing color stops.
- Tested Basic and Advanced modes.
- Tested static and animated gradients.

## Backward Compatibility

Legacy projects containing two-color gradients are automatically migrated to the new gradient format.