### PR TITLE
fix(runway): restore reference cadence and geometry

### DIFF
--- a/scripts/verify-reference.cjs
+++ b/scripts/verify-reference.cjs
@@ -32,6 +32,7 @@ Module._resolveFilename = function (request, parent, isMain, options) {
 };
 
 const { templateList, defaultsFor, easingFor, layerCountFor } = require('../templates');
+const { carouselReferenceDurations } = require('../templates/carousel');
 const { resolveEasing } = require('../lib/easing');
 const { loopCycles } = require('../lib/motion');
 const { solveLattice } = require('../templates/lattice');
@@ -101,9 +102,9 @@ function loopDrift(template, values, ctx) {
 //  cards sit at base size and neighbours are unambiguous:
 //    planeSize 730, gap 80  -> card 548x730, pitch 810
 //    planeSize 850, gap 500 -> card 638x850, pitch 1350
-//  which gives card height = planeSize (3:4) and pitch = planeSize + gap.
-//  This family's `gap` control is a centre distance AT BASE SIZE, so the 0.75
-//  divides out: cardSize = 0.75*planeSize, gap = BASE*(1 + gapRef/planeSize).
+//  `planeSize` is the extent ALONG THE TRAVEL AXIS. In this project cardSize is
+//  the long edge, so vertical converts by 0.75 while horizontal keeps the raw
+//  width. Both axes still land on a 0.75*(planeSize+gap) centre pitch.
 // ============================================================
 const RUNWAY = {
   'Runway 06': [600, 40], 'Runway 07': [546, 40], 'Runway 08': [568, 235], 'Runway 09': [440, 190],
@@ -117,8 +118,13 @@ for (const [name, [planeSize, gapRef]] of Object.entries(RUNWAY)) {
   if (!t) continue;
   const v = defaultsFor(t.meta.id);
   // cardSize and gap are integer sliders, so two roundings can compound.
-  near(v.cardSize, REF_SCALE * planeSize, 1, name, 'card long edge');
+  const horizontal = v.direction === 'left' || v.direction === 'right';
+  near(v.cardSize, horizontal ? planeSize : REF_SCALE * planeSize, 1, name, 'card long edge');
   near(v.gap * (v.cardSize / SPRITE_BASE), REF_SCALE * (planeSize + gapRef), 2, name, 'centre-to-centre pitch');
+  const authoredDuration = carouselReferenceDurations[t.meta.id];
+  check(Number.isFinite(authoredDuration) && authoredDuration > 0, name, 'missing authored Runway duration');
+  // Every reconstructed clip advances the complete six-card set exactly once.
+  near(v.speed, 6 / authoredDuration, 0.02, name, 'slot cadence');
   const ctx = makeCtx(t.meta.id, { cardAspect: 3 / 4 });
   check(loopDrift(t, v, ctx) < 1e-6, name, 'does not return to frame 0 at the loop point');
 }

--- a/store/useSceneStore.ts
+++ b/store/useSceneStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { defaultsFor, easingFor, templates } from '@/templates';
+import { carouselReferenceDurations } from '@/templates/carousel';
 import type { EasingSpec } from '@/lib/easing';
 import type { CropFocus } from '@/lib/crop';
 import { DEMO_ASSETS, demoSourceForSlot, isDemoAssetSource } from '@/lib/demoAssets';
@@ -466,10 +467,12 @@ export const useSceneStore = create<SceneState>((set, get) => ({
       };
       const ref3dDuration = REF_3D_DURATION[id];
       const isRef3dPreset = ref3dDuration !== undefined;
+      const runwayRefDuration = carouselReferenceDurations[id];
+      const isRunwayRefPreset = runwayRefDuration !== undefined;
       const referenceAspect = (isSpinnerPreset || isStickerPreset || isPosterPreset || isArcPreset) ? '4:5'
         : isOrbit3dPreset ? (ORBIT_3D_SQUARE.has(id) ? '1:1' : '4:5')
         : isWheelRefPreset ? '1:1'
-        : isRef2dPreset || isGlobeRefPreset || isRef3dPreset ? '3:4'
+        : isRunwayRefPreset || isRef2dPreset || isGlobeRefPreset || isRef3dPreset ? '3:4'
         : null;
       const referenceCanvas = referenceAspect ? dimsFor(referenceAspect) : null;
       // A blank scene has no track to patch, so the first pick BECOMES Layer 1.
@@ -496,6 +499,7 @@ export const useSceneStore = create<SceneState>((set, get) => ({
         duration: isSpinnerPreset ? spinnerDuration : isStickerPreset ? stickerDuration : isPosterPreset ? posterDuration
           : isPulseRefPreset ? pulseDuration : isFlipPreset ? 12 : isOrbit3dPreset ? orbitDuration
           : isArcPreset ? arcDuration : isWheelRefPreset ? wheelRefDuration
+          : isRunwayRefPreset ? runwayRefDuration
           : isRef2dPreset ? ref2dDuration : isGlobeRefPreset ? globeRefDuration
           : isRef3dPreset ? ref3dDuration : s.duration,
         ...((isSpinnerPreset || isStickerPreset || isPosterPreset) && !s.background.userSet ? {

--- a/templates/carousel.ts
+++ b/templates/carousel.ts
@@ -1,5 +1,5 @@
-import type { Template } from '@/lib/types';
-import { clamp, loopCycles, smooth } from '@/lib/motion';
+import type { Template, LayerTransform, TransformCtx } from '@/lib/types';
+import { clamp, frac, loopCycles, smooth } from '@/lib/motion';
 import { cardPath } from '@/lib/cardPath';
 import type { EasingSpec } from '@/lib/easing';
 import { variant } from './variant';
@@ -8,151 +8,298 @@ import { variant } from './variant';
 // `cardSize` reads directly in on-screen pixels.
 const BASE = 340;
 
+// ============================================================
+//  Runway — the reference's Carousel, transcribed from its own scene
+//
+//  Everything below stated as "the reference does X" was read out of its
+//  renderer rather than inferred from screenshots: its bundle ships the whole
+//  carousel branch in the clear, and the preset numbers come from its own
+//  `paramsPerModeBaseline`.
+//
+//  Three things make this family what it is, and this port used to have only
+//  the first: a strip that STEPS one slot at a time (moving for part of the
+//  beat and resting for the rest), a per-card STAGGER that turns that step into
+//  a wave running down the strip, and a size that either bulges at the middle
+//  (scaleFocus center) or ramps across the whole strip (start / end).
+// ============================================================
+
+/** Card width and height in px, honouring whichever edge the renderer normalized. */
+function cardBox(cardSize: number, aspect: number) {
+  return aspect >= 1
+    ? { w: cardSize, h: cardSize / aspect }
+    : { w: cardSize * aspect, h: cardSize };
+}
+
+interface RunwayPose {
+  x: number;
+  y: number;
+  scale: number;
+  rotation: number;
+  alpha: number;
+  skew: number;
+  axisPos: number;    // signed distance from the middle along the travel axis, px
+  horiz: boolean;
+  depth: number;
+}
+
+function runwayPose(
+  frame: number, index: number, count: number,
+  v: Record<string, any>, ctx: TransformCtx,
+): RunwayPose {
+  const horiz = v.direction === 'left' || v.direction === 'right';
+  // The reference's `up` and `left` are its two forward directions; both run the
+  // strip toward the negative side of their axis.
+  const dir = (v.direction === 'left' || v.direction === 'up') ? 1 : -1;
+
+  const sizeFactor = v.cardSize / BASE;
+  const pitch = v.gap * sizeFactor;                               // centre-to-centre px
+  const aspect = ctx.cardAspect ?? 3 / 4;
+  const box = cardBox(v.cardSize, aspect);
+  const axisExtent = horiz ? box.w : box.h;                       // the reference's `planeSize`
+
+  // ---- Stepped, staggered phase -------------------------------------------
+  // The reference advances a card by exactly one slot per beat: it eases across
+  // the first `duration` seconds of the beat and then stands still for the rest,
+  // and it shifts each card's clock by `stagger`, so the step runs down the
+  // strip as a wave instead of a block. `loopCycles` pins the beat to a whole
+  // number of slots per clip, which is what keeps the wave seamless at the loop.
+  //
+  // Two periods, and conflating them is what made this port run a quarter fast.
+  // A SLOT advance — the strip moving on by one place — takes `T`. A CARD step
+  // takes `T - stagger`, because each card starts one stagger after the card
+  // ahead of it and the strip only settles once the last one lands. `T` is what
+  // the eye reads as the beat; the card period is what the maths runs on.
+  const stagger = Math.max(0, v.stagger ?? 0);
+  // A staggered strip only repeats once the WHOLE SET has gone by: the wave is
+  // keyed to a card's place along the strip, so a single slot advance leaves
+  // every clock offset by one stagger. Unstaggered, one slot is enough. Getting
+  // this wrong does not look like a phase error, it looks like a jump cut at the
+  // loop point.
+  const steps = loopCycles(v.speed, ctx.duration, count);
+  const laps = Math.abs(steps);
+  const slotSeconds = laps > 0 ? ctx.duration / laps : 0;               // T
+  const cardSeconds = Math.max(1e-4, slotSeconds - stagger);
+  // `laps` is quantized to a complete card set. Advancing directly through it
+  // makes frame totalFrames identical to frame 0 for every individual asset;
+  // the recovered WIP divided by cardSeconds here and ended one slot late.
+  const base = laps > 0 ? frac(frame / ctx.totalFrames) * laps : 0;
+  const staggerPhase = stagger / cardSeconds;
+
+  // The reference lays the strip out as repeating COPIES and keys the stagger to
+  // a card's place along that unrolled strip, not to its slot number — which is
+  // the whole point, since the wave has to keep running as cards recycle. This
+  // port draws each card once and wraps it instead, so it has to pick the copy
+  // the card is currently standing in and stagger by THAT. Keying it to `index`
+  // freezes the wave to the slot list and every staggered preset drifts.
+  const march = dir * base;
+  const slot = index + count * Math.round((march - index) / Math.max(1, count));
+  // ...and the reference centres the strip by an integer number of slots, which
+  // shifts which copy sits in the middle and therefore where the wave is.
+  const visible = pitch > 0 ? clamp(Math.round((horiz ? ctx.width : ctx.height) / pitch), 1, count) : count;
+  const middle = Math.floor(visible / 2);
+  const lag = dir > 0 ? slot + middle : (count - 1 - slot + middle);
+
+  const pc = base - lag * staggerPhase;
+  const move = 1 - clamp((v.hold ?? 0) / 100, 0, 0.95);
+  // Move first, then rest — the reference's own order. f(n) = n at every integer
+  // either way, so the loop still closes.
+  const advance = Math.floor(pc) + (move <= 0 ? 1 : ctx.ease(clamp(frac(pc) / move, 0, 1)));
+
+  // gap:1 → the path carries the raw signed slot offset, folded into a window
+  // centred on the middle of the frame.
+  const path = cardPath({ kind: 'line', index: slot, count, phase: dir * advance, gap: 1, wrap: true });
+  const offset = path.x;
+  const raw = offset * pitch;                                     // px, before the focus push
+
+  // ---- Featuredness --------------------------------------------------------
+  // Two different shapes, and the reference picks between them on `scaleFocus`.
+  // `center` is a BULGE: a card is only bigger while it is within one pitch of
+  // the middle. `start` / `end` is a RAMP that runs monotonically across the
+  // whole strip, so the far end comes out SMALLER than base rather than equal
+  // to it — which is why porting it as a shifted bulge read wrong.
+  const big = Math.max(1, v.bigScale / 100);
+  const featured = v.bigScale > 100;
+  const ramped = featured && v.scaleFocus !== 'center';
+  const towards = v.scaleFocus === 'start' ? -1 : 1;
+  const reach = pitch * Math.max(1, (count - 1) / 2);
+  let grow: number;
+  if (ramped) {
+    grow = Math.max(0.1, 1 + (big - 1) * clamp(towards * raw / reach, -1, 1));
+  } else {
+    const k = featured && pitch > 0 ? Math.max(0, 1 - Math.abs(raw) / pitch) : 0;
+    grow = 1 + (big - 1) * k;
+  }
+
+  // A ramp makes one end of the strip bigger than the other, so an even pitch
+  // would let the big end collide. The reference opens the spacing out with a
+  // quadratic push away from the middle, capped so it can never fold the strip.
+  const push = ramped && pitch > 0
+    ? clamp(axisExtent * (big - 1) * towards / pitch, -0.9, 0.9)
+    : 0;
+  const spread = (q: number) => {
+    const a = Math.abs(q);
+    return a <= reach ? (q * q) / (2 * reach) : a - reach / 2;
+  };
+  const axisPos = raw + push * spread(raw);
+
+  // ---- Tilt ----------------------------------------------------------------
+  // The reference's tilt is a ROLL IN THE PLANE — its scene calls ctx.rotate —
+  // and it scales with how far across the FRAME the card has travelled, not with
+  // its slot index. Its own slider is 0-100 over 60 degrees; this one is in
+  // degrees, so the ports convert on the way in.
+  const halfAxis = Math.max(1, (horiz ? ctx.width : ctx.height) / 2);
+  const across = clamp(axisPos / halfAxis, -1, 1);
+  const lean = (v.tiltAmount * Math.PI) / 180;
+  const rotation =
+    v.tiltStyle === 'fan' ? lean * across :
+    v.tiltStyle === 'uniform' ? lean * Math.abs(across) :
+    v.tiltStyle === 'alternate' ? lean * across * (index % 2 === 0 ? 1 : -1) : 0;
+
+  // ---- Perspective (ours, not the reference's — every port runs it at 0) ----
+  const persp = v.perspective / 100;
+  const scale = sizeFactor * grow * (1 - (1 - path.depthNorm) * 0.35 * persp);
+  const skew = -Math.sign(offset) * (1 - path.depthNorm) * 0.18 * persp;
+
+  // ---- Fade ----------------------------------------------------------------
+  // Distance is measured against HALF THE FRAME, not against the slot count, and
+  // it is shaped by the scene curve — both straight out of the reference. It
+  // stays on alpha rather than `dim`: the reference paints the background colour
+  // under the card and blends the image into that, which for a card overlapping
+  // nothing is the same picture alpha gives, while `dim` can only go to black.
+  let alpha = v.fade > 0 ? Math.max(0, 1 - ctx.ease(Math.abs(across)) * (v.fade / 100)) : 1;
+
+  // A wrapped card teleports from one end of the strip to the other. Make that
+  // hand-off transparent even when a small gap keeps the final slot inside the
+  // canvas; otherwise the recycle reads as a pop. (The reference draws repeating
+  // copies instead, so its strip has no seam to hide; in every ported preset the
+  // seam sits well outside the frame and this costs nothing.)
+  if (count > 1) alpha *= smooth(clamp((count / 2 - Math.abs(offset)) / 0.7, 0, 1));
+
+  // Outer fade: as the card starts leaving the frame, fade it out — fully
+  // transparent by the time it has fully exited. Ours; the reference simply
+  // culls at the edge, so every port runs this at 0.
+  const cardHalf = (horiz ? box.w : box.h) * grow / 2;
+  const leaving = Math.abs(axisPos + (horiz ? v.offset.x : v.offset.y)) - (halfAxis - cardHalf);
+  if (leaving > 0 && v.outerFade > 0) {
+    const t = Math.min(1, leaving / Math.max(1, cardHalf * 2));
+    alpha *= 1 - (v.outerFade / 100) * (t * t * (3 - 2 * t));
+  }
+
+  return {
+    x: (horiz ? axisPos : 0) + v.offset.x,
+    y: (horiz ? 0 : axisPos) + v.offset.y,
+    scale, rotation, alpha, skew, axisPos, horiz,
+    // Nearest the middle draws on top, which is what lets a featured card
+    // overlap its neighbours instead of being buried by them.
+    depth: 1 - Math.min(1, Math.abs(axisPos) / halfAxis),
+  };
+}
+
+/**
+ * The reference's `solo`: instead of a strip it keeps only the card currently
+ * closest to the middle, so one image slides through the frame at a time. That
+ * is a different read from a strip rather than a variation on one, and two of
+ * its eighteen presets are built on it.
+ */
+function nearestSlot(
+  frame: number, count: number, v: Record<string, any>, ctx: TransformCtx,
+): number {
+  let best = 0;
+  let bestDist = Infinity;
+  for (let j = 0; j < count; j++) {
+    const d = Math.abs(runwayPose(frame, j, count, v, ctx).axisPos);
+    if (d < bestDist) { bestDist = d; best = j; }
+  }
+  return best;
+}
+
 export const carousel: Template = {
-  meta: { id: 'carousel', name: 'Runway', group: 'Runway', engine: 'webgl', defaultEasing: { id: 'glide' } },
+  meta: {
+    id: 'carousel', name: 'Runway', group: 'Runway',
+    // Deliberately NOT `engine: 'webgl'`. This family spent a while on the 3D
+    // path, which cost every card 30% of its black (a lit material carrying an
+    // emissive term) in exchange for a depth it never uses: its tilt is a roll
+    // IN the plane, which the sprite path does natively, and all eighteen ports
+    // run Perspective at 0. Flat art, colour 1:1.
+    defaultEasing: { id: 'glide' },
+  },
 
   controls: [
     // Four-way direction (as in the reference tool): left/right run the strip
     // horizontally, up/down run it vertically. Axis + travel sign in one control.
     { key: 'direction',    label: 'Direction',     type: 'pills', options: ['left','right','up','down'], default: 'left' },
+    { key: 'display',      label: 'Show',          type: 'pills', options: ['strip','single'], default: 'strip',
+      description: 'single keeps only the card nearest the middle — one image slides through the frame at a time.' },
     { key: 'count',        label: 'Count',         type: 'slider', min: 1, max: 12, step: 1,   default: 6 },
     { key: 'cardSize',     label: 'Plane Size',    type: 'slider', min: 50, max: 800, step: 1, default: 340 },
     { key: 'cornerRadius', label: 'Corner Radius', type: 'slider', min: 0, max: 100, step: 1,  default: 12 },
     { key: 'gap',          label: 'Gap',           type: 'slider', min: 0, max: 600, step: 1,  default: 360 }, // px between card centres (at base size)
     { key: 'bigScale',     label: 'Big Scale',     type: 'slider', min: 100, max: 200, step: 1, default: 120 }, // featured card size %
-    { key: 'scaleFocus',   label: 'Scale Focus',   type: 'pills', options: ['center','start','end'], default: 'center' }, // where the featured card sits
+    { key: 'scaleFocus',   label: 'Scale Focus',   type: 'pills', options: ['center','start','end'], default: 'center',
+      description: 'center bulges the middle card; start and end ramp the size across the whole strip.' },
     { key: 'perspective',  label: 'Perspective',   type: 'slider', min: 0, max: 200, step: 1,  default: 0 },
     { key: 'tiltStyle',    label: 'Tilt Style',    type: 'pills', options: ['off','fan','uniform','alternate'], default: 'off' },
-    { key: 'tiltAmount',   label: 'Tilt Amount',   type: 'slider', min: 0, max: 30, step: 1,   default: 8, section: 'Depth', unit: '°', visibleWhen: { key: 'tiltStyle', not: 'off' }, description: 'Tilts cards in real 3D while their runway path stays unchanged.' },
+    { key: 'tiltAmount',   label: 'Tilt Amount',   type: 'slider', min: -60, max: 60, step: 1,  default: 8, section: 'Depth', unit: '°', visibleWhen: { key: 'tiltStyle', not: 'off' }, description: 'Rolls the card in the plane, by how far across the frame it has travelled. Signed: the sign is which way it leans.' },
     { key: 'offset',       label: 'Offset',        type: 'xypad',                              default: { x: 0, y: 0 } },
-    { key: 'fade',         label: 'Fade',          type: 'slider', min: 0, max: 100, step: 1,  default: 0 },   // centre-distance fade %
+    { key: 'fade',         label: 'Fade',          type: 'slider', min: 0, max: 100, step: 1,  default: 0 },   // fade with distance from the middle %
     { key: 'outerFade',    label: 'Outer Fade',    type: 'slider', min: 0, max: 100, step: 1,  default: 100 }, // fade out while leaving the frame %
-    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 4, step: 0.1,  default: 0.6 }, // cards/sec
+    { key: 'speed',        label: 'Speed',         type: 'slider', min: 0, max: 4, step: 0.01, default: 0.6, precision: 2 }, // slots/sec
+    { key: 'stagger',      label: 'Stagger',       type: 'slider', min: 0, max: 0.5, step: 1 / 60, default: 0, unit: 's', precision: 2, section: 'Motion',
+      description: 'Delay between one slot starting its step and the next — turns the step into a wave down the strip.' },
+    { key: 'hold',         label: 'Hold',          type: 'slider', min: 0, max: 90, step: 1,   default: 0, unit: '%', section: 'Motion',
+      description: 'Share of each step spent standing still after arriving.' },
   ],
 
-  transform: (frame, index, count, v, ctx) => {
-    const horiz = v.direction === 'left' || v.direction === 'right';
-    const dir = (v.direction === 'left' || v.direction === 'up') ? 1 : -1;
-    const phase = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir); // ← Speed + Direction + Easing
-
-    // Cards recycle seamlessly (wrap). Featuredness peaks at centre.
-    const p = cardPath({ kind: 'line', index, count, phase, gap: 1, wrap: true });
-    const offset = p.x;                                          // gap:1 → x carries the raw signed offset
-    const sizeFactor = v.cardSize / BASE;
-
-    // pos = offset * Gap * (cardSize/BASE) → spacing grows with the card        ← Gap
-    const pos = offset * v.gap * sizeFactor;
-    const x = (horiz ? pos : 0) + v.offset.x;                    // ← Offset X
-    const y = (horiz ? 0 : pos) + v.offset.y;                    // ← Offset Y
-
-    // Scale Focus: shift the featuredness peak toward the entry (start) or
-    // exit (end) side of travel. dir=+1 means cards enter on the positive side.
-    const shift = Math.max(0, count / 2 - 1.5);
-    const focusOff =
-      v.scaleFocus === 'start' ? dir * shift :
-      v.scaleFocus === 'end'   ? -dir * shift : 0;
-    const featured = Math.max(0, 1 - Math.abs(offset - focusOff));
-
-    // Featured card grows toward Big Scale; others sit at 1.0                    ← Big Scale
-    let scale = sizeFactor * (1 + (v.bigScale / 100 - 1) * featured);            // ← Plane Size
-
-    // Tilt Style: fan = tilt ∝ signed centre distance; uniform = constant;
-    // alternate = ±tilt by card parity.                                          ← Tilt
-    const tiltRad = (v.tiltAmount * Math.PI) / 180;
-    // tanh gives the fan a continuous slope through the centre and a soft
-    // saturation toward the edges. The old clamp had visible velocity kinks
-    // when a card crossed ±3 slots.
-    const fan = Math.tanh(offset * 0.72);
-    const rotation =
-      v.tiltStyle === 'fan'       ? fan * tiltRad :
-      v.tiltStyle === 'uniform'   ? tiltRad :
-      v.tiltStyle === 'alternate' ? (index % 2 ? -tiltRad : tiltRad) : 0;
-
-    // Perspective: off-centre cards shrink and skew away from centre, along
-    // the travel axis (skewX for horizontal strips, skewY for vertical).       ← Perspective
-    const persp = v.perspective / 100;
-    scale *= 1 - (1 - p.depthNorm) * 0.35 * persp;
-    const skew = -Math.sign(offset) * (1 - p.depthNorm) * 0.18 * persp;
-
-    // Edge fade                                                                  ← Fade
-    let alpha = 1 - (v.fade / 100) * (1 - p.depthNorm);
-
-    // A wrapped card teleports from one end of the strip to the other. Make
-    // that hand-off fully transparent even when a small gap keeps the final
-    // slot inside the canvas; otherwise the recycle reads as a pop.
-    if (count > 1) {
-      const wrapFade = smooth(clamp((count / 2 - Math.abs(offset)) / 0.7, 0, 1));
-      alpha *= wrapFade;
+  transform: (frame, index, count, v, ctx): LayerTransform => {
+    const p = runwayPose(frame, index, count, v, ctx);
+    // In `single` the reference draws that one card plain: no fade, no roll.
+    if (v.display === 'single') {
+      const keep = nearestSlot(frame, count, v, ctx) === index;
+      return {
+        x: p.x, y: p.y, scale: p.scale, rotation: 0,
+        alpha: keep ? 1 : 0, skewX: 0, skewY: 0, depth: 1,
+      };
     }
-
-    // Outer fade: as the card starts leaving the frame, fade it out — fully     ← Outer Fade
-    // transparent by the time it has fully exited. Axis-aware.
-    const half = (horiz ? ctx.width : ctx.height) / 2;
-    const cardHalf = (v.cardSize * (scale / sizeFactor)) / 2;
-    const axisPos = horiz ? x : y;
-    const leaving = Math.abs(axisPos) - (half - cardHalf);       // >0 once the edge is crossed
-    if (leaving > 0) {
-      const t = Math.min(1, leaving / Math.max(1, cardHalf * 2)); // 1 = fully outside
-      alpha *= 1 - (v.outerFade / 100) * (t * t * (3 - 2 * t));   // smooth falloff
-    }
-
     return {
-      x,
-      y,
-      scale,
-      rotation,
-      alpha,
-      skewX: horiz ? skew : 0,
-      skewY: horiz ? 0 : skew,
-      depth: p.depthNorm + featured,                             // featured card always wins the draw order
+      x: p.x,
+      y: p.y,
+      scale: p.scale,
+      rotation: p.rotation,
+      alpha: p.alpha,
+      skewX: p.horiz ? p.skew : 0,
+      skewY: p.horiz ? 0 : p.skew,
+      depth: p.depth,
     };
-    // cornerRadius is applied where the sprite mask is built, not here.          ← Corner Radius
-  },
-  transform3d: (frame, index, count, v, ctx) => {
-    const flat = carousel.transform(frame, index, count, v, ctx);
-    const horiz = v.direction === 'left' || v.direction === 'right';
-    const dir = (v.direction === 'left' || v.direction === 'up') ? 1 : -1;
-    const phase = ctx.easedPhase((frame / ctx.totalFrames) * loopCycles(v.speed, ctx.duration, count) * dir);
-    const path = cardPath({ kind: 'line', index, count, phase, gap: 1, wrap: true });
-    const fan = Math.tanh(path.x * 0.72);
-    const signed = v.tiltStyle === 'fan' ? fan
-      : v.tiltStyle === 'alternate' ? (index % 2 ? -1 : 1)
-      : v.tiltStyle === 'uniform' ? 1 : 0;
-    const angle = signed * v.tiltAmount * Math.PI / 180;
-    const depth = -(1 - path.depthNorm) * (v.perspective / 100) * v.cardSize * 0.65;
-    return {
-      x: flat.x,
-      y: flat.y,
-      z: depth,
-      rotationX: horiz ? 0 : -angle,
-      rotationY: horiz ? angle : 0,
-      rotationZ: 0,
-      scale: flat.scale,
-      alpha: flat.alpha,
-    };
+    // cornerRadius is applied where the sprite mask is built, not here.
   },
 };
 
 // ============================================================
 //  Reference-catalogue presets (Carousel 01–18)
 //
-//  The reference ships nine looks, each as a vertical/horizontal pair. Its sizing
-//  was measured off two presets with `stagger: 0` and no centre scaling, so the
-//  cards sit at base size and neighbours are unambiguous:
+//  SIZING, verified by running the reference's own carousel scene against its
+//  own preset table and reading the card rects back out:
 //
-//    planeSize 730, gap 80  -> card 548x730, pitch 810
-//    planeSize 850, gap 500 -> card 638x850, pitch 1350
+//    `planeSize` is the card's extent ALONG THE TRAVEL AXIS, not its long edge.
+//      vertical    600 -> 450 x 600   (planeSize is the height)
+//      horizontal  546 -> 546 x 728   (planeSize is the WIDTH; the card is taller)
 //
-//  So a card is 3:4 with `height = planeSize`, and `pitch = planeSize + gap`.
-//  This family's `gap` is a centre distance AT BASE SIZE, so converting divides
-//  the 0.75 canvas factor straight out and leaves no measured constant behind:
+//  This project's `cardSize` is the LONG edge and its canvas is the reference's
+//  scaled by 0.75, so the two axes convert differently — which is why every
+//  horizontal preset here used to ship a quarter too small:
 //
-//    cardSize = 0.75 * planeSize
-//    gap      = BASE * (1 + gapRef / planeSize)
+//    vertical    cardSize = 0.75 * planeSize   gap = BASE        * (1 + gapRef/planeSize)
+//    horizontal  cardSize =        planeSize   gap = BASE * 0.75 * (1 + gapRef/planeSize)
 //
-//  Cross-check: Carousel 01 is planeSize 600 / gap 40, giving 340 * (1 + 40/600)
-//  = 363 — and Runway 01 already shipped with gap 360. The formula lands on a
-//  value that was arrived at independently, which is the best evidence it is right.
+//  Both land the same pitch, 0.75 * (planeSize + gapRef) — which is what the
+//  reference's own rects give: 600+40 comes out 640 apart, 546+40 comes out 586.
+//
+//  CADENCE. The reference's beat is NOT its `duration`; that is only the moving
+//  part. One slot advance takes `duration + count*stagger + delay`, and its clip
+//  is `(that + stagger) * cycles * count`, so the beat over a whole clip is
+//  clip/count. Twelve of the eighteen carry a stagger, and therefore a rest,
+//  that this port used to drop — which left them running a quarter too fast and
+//  as a rigid block instead of a wave.
 // ============================================================
 
 interface RefCarousel {
@@ -163,29 +310,58 @@ interface RefCarousel {
   /** Reference `centerScale`, applied only when its `scaleCenter` is on. */
   centerScale?: number;
   focus?: 'center' | 'start' | 'end';
+  /** Reference `tilt`, 0-100 over 60 degrees. */
   tilt?: number;
+  /** Reference `depthFade`, %. */
   fade?: number;
-  /** Seconds a card takes to advance, plus any hold — the reference's duration + delay. */
-  seconds: number;
+  /** Reference `duration` — the MOVING part of one slot advance, in seconds. */
+  move: number;
+  /** Reference `stagger`, seconds between one slot starting and the next. */
+  stagger?: number;
+  /** Reference `delay`, seconds of rest on top of the move. */
+  delay?: number;
+  /** Reference `solo`: one card in frame at a time instead of a strip. */
+  single?: boolean;
+}
+
+const REF_COUNT = 6;      // every one of the eighteen ships count 6
+const REF_SCALE = 0.75;   // the reference stages 1080x1440; this project 810x1080
+
+/** The clip length the reference computes for one of these presets, in seconds. */
+export function refCarouselSeconds(r: RefCarousel): number {
+  const stagger = r.stagger ?? 0;
+  const beat = r.move + REF_COUNT * stagger + (r.delay ?? 0);
+  return (beat + stagger) * REF_COUNT;
 }
 
 function refCarousel(r: RefCarousel): Record<string, any> {
   const vertical = (r.axis ?? 'vertical') === 'vertical';
+  const step = refCarouselSeconds(r) / REF_COUNT;      // seconds per SLOT advance
+  // ...and per CARD step, which is the one the reference eases across.
+  const card = r.move + REF_COUNT * (r.stagger ?? 0) + (r.delay ?? 0);
   return {
     // Reference `up`/`left` are its two forward directions on each axis.
     direction: vertical ? (r.reverse ? 'down' : 'up') : (r.reverse ? 'right' : 'left'),
-    cardSize: Math.round(0.75 * r.planeSize),
-    gap: Math.round(BASE * (1 + r.gap / r.planeSize)),
+    display: r.single ? 'single' : 'strip',
+    cardSize: Math.round(vertical ? REF_SCALE * r.planeSize : r.planeSize),
+    gap: Math.round(BASE * (vertical ? 1 : REF_SCALE) * (1 + r.gap / r.planeSize)),
     // `scaleCenter: off` in the reference keeps centerScale stored but inert, so
     // an absent centerScale here means a flat strip — no featured card.
     bigScale: Math.round((r.centerScale ?? 1) * 100),
     scaleFocus: r.focus ?? 'center',
     tiltStyle: r.tilt ? 'alternate' : 'off',
-    tiltAmount: Math.abs(r.tilt ?? 0),
+    // Its slider is 0-100 over 60 degrees; ours is in degrees, and SIGNED — its
+    // two tilted presets both author -25, and dropping the sign leans every card
+    // the wrong way, a 30 degree error where the roll is widest.
+    tiltAmount: Math.round((r.tilt ?? 0) * 0.6),
     fade: r.fade ?? 0,
+    // The reference culls a card at the frame edge rather than fading it out.
+    outerFade: 0,
     cornerRadius: 0,
     perspective: 0,
-    speed: Math.round((1 / r.seconds) * 100) / 100,
+    speed: Math.round((1 / step) * 100) / 100,
+    stagger: r.stagger ?? 0,
+    hold: Math.round((1 - r.move / step) * 100),
   };
 }
 
@@ -236,40 +412,69 @@ export const carouselVariants: Template[] = [
   }),
 ];
 
-export const carouselRefVariants: Template[] = [
-  // Flat strip, no featured card.
-  refPreset('carousel-r01', 'Runway 06', { planeSize: 600, gap: 40, seconds: 1.6 }, GLIDE),
-  refPreset('carousel-r02', 'Runway 07', { planeSize: 546, gap: 40, axis: 'horizontal', seconds: 1.6 }, GLIDE),
+/**
+ * The reference's own eighteen, keyed by the name they ship under here. Exported
+ * because scripts/verify-reference.cjs asserts the ports against these numbers
+ * and store/useSceneStore pins each preset's clip to the length the reference
+ * computes for it — three copies of the same table would only drift apart.
+ */
+export const REF_CAROUSEL: Record<string, RefCarousel> = {
+  // Flat strip, no featured card, stepping on a stagger.
+  'Runway 06': { planeSize: 600, gap: 40, move: 1.6, stagger: 1 / 15 },
+  'Runway 07': { planeSize: 546, gap: 40, axis: 'horizontal', move: 1.6, stagger: 1 / 15 },
 
-  // Featured card grows at centre, neighbours fade back.
-  refPreset('carousel-r03', 'Runway 08', { planeSize: 568, gap: 235, centerScale: 1.45, fade: 40, seconds: 1.6 }, GLIDE),
-  refPreset('carousel-r04', 'Runway 09', { planeSize: 440, gap: 190, centerScale: 1.45, fade: 40, axis: 'horizontal', seconds: 1.6 }, GLIDE),
+  // Featured card grows at the middle, neighbours fade back.
+  'Runway 08': { planeSize: 568, gap: 235, centerScale: 1.45, fade: 40, move: 1.6, stagger: 1 / 15 },
+  'Runway 09': { planeSize: 440, gap: 190, centerScale: 1.45, fade: 40, axis: 'horizontal', move: 1.6, stagger: 1 / 15 },
 
-  // Slow, evenly spaced, linear — a conveyor rather than a carousel.
-  refPreset('carousel-r05', 'Runway 10', { planeSize: 730, gap: 80, seconds: 2.3 }, LINEAR),
-  refPreset('carousel-r06', 'Runway 11', { planeSize: 540, gap: 80, axis: 'horizontal', seconds: 2.3 }, LINEAR),
+  // Slow, evenly spaced, linear, no stagger — a conveyor rather than a carousel.
+  'Runway 10': { planeSize: 730, gap: 80, move: 2.3 },
+  'Runway 11': { planeSize: 540, gap: 80, axis: 'horizontal', move: 2.3 },
 
   // Wide gutters: one card at a time with air around it.
-  refPreset('carousel-r07', 'Runway 12', { planeSize: 850, gap: 500, seconds: 1.6 }, SMOOTH),
-  refPreset('carousel-r08', 'Runway 13', { planeSize: 642, gap: 500, axis: 'horizontal', seconds: 1.6 }, SMOOTH),
+  'Runway 12': { planeSize: 850, gap: 500, move: 1.6, stagger: 1 / 15 },
+  'Runway 13': { planeSize: 642, gap: 500, axis: 'horizontal', move: 1.6, stagger: 1 / 15 },
 
-  // Steps with a hold: the reference adds delay 0.5 on top of duration 1.5.
-  refPreset('carousel-r09', 'Runway 14', { planeSize: 600, gap: 332, centerScale: 1.4, seconds: 2.0 }, SMOOTH),
-  refPreset('carousel-r10', 'Runway 15', { planeSize: 454, gap: 332, centerScale: 1.4, axis: 'horizontal', seconds: 2.0 }, SMOOTH),
+  // `solo`: one image slides through the frame at a time, resting half a second
+  // between advances. Not a strip at all — this family's other read.
+  'Runway 14': { planeSize: 600, gap: 332, centerScale: 1.4, single: true, move: 1.5, delay: 0.5 },
+  'Runway 15': { planeSize: 454, gap: 332, centerScale: 1.4, single: true, axis: 'horizontal', move: 1.5, delay: 0.5 },
 
-  // Featured card pinned to the leading edge instead of the middle.
-  refPreset('carousel-r11', 'Runway 16', { planeSize: 568, gap: 235, centerScale: 1.65, focus: 'start', seconds: 1.6 }, GLIDE),
-  refPreset('carousel-r12', 'Runway 17', { planeSize: 466, gap: 140, centerScale: 1.75, focus: 'start', axis: 'horizontal', seconds: 1.6 }, GLIDE),
+  // Size ramped across the strip, biggest at the leading edge.
+  'Runway 16': { planeSize: 568, gap: 235, centerScale: 1.65, focus: 'start', move: 1.6, stagger: 1 / 15 },
+  'Runway 17': { planeSize: 466, gap: 140, centerScale: 1.75, focus: 'start', axis: 'horizontal', move: 1.6, stagger: 1 / 15 },
 
-  // Trailing edge, running backwards, with the biggest featured jump.
-  refPreset('carousel-r13', 'Runway 18', { planeSize: 850, gap: 500, centerScale: 2, focus: 'end', reverse: true, seconds: 1.6 }, SMOOTH),
-  refPreset('carousel-r14', 'Runway 19', { planeSize: 639, gap: 500, centerScale: 2, focus: 'end', axis: 'horizontal', reverse: true, seconds: 1.6 }, SMOOTH),
+  // Trailing edge, running backwards, with the biggest ramp.
+  'Runway 18': { planeSize: 850, gap: 500, centerScale: 2, focus: 'end', reverse: true, move: 1.6, stagger: 1 / 15 },
+  'Runway 19': { planeSize: 639, gap: 500, centerScale: 2, focus: 'end', axis: 'horizontal', reverse: true, move: 1.6, stagger: 1 / 15 },
 
-  // Gapless deck: cards touch, so the featured one reads as lifting out of a stack.
-  refPreset('carousel-r15', 'Runway 20', { planeSize: 614, gap: 0, centerScale: 1.8, focus: 'start', seconds: 1.6 }, FLOW),
-  refPreset('carousel-r16', 'Runway 21', { planeSize: 473, gap: 0, centerScale: 1.8, focus: 'start', axis: 'horizontal', seconds: 1.6 }, FLOW),
+  // Gapless deck: cards touch, so the ramp reads as lifting out of a stack.
+  'Runway 20': { planeSize: 614, gap: 0, centerScale: 1.8, focus: 'start', move: 1.6 },
+  'Runway 21': { planeSize: 473, gap: 0, centerScale: 1.8, focus: 'start', axis: 'horizontal', move: 1.6 },
 
-  // Alternating tilt — every other card leans the other way.
-  refPreset('carousel-r17', 'Runway 22', { planeSize: 748, gap: 273, tilt: -25, seconds: 1.6 }, FLOW),
-  refPreset('carousel-r18', 'Runway 23', { planeSize: 657, gap: 273, tilt: -25, axis: 'horizontal', seconds: 1.6 }, FLOW),
-];
+  // Alternating roll — every other card leans the other way.
+  'Runway 22': { planeSize: 748, gap: 273, tilt: -25, move: 1.6 },
+  'Runway 23': { planeSize: 657, gap: 273, tilt: -25, axis: 'horizontal', move: 1.6 },
+};
+
+const REF_EASING: Record<string, EasingSpec> = {
+  'Runway 06': GLIDE,  'Runway 07': GLIDE,  'Runway 08': GLIDE,  'Runway 09': GLIDE,
+  'Runway 10': LINEAR, 'Runway 11': LINEAR, 'Runway 12': SMOOTH, 'Runway 13': SMOOTH,
+  'Runway 14': SMOOTH, 'Runway 15': SMOOTH, 'Runway 16': GLIDE,  'Runway 17': GLIDE,
+  'Runway 18': SMOOTH, 'Runway 19': SMOOTH, 'Runway 20': FLOW,   'Runway 21': FLOW,
+  'Runway 22': FLOW,   'Runway 23': FLOW,
+};
+
+export const carouselRefVariants: Template[] = Object.keys(REF_CAROUSEL).map((name, i) => (
+  refPreset(`carousel-r${String(i + 1).padStart(2, '0')}`, name, REF_CAROUSEL[name], REF_EASING[name])
+));
+
+// The same six steps read too fast when inherited from a shorter previous
+// scene. Selecting a reconstructed Runway also restores the clip length that
+// the reference authored for that preset.
+export const carouselReferenceDurations: Record<string, number> = Object.fromEntries(
+  Object.keys(REF_CAROUSEL).map((name, i) => [
+    `carousel-r${String(i + 1).padStart(2, '0')}`,
+    refCarouselSeconds(REF_CAROUSEL[name]),
+  ])
+);


### PR DESCRIPTION
## What changed
- restore the uncommitted Runway/Carousel reconstruction recovered from the local Claude worktree backup
- reproduce stepped motion, stagger, hold periods, scale focus, single-card mode, fade, and in-plane tilt
- correct horizontal preset sizing and spacing
- restore each reference preset's authored duration when selected
- keep every preset loop-safe for individual assets

## Why this is separate
PR #67 only improves thumbnail loading and still generation. This PR restores preset behavior that was never committed, and therefore changes what the real stage and its thumbnails render.

## Validation
- npm test
- npx tsc --noEmit
- npm run build
- 1,731 reference assertions, including 36 new Runway cadence/duration checks