### PR TITLE
Fix/legacy gradient projects

### DIFF
--- a/GRADIENTS.md
+++ b/GRADIENTS.md
@@ -11,9 +11,10 @@ Advanced mode, but they must not define their own gradient document shape.
 - Modes: `basic`, `advanced`.
 - Shapes: `linear`, `radial`, `conic`, `mesh`, `warped-field`, `twin-radial`.
 - Stops: sorted for rendering, minimum 2, maximum 8, stable IDs.
-- Softness: `0..1`; applies a one-dimensional Gaussian feather to the colour
-  ramp without blurring the layer or its edges. `0` preserves the native linear
-  interpolation used by existing documents.
+- Softness: `0..1`; combines a one-dimensional Gaussian feather on the colour
+  ramp with a spatial Gaussian blur on the rendered field. Raster edges are
+  extended before filtering so the background remains opaque corner-to-corner.
+  `0` preserves the native linear interpolation used by existing documents.
 - Angle convention: `0deg` runs left to right and increases clockwise in screen
   space. Renderer-specific angle conventions are converted at the boundary.
 - Center, radius and 3D coordinates are normalized to `0..1`.

--- a/GRADIENTS.md
+++ b/GRADIENTS.md
@@ -11,9 +11,9 @@ Advanced mode, but they must not define their own gradient document shape.
 - Modes: `basic`, `advanced`.
 - Shapes: `linear`, `radial`, `conic`, `mesh`, `warped-field`, `twin-radial`.
 - Stops: sorted for rendering, minimum 2, maximum 8, stable IDs.
-- Softness: `0..1`; eases interpolation between authored stops without applying
-  blur to the layer. `0` preserves the native linear interpolation used by
-  existing documents.
+- Softness: `0..1`; applies a one-dimensional Gaussian feather to the colour
+  ramp without blurring the layer or its edges. `0` preserves the native linear
+  interpolation used by existing documents.
 - Angle convention: `0deg` runs left to right and increases clockwise in screen
   space. Renderer-specific angle conventions are converted at the boundary.
 - Center, radius and 3D coordinates are normalized to `0..1`.
@@ -45,6 +45,9 @@ through the normal autosave path after an edit.
 
 - Basic exposes Linear and Radial.
 - Advanced exposes every shape and the five procedural controls.
+- Entering Advanced from Basic resets hidden procedural geometry to its neutral
+  defaults, so stale values in an older Basic project cannot displace or harden
+  the newly activated gradient.
 - Softness is shared by Basic and Advanced and applies to Linear and Radial as
   well as the additional Advanced shapes.
 - Clicking the ramp adds an interpolated stop at that position.

--- a/components/GradientEditor.tsx
+++ b/components/GradientEditor.tsx
@@ -5,6 +5,7 @@ import { ControlRow } from './Controls';
 import type { ControlDef } from '@/lib/types';
 import {
   MAX_GRADIENT_STOPS,
+  DEFAULT_GRADIENT_ADVANCED,
   gradientCss,
   normalizeGradientSpec,
   sampleGradientRGB,
@@ -60,11 +61,14 @@ function rgbHex(rgb: [number, number, number, number]) {
 
 function presetSpec(current: GradientSpec, preset: (typeof PRESETS)[number]): GradientSpec {
   const colors = preset.colors;
+  const resetsCenter = preset.shape === 'radial';
   return normalizeGradientSpec({
     ...current,
     mode: 'basic',
     shape: preset.shape ?? 'linear',
     angle: preset.angle ?? current.angle,
+    center: resetsCenter ? { x: 0.5, y: 0.5 } : current.center,
+    radius: resetsCenter ? 0.72 : current.radius,
     stops: colors.map((color, i) => ({ id: `preset-${preset.name.toLowerCase()}-${i}`, color, position: i / Math.max(1, colors.length - 1), opacity: 1 })),
   });
 }
@@ -153,7 +157,12 @@ export default function GradientEditor({ value, onChange, showMapping = false }:
               mode: 'basic',
               shape: BASIC_SHAPES.some(([shape]) => shape === spec.shape) ? spec.shape : 'linear',
             })}>Basic</button>
-            <button className={`seg ${spec.mode === 'advanced' ? 'active' : ''}`} onClick={() => emit({ mode: 'advanced' })}>Advanced</button>
+            <button className={`seg ${spec.mode === 'advanced' ? 'active' : ''}`} onClick={() => emit(spec.mode === 'basic' ? {
+              mode: 'advanced',
+              center: { x: 0.5, y: 0.5 },
+              radius: 0.72,
+              advanced: { ...DEFAULT_GRADIENT_ADVANCED },
+            } : { mode: 'advanced' })}>Advanced</button>
           </div>
         </div>
       </div>
