### PR TITLE
Fix renderer lifecycle crashes and improve gradient softness

### DIFF
--- a/GRADIENTS.md
+++ b/GRADIENTS.md
@@ -11,10 +11,11 @@ Advanced mode, but they must not define their own gradient document shape.
 - Modes: `basic`, `advanced`.
 - Shapes: `linear`, `radial`, `conic`, `mesh`, `warped-field`, `twin-radial`.
 - Stops: sorted for rendering, minimum 2, maximum 8, stable IDs.
-- Softness: `0..1`; combines a one-dimensional Gaussian feather on the colour
-  ramp with a spatial Gaussian blur on the rendered field. Raster edges are
-  extended before filtering so the background remains opaque corner-to-corner.
-  `0` preserves the native linear interpolation used by existing documents.
+- Softness: `0..1`; rendered backgrounds receive one spatial Gaussian blur
+  pass. Raster edges are extended before filtering so the background remains
+  opaque corner-to-corner. The point sampler used by 3D vertex fills keeps a
+  one-dimensional Gaussian approximation because it has no complete image to
+  post-filter. `0` preserves native linear interpolation in existing documents.
 - Angle convention: `0deg` runs left to right and increases clockwise in screen
   space. Renderer-specific angle conventions are converted at the boundary.
 - Center, radius and 3D coordinates are normalized to `0..1`.
@@ -62,8 +63,10 @@ through the normal autosave path after an edit.
 ## Rendering and performance
 
 Basic Linear/Radial uses native Canvas 2D interpolation at up to the logical
-canvas resolution. Advanced fields use a 384px long-edge procedural texture and
-are scaled by the GPU. Static gradients are signature-cached; only a non-zero
+canvas resolution. Advanced fields use a shape- and motion-sensitive raster
+budget and are scaled by the GPU. Softness is applied before that scaling, with
+a radius proportional to the short edge so Basic, Advanced, 2D and 3D retain
+the same apparent blur. Static gradients are signature-cached; only a non-zero
 Flow value invalidates the texture as the timeline advances.
 
 Flow follows a circular time path, so phase `0` and `1` are identical and video