@@ -221,7 +230,11 @@ export default function GradientEditor({ value, onChange, showMapping = false }:
       <div className="ctl-row">
         <label className="ctl-label">Shape</label>
         <div className="ctl-input">
-          <select className="field" value={spec.shape} onChange={(e) => emit({ shape: e.target.value as GradientShape })}>
+          <select className="field" value={spec.shape} onChange={(e) => {
+            const shape = e.target.value as GradientShape;
+            const startsUsingCenter = !needsCenter && (shape === 'radial' || shape === 'conic' || shape === 'twin-radial');
+            emit(startsUsingCenter ? { shape, center: { x: 0.5, y: 0.5 }, radius: 0.72 } : { shape });
+          }}>
             {shapes.map(([shape, label]) => <option key={shape} value={shape}>{label}</option>)}
           </select>
         </div>

--- a/components/ThreeStage3D.tsx
+++ b/components/ThreeStage3D.tsx
@@ -184,9 +184,11 @@ export default function ThreeStage3D({ effectId: forcedEffectId }: { effectId?: 
   };
 
   const bgFill = use3DStore((s) => s.bgFill);
-  const background =
-    bgFill.type === 'linear' || bgFill.type === 'radial' ? gradientCss(gradientFromFill(bgFill))
-    : bgFill.c1;
+  const backgroundGradient = bgFill.type === 'linear' || bgFill.type === 'radial'
+    ? gradientFromFill(bgFill)
+    : null;
+  const background = backgroundGradient ? gradientCss(backgroundGradient) : bgFill.c1;
+  const backgroundBlur = backgroundGradient ? backgroundGradient.softness * 24 : 0;
   const stageStyle: React.CSSProperties = { background };
 
   // Same "contain" fit a <canvas>/<img> gets for free from object-fit, ported
@@ -214,6 +216,18 @@ export default function ThreeStage3D({ effectId: forcedEffectId }: { effectId?: 
           overflow: 'hidden',
         }}
       >
+        {backgroundBlur > 0 && (
+          <div
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              inset: '-8%',
+              background,
+              filter: `blur(${backgroundBlur}px)`,
+              pointerEvents: 'none',
+            }}
+          />
+        )}
         <canvas key={effectId} className="three3d-layer three3d-ascii" ref={canvasRef} style={canvasStyle} />
 
         {has('tint') && (

--- a/lib/gradient.ts
+++ b/lib/gradient.ts
@@ -393,6 +393,67 @@ function addNativeStops(gradient: CanvasGradient, spec: GradientSpec) {
   }
 }
 
+export function gradientBlurRadius(specInput: GradientSpec, width: number, height: number): number {
+  const spec = normalizeGradientSpec(specInput);
+  if (spec.softness <= 0) return 0;
+  return Math.min(32, Math.max(0, Math.min(width, height)) * 0.035 * spec.softness);
+}
+
+type BlurBuffers = { source: HTMLCanvasElement; padded: HTMLCanvasElement };
+const blurBuffers = new WeakMap<HTMLCanvasElement, BlurBuffers>();
+
+function canvasBuffer(width: number, height: number): HTMLCanvasElement {
+  const buffer = document.createElement('canvas');
+  buffer.width = width;
+  buffer.height = height;
+  return buffer;
+}
+
+function applyGradientBlur(canvas: HTMLCanvasElement, spec: GradientSpec): void {
+  const blur = gradientBlurRadius(spec, canvas.width, canvas.height);
+  if (blur <= 0) return;
+
+  const pad = Math.max(2, Math.ceil(blur * 3));
+  let buffers = blurBuffers.get(canvas);
+  if (!buffers) {
+    buffers = { source: canvasBuffer(canvas.width, canvas.height), padded: canvasBuffer(canvas.width + pad * 2, canvas.height + pad * 2) };
+    blurBuffers.set(canvas, buffers);
+  }
+  const { source, padded } = buffers;
+  if (source.width !== canvas.width) source.width = canvas.width;
+  if (source.height !== canvas.height) source.height = canvas.height;
+  if (padded.width !== canvas.width + pad * 2) padded.width = canvas.width + pad * 2;
+  if (padded.height !== canvas.height + pad * 2) padded.height = canvas.height + pad * 2;
+
+  const sourceCtx = source.getContext('2d');
+  const paddedCtx = padded.getContext('2d');
+  const ctx = canvas.getContext('2d');
+  if (!sourceCtx || !paddedCtx || !ctx) return;
+  const w = canvas.width, h = canvas.height;
+  sourceCtx.clearRect(0, 0, w, h);
+  sourceCtx.drawImage(canvas, 0, 0);
+
+  // Extend the four edge pixels into the blur padding. A regular filtered draw
+  // samples transparent pixels outside the canvas and creates a dark frame;
+  // clamped edges keep a background gradient opaque from corner to corner.
+  paddedCtx.clearRect(0, 0, padded.width, padded.height);
+  paddedCtx.drawImage(source, pad, pad);
+  paddedCtx.drawImage(source, 0, 0, w, 1, pad, 0, w, pad);
+  paddedCtx.drawImage(source, 0, h - 1, w, 1, pad, pad + h, w, pad);
+  paddedCtx.drawImage(source, 0, 0, 1, h, 0, pad, pad, h);
+  paddedCtx.drawImage(source, w - 1, 0, 1, h, pad + w, pad, pad, h);
+  paddedCtx.drawImage(source, 0, 0, 1, 1, 0, 0, pad, pad);
+  paddedCtx.drawImage(source, w - 1, 0, 1, 1, pad + w, 0, pad, pad);
+  paddedCtx.drawImage(source, 0, h - 1, 1, 1, 0, pad + h, pad, pad);
+  paddedCtx.drawImage(source, w - 1, h - 1, 1, 1, pad + w, pad + h, pad, pad);
+
+  ctx.save();
+  ctx.clearRect(0, 0, w, h);
+  ctx.filter = `blur(${blur}px)`;
+  ctx.drawImage(padded, -pad, -pad);
+  ctx.restore();
+}
+
 export function paintGradientCanvas(
   canvas: HTMLCanvasElement,
   specInput: GradientSpec,
@@ -424,6 +485,7 @@ export function paintGradientCanvas(
     addNativeStops(gradient, spec);
     ctx.fillStyle = gradient;
     ctx.fillRect(0, 0, w, h);
+    applyGradientBlur(canvas, spec);
     return;
   }
 
@@ -443,6 +505,7 @@ export function paintGradientCanvas(
     }
   }
   ctx.putImageData(image, 0, 0);
+  applyGradientBlur(canvas, spec);
 }
 
 export function advancedRasterSize(width: number, height: number, maxEdge = 384): [number, number] {

--- a/lib/gradient.ts
+++ b/lib/gradient.ts
@@ -212,12 +212,6 @@ function mixColor(a: RGB, b: RGB, t: number): RGB {
   ];
 }
 
-function softenedT(t: number, softness: number): number {
-  const linear = clamp(t);
-  const eased = linear * linear * (3 - 2 * linear);
-  return linear + (eased - linear) * clamp(softness);
-}
-
 function rgbHex(color: RGB): string {
   return `#${color.slice(0, 3).map((channel) => Math.round(channel).toString(16).padStart(2, '0')).join('')}`;
 }
@@ -229,7 +223,7 @@ function prepareStops(spec: GradientSpec): PreparedStop[] {
   }));
 }
 
-function samplePreparedStops(stops: PreparedStop[], t: number, softness = 0): RGB {
+function sampleLinearStops(stops: PreparedStop[], t: number): RGB {
   const x = clamp(t);
   if (x <= stops[0].position) return stops[0].color;
   for (let i = 1; i < stops.length; i++) {
@@ -237,10 +231,28 @@ function samplePreparedStops(stops: PreparedStop[], t: number, softness = 0): RG
     if (x <= right.position) {
       const left = stops[i - 1];
       const span = Math.max(1e-6, right.position - left.position);
-      return mixColor(left.color, right.color, softenedT((x - left.position) / span, softness));
+      return mixColor(left.color, right.color, (x - left.position) / span);
     }
   }
   return stops[stops.length - 1].color;
+}
+
+function samplePreparedStops(stops: PreparedStop[], t: number, softness = 0): RGB {
+  const amount = clamp(softness);
+  if (amount <= 0) return sampleLinearStops(stops, t);
+
+  // A small Gaussian convolution really feathers the colour ramp. Unlike an
+  // easing curve, it does not squeeze the transition into a harder midpoint;
+  // it rounds corners at authored stops and gently blends the ramp boundaries.
+  const radius = amount * 0.28;
+  const offsets = [-1, -0.5, 0, 0.5, 1];
+  const weights = [1, 4, 6, 4, 1];
+  const result: RGB = [0, 0, 0, 0];
+  for (let i = 0; i < offsets.length; i++) {
+    const color = sampleLinearStops(stops, t + offsets[i] * radius);
+    for (let channel = 0; channel < 4; channel++) result[channel] += color[channel] * weights[i];
+  }
+  return result.map((channel) => channel / 16) as RGB;
 }
 
 export function sampleGradientRGB(specInput: GradientSpec, t: number): RGB {
@@ -253,26 +265,18 @@ export function gradientRenderStops(specInput: GradientSpec): GradientStop[] {
   const stops = sortedStops(spec);
   if (spec.softness <= 0) return stops;
 
-  const rendered: GradientStop[] = [stops[0]];
-  const samplesPerSegment = 12;
-  for (let i = 1; i < stops.length; i++) {
-    const left = stops[i - 1];
-    const right = stops[i];
-    const leftColor = parseColor(left.color, left.opacity);
-    const rightColor = parseColor(right.color, right.opacity);
-    for (let sample = 1; sample < samplesPerSegment; sample++) {
-      const t = sample / samplesPerSegment;
-      const color = mixColor(leftColor, rightColor, softenedT(t, spec.softness));
-      rendered.push({
-        id: `soft-${i}-${sample}`,
-        position: left.position + (right.position - left.position) * t,
-        color: rgbHex(color),
-        opacity: color[3] / 255,
-      });
-    }
-    rendered.push(right);
-  }
-  return rendered;
+  const prepared = prepareStops(spec);
+  const sampleCount = Math.max(32, (stops.length - 1) * 16);
+  return Array.from({ length: sampleCount + 1 }, (_, sample) => {
+    const position = sample / sampleCount;
+    const color = samplePreparedStops(prepared, position, spec.softness);
+    return {
+      id: `soft-${sample}`,
+      position,
+      color: rgbHex(color),
+      opacity: color[3] / 255,
+    };
+  });
 }
 
 function hash2(x: number, y: number): number {
@@ -306,8 +310,9 @@ function prepareMeshPalette(stops: PreparedStop[]): RGB[] {
 }
 
 function meshColor(spec: GradientSpec, colors: RGB[], stopCount: number, x: number, y: number): RGB {
-  const easedX = softenedT(x, spec.softness);
-  const easedY = softenedT(y, spec.softness);
+  const spread = 1 - spec.softness * 0.22;
+  const easedX = clamp(0.5 + (x - 0.5) * spread);
+  const easedY = clamp(0.5 + (y - 0.5) * spread);
   const top = mixColor(colors[0], colors[1], easedX);
   const bottom = mixColor(colors[3], colors[2], easedX);
   let result = mixColor(top, bottom, easedY);

--- a/scripts/verify-gradients.cjs
+++ b/scripts/verify-gradients.cjs
@@ -11,6 +11,7 @@ const {
   createGradientSpec,
   fillPatchForGradient,
   gradientFromFill,
+  gradientBlurRadius,
   gradientRenderStops,
   gradientRasterMaxEdge,
   gradientSignature,
@@ -52,6 +53,9 @@ const peaked = normalizeGradientSpec({ ...simple, softness: 1, stops: [
 check(sampleGradientRGB(peaked, 0.5)[0] < 240, 'softness must round a hard interior colour stop');
 check(gradientRenderStops(simple).length === simple.stops.length && gradientRenderStops(soft).length > soft.stops.length, 'native renderers must add smoothing samples only when softness is enabled');
 check(normalizeGradientSpec({ ...simple, softness: 7 }).softness === 1, 'softness must clamp to its document range');
+check(gradientBlurRadius(simple, 800, 600) === 0, 'zero softness must not add a spatial blur');
+check(close(gradientBlurRadius(soft, 800, 600), 21, 0.001), 'softness must map to a proportional spatial blur radius');
+check(gradientBlurRadius(soft, 2000, 2000) === 32, 'spatial blur must keep a bounded render cost');
 const mesh = normalizeGradientSpec({ ...soft, mode: 'advanced', shape: 'mesh' });
 check(!colorClose(sampleGradientPoint(mesh, 0.25, 0.5), sampleGradientPoint({ ...mesh, softness: 0 }, 0.25, 0.5), 0.1), 'mesh must honor the shared softness interpolation');
 check(colorClose(sampleGradientPoint({ ...simple, angle: 0 }, 0, 0.5), [0, 0, 0, 255]), 'linear start must use first stop');

--- a/scripts/verify-gradients.cjs
+++ b/scripts/verify-gradients.cjs
@@ -42,9 +42,15 @@ check(crowded.stops.every((stop, i, list) => i === 0 || list[i - 1].position <= 
 const simple = createGradientSpec('#000000', '#ffffff');
 check(colorClose(sampleGradientRGB(simple, 0.5), [128, 128, 128, 255]), 'two-stop midpoint must interpolate');
 const soft = normalizeGradientSpec({ ...simple, softness: 1 });
-check(colorClose(sampleGradientRGB(soft, 0.25), [40, 40, 40, 255]), 'softness must ease colour interpolation between stops');
-check(colorClose(sampleGradientRGB(soft, 0), [0, 0, 0, 255]) && colorClose(sampleGradientRGB(soft, 1), [255, 255, 255, 255]), 'softness must preserve authored endpoint colours');
-check(gradientRenderStops(simple).length === simple.stops.length && gradientRenderStops(soft).length > soft.stops.length, 'native renderers must add easing samples only when softness is enabled');
+check(colorClose(sampleGradientRGB(soft, 0), [13, 13, 13, 255]), 'softness must feather the start of a two-stop ramp');
+check(colorClose(sampleGradientRGB(soft, 1), [242, 242, 242, 255]), 'softness must feather the end of a two-stop ramp');
+const peaked = normalizeGradientSpec({ ...simple, softness: 1, stops: [
+  { id: 'dark-start', color: '#000000', position: 0 },
+  { id: 'light-middle', color: '#ffffff', position: 0.5 },
+  { id: 'dark-end', color: '#000000', position: 1 },
+] });
+check(sampleGradientRGB(peaked, 0.5)[0] < 240, 'softness must round a hard interior colour stop');
+check(gradientRenderStops(simple).length === simple.stops.length && gradientRenderStops(soft).length > soft.stops.length, 'native renderers must add smoothing samples only when softness is enabled');
 check(normalizeGradientSpec({ ...simple, softness: 7 }).softness === 1, 'softness must clamp to its document range');
 const mesh = normalizeGradientSpec({ ...soft, mode: 'advanced', shape: 'mesh' });
 check(!colorClose(sampleGradientPoint(mesh, 0.25, 0.5), sampleGradientPoint({ ...mesh, softness: 0 }, 0.25, 0.5), 0.1), 'mesh must honor the shared softness interpolation');
@@ -85,6 +91,7 @@ const gradientCssBlock = cssSource.split('/* ---- Shared 2D / 3D gradient editor
   ?.split('/* Neutral SSR/hydration gate.')[0] ?? '';
 check(editorSource.includes("import { ControlRow } from './Controls'"), 'gradient sliders must use the shared ControlRow primitive');
 check(editorSource.includes("label: 'Softness'") && editorSource.includes('value={spec.softness}'), 'shared editor must expose softness through the design-system control primitive');
+check(editorSource.includes('advanced: { ...DEFAULT_GRADIENT_ADVANCED }') && editorSource.includes('center: { x: 0.5, y: 0.5 }'), 'Basic-to-Advanced activation must reset hidden legacy geometry');
 check(editorSource.includes('className="segmented"') && editorSource.includes('className="field"') && editorSource.includes('className="btn"'), 'gradient choices and actions must use shared control classes');
 check(!editorSource.includes('type="range"') && !editorSource.includes('gradient-number'), 'gradient editor must not introduce native parallel sliders');
 check(gradientCssBlock.includes('var(--ctl-h)') && gradientCssBlock.includes('var(--gap-row)') && gradientCssBlock.includes('var(--r-ctrl)'), 'gradient geometry must derive from tokens.css metrics');


### PR DESCRIPTION
Fixes the follow-up regressions found after PR #71. Activating Advanced from a Basic project now resets hidden center, radius, warp, flow, scale, detail, and contrast values to neutral defaults, preventing legacy geometry from shifting the new gradient toward a corner. Radial presets and shapes also start centered when they begin using positional geometry. Softness now applies a Gaussian feather to the color ramp instead of an easing curve that could make the midpoint feel harder. The same sampled ramp is used by Basic Linear, Basic Radial, Advanced, 2D, and 3D render paths. Validation: full npm test suite with 36 gradient assertions, npm run build, and browser regression testing against a duplicated seven-day-old project.