--- a/components/PreviewStage.tsx
+++ b/components/PreviewStage.tsx
@@ -53,6 +53,7 @@ export default function PreviewStage() {
     // advancing), or once after any state/texture change while paused. An idle
     // paused preview draws nothing — no wasted GPU/CPU at 60fps on a still image.
     const loop = () => {
+      if (!mounted || initGeneration !== initGenerationRef.current || !rendererRef.current) return;
       const st = useSceneStore.getState();
 
       // freeze/resume card video decoding together with the timeline

--- a/lib/gradient.ts
+++ b/lib/gradient.ts
@@ -30,7 +30,7 @@ export interface GradientSpec {
   mode: GradientMode;
   shape: GradientShape;
   stops: GradientStop[];
-  softness: number; // 0..1; eases colour transitions without blurring the layer
+  softness: number; // 0..1; spatially blurs rendered fields (point samples use a 1-D approximation)
   angle: number; // 0deg = left to right; clockwise in screen space
   center: { x: number; y: number };
   radius: number;
@@ -174,7 +174,11 @@ export function gradientSignature(spec: GradientSpec, phase = 0): string {
 
 export function gradientCss(specInput: GradientSpec): string {
   const spec = normalizeGradientSpec(specInput);
-  const stops = gradientRenderStops(spec).map((s) => {
+  // CSS is a startup/editor fallback. Keep authored stops here: expanding the
+  // one-dimensional softness kernel into extra stops and then blurring the
+  // real canvas applied softness twice, shifted endpoint colours and produced
+  // a very wide dark wedge at the seam of conic gradients.
+  const stops = sortedStops(spec).map((s) => {
     const color = s.opacity == null || s.opacity >= 1 ? s.color : `${s.color}${Math.round(s.opacity * 255).toString(16).padStart(2, '0')}`;
     return `${color} ${Math.round(s.position * 1000) / 10}%`;
   }).join(', ');
@@ -210,10 +214,6 @@ function mixColor(a: RGB, b: RGB, t: number): RGB {
     a[2] + (b[2] - a[2]) * k,
     a[3] + (b[3] - a[3]) * k,
   ];
-}
-
-function rgbHex(color: RGB): string {
-  return `#${color.slice(0, 3).map((channel) => Math.round(channel).toString(16).padStart(2, '0')).join('')}`;
 }
 
 function prepareStops(spec: GradientSpec): PreparedStop[] {
@@ -257,26 +257,17 @@ function samplePreparedStops(stops: PreparedStop[], t: number, softness = 0): RG
 
 export function sampleGradientRGB(specInput: GradientSpec, t: number): RGB {
   const spec = normalizeGradientSpec(specInput);
-  return samplePreparedStops(prepareStops(spec), t, spec.softness);
+  // Used by the stop editor when inserting a new authored colour. Softness is
+  // a render treatment, so it must not silently bake modified colours back
+  // into the gradient document.
+  return sampleLinearStops(prepareStops(spec), t);
 }
 
 export function gradientRenderStops(specInput: GradientSpec): GradientStop[] {
-  const spec = normalizeGradientSpec(specInput);
-  const stops = sortedStops(spec);
-  if (spec.softness <= 0) return stops;
-
-  const prepared = prepareStops(spec);
-  const sampleCount = Math.max(32, (stops.length - 1) * 16);
-  return Array.from({ length: sampleCount + 1 }, (_, sample) => {
-    const position = sample / sampleCount;
-    const color = samplePreparedStops(prepared, position, spec.softness);
-    return {
-      id: `soft-${sample}`,
-      position,
-      color: rgbHex(color),
-      opacity: color[3] / 255,
-    };
-  });
+  // Authored stops remain the renderer contract. Raster backgrounds apply
+  // softness spatially after painting; expanding the ramp here caused every
+  // canvas path to receive the effect twice.
+  return sortedStops(normalizeGradientSpec(specInput));
 }
 
 function hash2(x: number, y: number): number {
@@ -385,7 +376,9 @@ export function sampleGradientPoint(specInput: GradientSpec, x: number, y: numbe
 }
 
 function addNativeStops(gradient: CanvasGradient, spec: GradientSpec) {
-  for (const stop of gradientRenderStops(spec)) {
+  // The rendered canvas receives one spatial blur pass below. Feeding the
+  // already-feathered stop ramp into it would double the effect.
+  for (const stop of sortedStops(spec)) {
     const color = stop.opacity == null || stop.opacity >= 1
       ? stop.color
       : `${stop.color}${Math.round(stop.opacity * 255).toString(16).padStart(2, '0')}`;
@@ -396,7 +389,15 @@ function addNativeStops(gradient: CanvasGradient, spec: GradientSpec) {
 export function gradientBlurRadius(specInput: GradientSpec, width: number, height: number): number {
   const spec = normalizeGradientSpec(specInput);
   if (spec.softness <= 0) return 0;
-  return Math.min(32, Math.max(0, Math.min(width, height)) * 0.035 * spec.softness);
+  // Express the radius as a share of the short edge. Basic and Advanced use
+  // different raster budgets, so a fixed raster-pixel cap made the same value
+  // look different after their textures were scaled to the stage. The active
+  // raster budgets already bound real render cost; the final guard only
+  // protects direct callers with unusually large canvases.
+  // Canvas/CSS blur treats this number as a Gaussian deviation; the visible
+  // transition spans roughly six times the radius. 1.8% therefore produces a
+  // deliberate ~11% feather at Softness 1 instead of washing out the field.
+  return Math.min(64, Math.max(0, Math.min(width, height)) * 0.018 * spec.softness);
 }
 
 type BlurBuffers = { source: HTMLCanvasElement; padded: HTMLCanvasElement };
@@ -469,6 +470,11 @@ export function paintGradientCanvas(
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
 
+  // Softness is a single spatial operation for rendered backgrounds. The
+  // shared point sampler retains its 1-D convolution as a fallback for 3D
+  // vertex fills, where there is no complete image to post-filter.
+  const renderSpec = spec.softness > 0 ? { ...spec, softness: 0 } : spec;
+
   // Basic gradients use the browser's native, high-resolution interpolation.
   if (spec.mode === 'basic' && (spec.shape === 'linear' || spec.shape === 'radial')) {
     let gradient: CanvasGradient;
@@ -482,7 +488,7 @@ export function paintGradientCanvas(
       const cx = w / 2, cy = h / 2;
       gradient = ctx.createLinearGradient(cx - vx * half, cy - vy * half, cx + vx * half, cy + vy * half);
     }
-    addNativeStops(gradient, spec);
+    addNativeStops(gradient, renderSpec);
     ctx.fillStyle = gradient;
     ctx.fillRect(0, 0, w, h);
     applyGradientBlur(canvas, spec);
@@ -494,11 +500,11 @@ export function paintGradientCanvas(
   // Normalisation, sorting, hex parsing and opacity composition are invariant
   // across this raster. Preparing once here removes hundreds of thousands of
   // object allocations from every Advanced frame.
-  const preparedStops = prepareStops(spec);
-  const meshPalette = spec.shape === 'mesh' ? prepareMeshPalette(preparedStops) : undefined;
+  const preparedStops = prepareStops(renderSpec);
+  const meshPalette = renderSpec.shape === 'mesh' ? prepareMeshPalette(preparedStops) : undefined;
   for (let py = 0; py < h; py++) {
     for (let px = 0; px < w; px++) {
-      const c = samplePreparedGradientPoint(spec, preparedStops, (px + 0.5) / w, (py + 0.5) / h, phase, meshPalette);
+      const c = samplePreparedGradientPoint(renderSpec, preparedStops, (px + 0.5) / w, (py + 0.5) / h, phase, meshPalette);
       const i = (py * w + px) * 4;
       data[i] = Math.round(c[0]); data[i + 1] = Math.round(c[1]);
       data[i + 2] = Math.round(c[2]); data[i + 3] = Math.round(c[3]);

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -107,6 +107,7 @@ export class SceneRenderer {
   // containers; zIndex mirrors the store's track order.
   private trackRTs = new Map<string, TrackRT>();
   private ready = false;
+  private destroyed = false;
 
   private lastFxSig = '';
   private bgImageUrl = '';                        // last-loaded uploaded bg url
@@ -120,19 +121,26 @@ export class SceneRenderer {
   }
 
   async init(canvas: HTMLCanvasElement) {
+    if (this.destroyed) return;
     const { width, height } = useSceneStore.getState();
-    await this.app.init({
-      canvas,
-      width,
-      height,
-      backgroundAlpha: 0,
-      antialias: true,
-      autoStart: false,          // we drive rendering ourselves
-      preference: 'webgl',
-      powerPreference: 'high-performance', // hint the browser to use the discrete GPU
-      resolution: 1,
-      preserveDrawingBuffer: true, // so toDataURL reads real pixels during export
-    });
+    try {
+      await this.app.init({
+        canvas,
+        width,
+        height,
+        backgroundAlpha: 0,
+        antialias: true,
+        autoStart: false,          // we drive rendering ourselves
+        preference: 'webgl',
+        powerPreference: 'high-performance', // hint the browser to use the discrete GPU
+        resolution: 1,
+        preserveDrawingBuffer: true, // so toDataURL reads real pixels during export
+      });
+    } catch {
+      return;
+    }
+
+    if (this.destroyed || !this.app?.renderer) return;
 
     this.motion.sortableChildren = true;
     this.bgSprite.anchor.set(0.5);
@@ -151,13 +159,15 @@ export class SceneRenderer {
   }
 
   resize(width: number, height: number, resolution = 1) {
-    if (!this.ready) return;
-    this.app.renderer.resize(width, height, resolution);
-    this.motion.position.set(width / 2, height / 2);
-    this.bgSprite.position.set(width / 2, height / 2);
-    this.gradientSprite.position.set(width / 2, height / 2);
-    this.content.filterArea = new PIXI.Rectangle(0, 0, width, height);
-    this.overlay.position.set(0, 0);
+    if (!this.ready || this.destroyed || !this.app?.renderer) return;
+    try {
+      this.app.renderer.resize(width, height, resolution);
+      this.motion.position.set(width / 2, height / 2);
+      this.bgSprite.position.set(width / 2, height / 2);
+      this.gradientSprite.position.set(width / 2, height / 2);
+      this.content.filterArea = new PIXI.Rectangle(0, 0, width, height);
+      this.overlay.position.set(0, 0);
+    } catch { /* noop */ }
   }
 
   // ---- asset / slot management ----
@@ -799,8 +809,14 @@ export class SceneRenderer {
 
   // Realize + render a frame synchronously (used by export).
   renderFrame(frame: number) {
-    this.getFrameState(frame);
-    this.app.renderer.render(this.app.stage);
+    if (!this.ready || this.destroyed || !this.app?.renderer) return;
+    try {
+      this.getFrameState(frame);
+      if (!this.ready || this.destroyed || !this.app?.renderer) return;
+      this.app.renderer.render(this.app.stage);
+    } catch {
+      // guard against renderer being destroyed mid-frame or WebGL context lost
+    }
   }
 
   // Deterministic capture: realize frame, render, read pixels as a JPEG data URL.
@@ -808,8 +824,9 @@ export class SceneRenderer {
   // the scene always paints a background so the missing alpha channel is moot.
   // ffmpeg re-encodes to h264/gif downstream, so there's no visible quality loss.
   captureFrame(frame: number): string {
+    if (!this.ready || this.destroyed || !this.app?.renderer) return '';
     this.renderFrame(frame);
-    return (this.app.canvas as HTMLCanvasElement).toDataURL('image/jpeg', 0.92);
+    return (this.app.canvas as HTMLCanvasElement)?.toDataURL?.('image/jpeg', 0.92) ?? '';
   }
 
   // Multiply the backing-store resolution for export capture. Logical
@@ -826,6 +843,7 @@ export class SceneRenderer {
 
   destroy() {
     this.ready = false;
+    this.destroyed = true;
     this.texturePromises.clear();
     this.videoEls.forEach((v) => { try { v.pause(); v.removeAttribute('src'); v.load(); } catch { /* noop */ } });
     this.videoEls.clear();

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -108,8 +108,10 @@ export class SceneRenderer3D implements IRenderer {
   private width = 810;
   private height = 1080;
   ready = false;
+  private destroyed = false;
 
   async init(canvas: HTMLCanvasElement) {
+    if (this.destroyed) return;
     const s = useSceneStore.getState();
     this.width = s.width;
     this.height = s.height;
@@ -126,8 +128,10 @@ export class SceneRenderer3D implements IRenderer {
     this.renderer.setPixelRatio(1);
     this.renderer.setSize(this.width, this.height, false);
     const { R3FSceneBridge } = await import('@/lib/r3fSceneBridge');
+    if (this.destroyed) return;
     this.r3f = new R3FSceneBridge();
     await this.r3f.init(canvas, this.renderer, this.scene, this.camera, this.width, this.height);
+    if (this.destroyed) return;
     this.createCompositor();
     this.ready = true;
     this.syncAssets();
@@ -1074,88 +1078,94 @@ export class SceneRenderer3D implements IRenderer {
   }
 
   renderFrame(frame: number) {
-    if (!this.ready) return;
-    this.getFrameState(frame);
-    const s = useSceneStore.getState();
+    if (!this.ready || this.destroyed || !this.renderer) return;
+    try {
+      this.getFrameState(frame);
+      if (!this.ready || this.destroyed || !this.renderer) return;
+      const s = useSceneStore.getState();
 
-    // The accumulator begins with the opaque scene background.
-    this.renderer.setRenderTarget(this.composeA);
-    this.renderer.setClearColor(0x000000, 1);
-    this.renderer.clear(true, true, true);
-    this.renderer.render(this.scene, this.camera);
-
-    let read = this.composeA;
-    let write = this.composeB;
-    const composeMaterial = this.composeQuad.material;
-    s.tracks.forEach((track) => {
-      const rt = this.trackRTs.get(track.id);
-      if (!rt?.active) return;
-
-      // A layer owns its depth buffer. Z can never leak into another layer.
-      this.renderer.setRenderTarget(rt.target);
-      this.renderer.setClearColor(0x000000, 0);
+      // The accumulator begins with the opaque scene background.
+      this.renderer.setRenderTarget(this.composeA);
+      this.renderer.setClearColor(0x000000, 1);
       this.renderer.clear(true, true, true);
-      this.renderer.render(rt.scene, rt.camera);
+      this.renderer.render(this.scene, this.camera);
 
-      composeMaterial.uniforms.baseMap.value = read.texture;
-      composeMaterial.uniforms.layerMap.value = rt.target.texture;
-      composeMaterial.uniforms.opacity.value = rt.opacity;
-      composeMaterial.uniforms.blendMode.value = rt.blend === 'add' ? 1
-        : rt.blend === 'screen' ? 2
-        : rt.blend === 'multiply' ? 3 : 0;
-      this.renderer.setRenderTarget(write);
-      this.renderer.clear(true, false, false);
-      this.renderer.render(this.composeScene, this.composeCam);
-      [read, write] = [write, read];
-    });
+      let read = this.composeA;
+      let write = this.composeB;
+      const composeMaterial = this.composeQuad.material;
+      s.tracks.forEach((track) => {
+        const rt = this.trackRTs.get(track.id);
+        if (!rt?.active) return;
 
-    // Effects, as further passes on the SAME ping-pong the tracks just used.
-    // Until now this pass looked pixelate up by id and folded it into the output
-    // quad, so the other effects in effects/ simply did not exist for the webgl
-    // presets. Each active effect is now a pass, applied in the order the panel
-    // lists them — the same order the 2D path gives PIXI.Container.filters.
-    //
-    // The resolution handed to the shader is the RENDER TARGET's, not the
-    // scene's: during export the whole chain runs supersampled, and an effect
-    // measured in scene pixels would come out proportionally finer in the
-    // exported frame than on screen.
-    const fxCtx = {
-      width: this.width * this.resolution,
-      height: this.height * this.resolution,
-      time: frame / Math.max(1, s.fps),
-    };
-    for (const active of s.effects) {
-      if (!active.enabled) continue;
-      const def = getEffect(active.effectId);
-      if (!def) continue;
-      try {
-        const material = threeMaterialFor(def);
-        applyThreeUniforms(material, def, active.values, fxCtx);
-        material.uniforms.map.value = read.texture;
-        this.fxQuad.material = material;
+        // A layer owns its depth buffer. Z can never leak into another layer.
+        this.renderer.setRenderTarget(rt.target);
+        this.renderer.setClearColor(0x000000, 0);
+        this.renderer.clear(true, true, true);
+        this.renderer.render(rt.scene, rt.camera);
+
+        composeMaterial.uniforms.baseMap.value = read.texture;
+        composeMaterial.uniforms.layerMap.value = rt.target.texture;
+        composeMaterial.uniforms.opacity.value = rt.opacity;
+        composeMaterial.uniforms.blendMode.value = rt.blend === 'add' ? 1
+          : rt.blend === 'screen' ? 2
+          : rt.blend === 'multiply' ? 3 : 0;
         this.renderer.setRenderTarget(write);
         this.renderer.clear(true, false, false);
-        this.renderer.render(this.fxScene, this.composeCam);
+        this.renderer.render(this.composeScene, this.composeCam);
         [read, write] = [write, read];
-      } catch { /* a shader that will not compile must not take the scene down */ }
+      });
+
+      // Effects, as further passes on the SAME ping-pong the tracks just used.
+      // Until now this pass looked pixelate up by id and folded it into the output
+      // quad, so the other effects in effects/ simply did not exist for the webgl
+      // presets. Each active effect is now a pass, applied in the order the panel
+      // lists them — the same order the 2D path gives PIXI.Container.filters.
+      //
+      // The resolution handed to the shader is the RENDER TARGET's, not the
+      // scene's: during export the whole chain runs supersampled, and an effect
+      // measured in scene pixels would come out proportionally finer in the
+      // exported frame than on screen.
+      const fxCtx = {
+        width: this.width * this.resolution,
+        height: this.height * this.resolution,
+        time: frame / Math.max(1, s.fps),
+      };
+      for (const active of s.effects) {
+        if (!active.enabled) continue;
+        const def = getEffect(active.effectId);
+        if (!def) continue;
+        try {
+          const material = threeMaterialFor(def);
+          applyThreeUniforms(material, def, active.values, fxCtx);
+          material.uniforms.map.value = read.texture;
+          this.fxQuad.material = material;
+          this.renderer.setRenderTarget(write);
+          this.renderer.clear(true, false, false);
+          this.renderer.render(this.fxScene, this.composeCam);
+          [read, write] = [write, read];
+        } catch { /* a shader that will not compile must not take the scene down */ }
+      }
+
+      this.outputQuad.material.uniforms.map.value = read.texture;
+      this.renderer.setRenderTarget(null);
+      this.renderer.setClearColor(0x000000, 1);
+      this.renderer.clear(true, true, true);
+      this.renderer.render(this.outputScene, this.composeCam);
+
+      // HUD pass (logo + safe-area) is deliberately outside global pixelation.
+      this.renderer.autoClear = false;
+      this.renderer.render(this.hud, this.hudCam);
+      this.renderer.autoClear = true;
+    } catch {
+      // guard against renderer being disposed mid-frame or WebGL context lost
     }
-
-    this.outputQuad.material.uniforms.map.value = read.texture;
-    this.renderer.setRenderTarget(null);
-    this.renderer.setClearColor(0x000000, 1);
-    this.renderer.clear(true, true, true);
-    this.renderer.render(this.outputScene, this.composeCam);
-
-    // HUD pass (logo + safe-area) is deliberately outside global pixelation.
-    this.renderer.autoClear = false;
-    this.renderer.render(this.hud, this.hudCam);
-    this.renderer.autoClear = true;
   }
 
   captureFrame(frame: number): string {
+    if (!this.ready || this.destroyed || !this.renderer) return '';
     this.renderFrame(frame);
     // JPEG (q0.92) — see the Pixi renderer's captureFrame for the rationale.
-    return this.renderer.domElement.toDataURL('image/jpeg', 0.92);
+    return this.renderer.domElement?.toDataURL?.('image/jpeg', 0.92) ?? '';
   }
 
   extractCanvas(): HTMLCanvasElement {
@@ -1164,6 +1174,7 @@ export class SceneRenderer3D implements IRenderer {
 
   destroy() {
     this.ready = false;
+    this.destroyed = true;
     this.texturePromises.clear();
     this.r3f?.destroy();
     this.r3f = null;

--- a/scripts/verify-gradients.cjs
+++ b/scripts/verify-gradients.cjs
@@ -10,6 +10,7 @@ const {
   MAX_GRADIENT_STOPS,
   createGradientSpec,
   fillPatchForGradient,
+  gradientCss,
   gradientFromFill,
   gradientBlurRadius,
   gradientRenderStops,
@@ -43,19 +44,20 @@ check(crowded.stops.every((stop, i, list) => i === 0 || list[i - 1].position <= 
 const simple = createGradientSpec('#000000', '#ffffff');
 check(colorClose(sampleGradientRGB(simple, 0.5), [128, 128, 128, 255]), 'two-stop midpoint must interpolate');
 const soft = normalizeGradientSpec({ ...simple, softness: 1 });
-check(colorClose(sampleGradientRGB(soft, 0), [13, 13, 13, 255]), 'softness must feather the start of a two-stop ramp');
-check(colorClose(sampleGradientRGB(soft, 1), [242, 242, 242, 255]), 'softness must feather the end of a two-stop ramp');
+check(colorClose(sampleGradientRGB(soft, 0), [0, 0, 0, 255]), 'softness must not alter authored start-stop sampling');
+check(colorClose(sampleGradientRGB(soft, 1), [255, 255, 255, 255]), 'softness must not alter authored end-stop sampling');
 const peaked = normalizeGradientSpec({ ...simple, softness: 1, stops: [
   { id: 'dark-start', color: '#000000', position: 0 },
   { id: 'light-middle', color: '#ffffff', position: 0.5 },
   { id: 'dark-end', color: '#000000', position: 1 },
 ] });
-check(sampleGradientRGB(peaked, 0.5)[0] < 240, 'softness must round a hard interior colour stop');
-check(gradientRenderStops(simple).length === simple.stops.length && gradientRenderStops(soft).length > soft.stops.length, 'native renderers must add smoothing samples only when softness is enabled');
+check(sampleGradientRGB(peaked, 0.5)[0] === 255, 'softness must not bake a rounded interior colour into the document');
+check(gradientRenderStops(simple).length === simple.stops.length && gradientRenderStops(soft).length === soft.stops.length, 'render stops must remain the authored stops at every softness');
 check(normalizeGradientSpec({ ...simple, softness: 7 }).softness === 1, 'softness must clamp to its document range');
 check(gradientBlurRadius(simple, 800, 600) === 0, 'zero softness must not add a spatial blur');
-check(close(gradientBlurRadius(soft, 800, 600), 21, 0.001), 'softness must map to a proportional spatial blur radius');
-check(gradientBlurRadius(soft, 2000, 2000) === 32, 'spatial blur must keep a bounded render cost');
+check(close(gradientBlurRadius(soft, 800, 600), 10.8, 0.001), 'softness must map to a proportional spatial blur radius');
+check(gradientBlurRadius(soft, 4000, 4000) === 64, 'spatial blur must keep a bounded render cost');
+check(gradientCss(soft).includes('#000000 0%') && gradientCss(soft).includes('#ffffff 100%'), 'CSS fallback must preserve authored stops instead of applying softness a second time');
 const mesh = normalizeGradientSpec({ ...soft, mode: 'advanced', shape: 'mesh' });
 check(!colorClose(sampleGradientPoint(mesh, 0.25, 0.5), sampleGradientPoint({ ...mesh, softness: 0 }, 0.25, 0.5), 0.1), 'mesh must honor the shared softness interpolation');
 check(colorClose(sampleGradientPoint({ ...simple, angle: 0 }, 0, 0.5), [0, 0, 0, 255]), 'linear start must use first stop');
@@ -109,6 +111,8 @@ check(/const background = \{[\s\S]*?\.\.\.s\.background,[\s\S]*?\.\.\.rawBackgro
 check(rendererSource.includes("s.background.source === 'color' && s.background.gradient"), '2D renderer must obey the same background source guard as 3D');
 check(rendererSource.includes('if (!gradientCanvas || resized)') && rendererSource.includes('this.gradientCanvas = gradientCanvas'), 'Pixi gradient resolution changes must allocate a fresh canvas texture source');
 check(renderer3dSource.includes('if (!gradientTex || resized)') && renderer3dSource.includes('gradientTex?.dispose()') && renderer3dSource.includes('this.gradientTex = gradientTex'), 'Three gradient resolution changes must recreate and dispose their canvas texture');
+const gradientSource = fs.readFileSync(path.join(root, 'lib', 'gradient.ts'), 'utf8');
+check(gradientSource.includes('const renderSpec = spec.softness > 0 ? { ...spec, softness: 0 } : spec'), 'background rasters must receive exactly one softness pass');
 
 if (failures.length) {
   console.error(`Gradient verification failed (${failures.length}/${assertions})`);


### PR DESCRIPTION
## Summary

- apply background softness exactly once as a spatial Gaussian blur
- preserve authored stop colors in CSS fallbacks and when inserting new stops
- use a resolution-independent radius so Basic, Advanced, 2D, and 3D keep the same apparent softness
- recalibrate the maximum blur to feather transitions without washing out procedural fields

## Problems fixed

The deployed implementation first convolved the color ramp and then blurred the rendered bitmap. This double application shifted endpoint colors, created an oversized dark wedge around conic seams, flattened Warped Field details, and made the result vary between raster budgets. Adding a stop while softness was enabled could also bake a processed color into the gradient document.

Background rasters now paint the authored gradient and receive one post-render blur pass. Point-sampled 3D material fills retain their one-dimensional approximation because they do not have a complete image to post-process.

## Validation

- verified Basic and Advanced gradients in a production build
- verified Conic and Warped Field at Softness 0 and 1
- verified the same Advanced gradient in the 2D and Three.js renderers
- confirmed there are no new browser errors
- `npm test` passes, including 43 gradient assertions
- `npm run build` passes
