### PR TITLE
fix(mockup): speed up project preview loading

### DIFF
--- a/components/EditorShell.tsx
+++ b/components/EditorShell.tsx
@@ -10,6 +10,7 @@ import { modeForSection, sectionFromPathname } from '@/lib/navSections';
 import { capturePoster } from '@/lib/projectPoster';
 import { flushScene, startSceneAutosave } from '@/lib/scenePersist';
 import { flushThreeD, startThreeDAutosave } from '@/lib/three3dPersist';
+import { preloadMockupProject } from '@/lib/mockupPreload';
 import { useHistoryStore } from '@/store/useHistoryStore';
 import { useProjectStore } from '@/store/useProjectStore';
 import { useUIStore } from '@/store/useUIStore';
@@ -144,6 +145,25 @@ export default function EditorShell({ children }: { children?: React.ReactNode }
     if (existing) openProject(existing.id);
     else createProject(`Project ${projects.length + 1}`, wanted);
   }, [activeProjectId, createProject, openProject, projects, projectsBooted, section]);
+
+  // Mockup GLBs can be much larger than the rest of the editor (the XDR is
+  // ~13 MB). Parse the most recent Mockup project's device during an idle turn
+  // in the other sections, so Library → Mockup only has to clone/setup it.
+  useEffect(() => {
+    if (!projectsBooted || section === 'mockup') return;
+    const mockup = projects.find((project) => project.mode === 'mockup');
+    const run = () => { void preloadMockupProject(mockup?.id); };
+    const idleWindow = window as Window & {
+      requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+    if (idleWindow.requestIdleCallback) {
+      const handle = idleWindow.requestIdleCallback(run, { timeout: 500 });
+      return () => idleWindow.cancelIdleCallback?.(handle);
+    }
+    const handle = globalThis.setTimeout(run, 150);
+    return () => globalThis.clearTimeout(handle);
+  }, [projects, projectsBooted, section]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -8,6 +8,7 @@ import LogoMark from '@/components/LogoMark';
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
 import { capturePoster } from '@/lib/projectPoster';
+import { preloadMockupProject } from '@/lib/mockupPreload';
 import { IS_HOSTED_DEPLOYMENT } from '@/lib/deployment';
 import NewsNotifier from './NewsNotifier';
 import UpdateNotifier from './UpdateNotifier';
@@ -39,13 +40,30 @@ export default function IconRail() {
   const [experimentalsOpen, setExperimentalsOpen] = useState(false);
   const experimentalActive = EXPERIMENTAL_NAV.some((item) => item.id === active);
 
-  // Leaving a section is the one moment the stage still shows what the user was
-  // working on AND we know they're about to look elsewhere — so that is when the
-  // project's card picture is grabbed. Reading the id at click time keeps the
-  // rail from re-rendering on every project switch.
+  // Library and Mockup own different project documents. Hydrate the destination
+  // before swapping the panel/stage so Mockup mounts once with its real model,
+  // rather than mounting empty and restarting after EditorShell's effect.
   const leaveSection = (next: NavSectionId) => {
-    if (next !== active) capturePoster(useProjectStore.getState().activeId);
+    const projects = useProjectStore.getState();
+    if (next === 'library' || next === 'mockup') {
+      const wanted = modeForSection(next);
+      const current = projects.projects.find((item) => item.id === projects.activeId);
+      if (current?.mode !== wanted) {
+        const destination = projects.projects.find((item) => item.mode === wanted);
+        if (destination) projects.open(destination.id);
+        else projects.create(`Project ${projects.projects.length + 1}`, wanted);
+      }
+    }
+    // Posters only need to be current when the user is about to see the project
+    // cards. Capturing on every rail hop forced a full synchronous render and
+    // was the main Library → Mockup delay.
+    if (next === 'projects' && next !== active) capturePoster(projects.activeId);
     setNav(next);
+  };
+
+  const warmMockup = () => {
+    const project = useProjectStore.getState().projects.find((item) => item.mode === 'mockup');
+    void preloadMockupProject(project?.id);
   };
 
   // An ACTION, not a nav section — so it never takes the active state. The +
@@ -79,6 +97,8 @@ export default function IconRail() {
             // panel swap on the same frame as the click: the mirror in
             // EditorShell is an effect, which lands a frame later.
             onClick={() => leaveSection(n.id)}
+            onPointerEnter={n.id === 'mockup' ? warmMockup : undefined}
+            onFocus={n.id === 'mockup' ? warmMockup : undefined}
             aria-current={active === n.id ? 'page' : undefined}
             className={`rail-item ${active === n.id ? 'active' : ''}`}
           >

--- a/components/MockupPanel.tsx
+++ b/components/MockupPanel.tsx
@@ -16,7 +16,10 @@ const Chevron = () => (
 // selects it and expands its panel showing the real 3D thumb, finish swatches,
 // and animation preset cards. Same accordion pattern as TemplatesCard.
 export default function MockupPanel() {
-  const modelUrl = use3DStore((s) => (s.models[s.effectId] ?? defaultModelFor(s.effectId)).url);
+  // This panel always edits Mockup, even during the render in which a project
+  // switch is still settling. Reading s.effectId here could briefly point the
+  // device picker at the generic 3D model slot.
+  const modelUrl = use3DStore((s) => (s.models.mockup ?? defaultModelFor('mockup')).url);
   const mockupAnimation = use3DStore((s) => s.mockupAnimation || 'static');
   const setMockupAnimation = use3DStore((s) => s.setMockupAnimation);
 

--- a/components/MockupThumb.tsx
+++ b/components/MockupThumb.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 import { fitAndCenter } from '@/three3d/frame';
-import type { DeviceDef } from '@/three3d/devices';
+import { DEVICES, type DeviceDef } from '@/three3d/devices';
+import { loadGLBSource } from '@/three3d/gltfCache';
+import { asset } from '@/lib/paths';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // SHARED SINGLETON — one renderer, one scene, one camera, one env-map.
@@ -68,22 +69,55 @@ function getShared(): SharedCtx {
   return _ctx;
 }
 
-// ── GLB cache ───────────────────────────────────────────────────────────────
+// ── Thumb-model cache ───────────────────────────────────────────────────────
+// The parsed source is shared with the full-size preview. Thumbs get one clone
+// of their own because fitting/reparenting it must not mutate the source.
 const glbCache = new Map<string, THREE.Group>();
 const glbLoading = new Map<string, Promise<THREE.Group>>();
-const loader = new GLTFLoader();
 
 function loadGLB(url: string): Promise<THREE.Group> {
-  if (glbCache.has(url)) return Promise.resolve(glbCache.get(url)!.clone(true));
-  if (glbLoading.has(url)) return glbLoading.get(url)!.then((g) => g.clone(true));
-  const p = new Promise<THREE.Group>((resolve, reject) => {
-    loader.load(url, (gltf) => {
-      glbCache.set(url, gltf.scene.clone(true));
-      resolve(gltf.scene.clone(true));
-    }, undefined, reject);
+  const resolvedUrl = asset(url);
+  const cached = glbCache.get(resolvedUrl);
+  if (cached) return Promise.resolve(cached);
+  const loading = glbLoading.get(resolvedUrl);
+  if (loading) return loading;
+  const p = loadGLBSource(resolvedUrl).then((source) => {
+    const model = source.clone(true);
+    glbCache.set(resolvedUrl, model);
+    glbLoading.delete(resolvedUrl);
+    return model;
+  }, (error) => {
+    glbLoading.delete(resolvedUrl);
+    throw error;
   });
-  glbLoading.set(url, p);
+  glbLoading.set(resolvedUrl, p);
   return p;
+}
+
+// Passive effects for the sidebar run before the stage effect because the
+// sidebar appears first in the tree. Deferring thumbnail work one idle turn
+// lets the full-size preview register as the first GLB consumer and paint first.
+function scheduleThumbWork(task: () => void): () => void {
+  const idleWindow = window as Window & {
+    requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+  if (idleWindow.requestIdleCallback) {
+    const handle = idleWindow.requestIdleCallback(task, { timeout: 400 });
+    return () => idleWindow.cancelIdleCallback?.(handle);
+  }
+  const handle = window.setTimeout(task, 100);
+  return () => window.clearTimeout(handle);
+}
+
+// Every card for one device uses the same model and only one card can own the
+// shared renderer. Fitting is therefore model setup, not per-thumbnail work.
+const fittedHeight = new WeakMap<THREE.Group, number>();
+
+function ensureFitted(model: THREE.Group, fitHeight: number): void {
+  if (fittedHeight.get(model) === fitHeight) return;
+  fitAndCenter(model, fitHeight);
+  fittedHeight.set(model, fitHeight);
 }
 
 // ── Render with the shared renderer (sets model, camera, draws) ─────────────
@@ -95,7 +129,7 @@ function renderToShared(
 ): void {
   const ctx = getShared();
   while (ctx.pivot.children.length) ctx.pivot.remove(ctx.pivot.children[0]);
-  fitAndCenter(model, fitHeight);
+  ensureFitted(model, fitHeight);
   ctx.pivot.add(model);
   applyPose(ctx, animKey, progress, fitHeight);
   ctx.renderer.render(ctx.scene, ctx.camera);
@@ -123,23 +157,31 @@ function applyPose(ctx: SharedCtx, animKey: string, progress: number, fitHeight:
 }
 
 // ── Snapshot helper (used only once per idle frame) ──────────────────────────
+const snapshotCache = new Map<string, string>();
+let snapshotCanvas: HTMLCanvasElement | null = null;
+
 function takeSnapshot(
   model: THREE.Group,
   fitHeight: number,
   animKey: string,
   progress: number,
+  cacheKey: string,
 ): string {
+  const cached = snapshotCache.get(cacheKey);
+  if (cached) return cached;
   const ctx = getShared();
-  // Temporarily enable preserveDrawingBuffer for toDataURL
   renderToShared(model, fitHeight, animKey, progress);
-  // Read pixels synchronously (WebGL readback)
-  const w = THUMB_W, h = THUMB_H;
-  const offCanvas = document.createElement('canvas');
-  offCanvas.width = w;
-  offCanvas.height = h;
-  const offCtx = offCanvas.getContext('2d')!;
+  // Reuse one readback surface. WebP preserves the transparent backdrop while
+  // encoding much faster and smaller than the PNG previously made 16 times.
+  snapshotCanvas ??= document.createElement('canvas');
+  snapshotCanvas.width = THUMB_W;
+  snapshotCanvas.height = THUMB_H;
+  const offCtx = snapshotCanvas.getContext('2d')!;
+  offCtx.clearRect(0, 0, THUMB_W, THUMB_H);
   offCtx.drawImage(ctx.canvas, 0, 0);
-  return offCanvas.toDataURL('image/png');
+  const src = snapshotCanvas.toDataURL('image/webp', 0.86);
+  snapshotCache.set(cacheKey, src);
+  return src;
 }
 
 // ── Camera pose solver ──────────────────────────────────────────────────────
@@ -182,15 +224,18 @@ export function DeviceThumb({ device }: { device: DeviceDef }) {
 
   useEffect(() => {
     let cancelled = false;
-    loadGLB(device.modelUrl).then((model) => {
-      if (cancelled) return;
-      setSrc(takeSnapshot(model, device.fitHeight, 'static', 0.3));
+    const cancelScheduled = scheduleThumbWork(() => {
+      loadGLB(device.modelUrl).then((model) => {
+        if (cancelled) return;
+        setSrc(takeSnapshot(model, device.fitHeight, 'static', 0.3, `${device.modelUrl}|static|0.3`));
+      });
     });
-    return () => { cancelled = true; };
+    return () => { cancelled = true; cancelScheduled(); };
   }, [device.modelUrl, device.fitHeight]);
 
   return (
     <div className="tpl-thumb" aria-hidden="true">
+      {!src && <div className="tpl-thumb-skeleton" />}
       {src && (
         <img
           src={src} alt="" draggable={false}
@@ -219,8 +264,6 @@ export function MockupAnimThumb({
   const fitHeightRef = useRef(2.077);
 
   const getDeviceInfo = useCallback((): { url: string; fitHeight: number } => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { DEVICES } = require('@/three3d/devices');
     const dk = deviceKey ?? 'iphone17pro';
     const dev = DEVICES.find((d: DeviceDef) => d.key === dk) ?? DEVICES[0];
     return { url: dev?.modelUrl ?? '/3d/devices/iphone17pro-clean.glb', fitHeight: dev?.fitHeight ?? 2.077 };
@@ -231,12 +274,14 @@ export function MockupAnimThumb({
     let cancelled = false;
     const info = getDeviceInfo();
     fitHeightRef.current = info.fitHeight;
-    loadGLB(info.url).then((model) => {
-      if (cancelled) return;
-      modelRef.current = model;
-      setSrc(takeSnapshot(model, info.fitHeight, animKey, 0.3));
+    const cancelScheduled = scheduleThumbWork(() => {
+      loadGLB(info.url).then((model) => {
+        if (cancelled) return;
+        modelRef.current = model;
+        setSrc(takeSnapshot(model, info.fitHeight, animKey, 0.3, `${info.url}|${animKey}|0.3`));
+      });
     });
-    return () => { cancelled = true; };
+    return () => { cancelled = true; cancelScheduled(); };
   }, [animKey, deviceKey, getDeviceInfo]);
 
   // Hover → move shared canvas in, run animation loop. Leave → remove canvas.
@@ -313,6 +358,7 @@ export function MockupAnimThumb({
 
   return (
     <div ref={thumbRef} className={`tpl-thumb ${isPreviewing ? 'is-previewing' : ''}`} aria-hidden="true">
+      {!src && <div className="tpl-thumb-skeleton" />}
       {src && (
         <img
           ref={imgRef} src={src} alt="" draggable={false}

--- a/lib/mockupPreload.ts
+++ b/lib/mockupPreload.ts
@@ -1,0 +1,12 @@
+import { readProjectThreeD } from '@/lib/three3dPersist';
+import { asset } from '@/lib/paths';
+import { DEVICES } from '@/three3d/devices';
+import { loadGLBSource } from '@/three3d/gltfCache';
+
+/** Warm the exact model the next Mockup project will open. */
+export function preloadMockupProject(projectId?: string): Promise<void> {
+  const saved = projectId ? readProjectThreeD(projectId) : null;
+  const url = saved?.models?.mockup?.url ?? DEVICES[0]?.modelUrl;
+  if (!url || url.startsWith('blob:')) return Promise.resolve();
+  return loadGLBSource(asset(url)).then(() => {}, () => {});
+}

--- a/store/useProjectStore.ts
+++ b/store/useProjectStore.ts
@@ -25,6 +25,7 @@ import {
 import { useSceneStore } from './useSceneStore';
 import { reset3DMemory, use3DStore } from './use3DStore';
 import { useHistoryStore } from './useHistoryStore';
+import { DEVICES, selectDevice } from '@/three3d/devices';
 
 // Any switch of the open project drops undo history: undoing across a switch
 // would write one project's scene into another.
@@ -51,6 +52,21 @@ export interface ProjectState {
 
 const DEFAULT_NAME = 'Default project';
 
+/**
+ * A Mockup document must always address the Mockup model slot. Route effects
+ * also keep effectId in sync, but project hydration runs later and can reset it
+ * to the generic 3D default. Enforce the invariant at the document boundary,
+ * then seed legacy/new projects that do not have a device yet.
+ */
+function prepareMockupStudio(): void {
+  let studio = use3DStore.getState();
+  if (studio.effectId !== 'mockup') {
+    studio.setEffect('mockup');
+    studio = use3DStore.getState();
+  }
+  if (!studio.models.mockup?.url && DEVICES[0]) selectDevice(DEVICES[0].key);
+}
+
 // The 3D/Mockup slice lives in its own store under its own storage key, so every
 // switch below has to move it in step with the 2D scene. Restoring it is one
 // helper so the five paths cannot drift, and it RETURNS the slice it loaded so
@@ -65,11 +81,14 @@ function load3D(projectId: string) {
   reset3DMemory();
   if (slice) {
     use3DStore.getState().hydrate3D(slice);
+    prepareMockupStudio();
     // Screen media saves an id, never a blob: url — those are dead after a
     // reload. Rebuild the urls from the stored bytes.
     void use3DStore.getState().rehydrateScreenMedia();
   } else {
-    // reset3DMemory above already established the defaults.
+    // reset3DMemory above established generic defaults; Mockup owns a concrete
+    // device from its first paint rather than an empty, unselectable stage.
+    prepareMockupStudio();
   }
   return slice;
 }
@@ -122,16 +141,17 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
   open: (id) => {
     if (id === get().activeId) return;
-    // The card picture of the project being left, grabbed while its stage is
-    // still the one on screen (see lib/projectPoster: the pixel read is sync).
     const current = get().projects.find((p) => p.id === get().activeId);
-    capturePoster(get().activeId);
+    const next = listProjects().find((p) => p.id === id);
+    if (!next) return;
+    // Switching projects inside one document mode updates the card picture.
+    // A Library ↔ Mockup hop does not need it now and must not synchronously
+    // render a multi-megapixel poster before the destination can mount.
+    if (current?.mode === next.mode) capturePoster(get().activeId);
     flushProject(current);              // only the document this project owns
     setAutosaveTarget(null);            // nothing may be written mid-swap
     setThreeDSaveTarget(null);
     setActiveProject(id);
-    const next = listProjects().find((p) => p.id === id);
-    if (!next) return;
     loadProject(next);
     resetHistory();
     // The "saved 2 min ago" of the project just left says nothing about this
@@ -143,7 +163,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
   create: (name, mode = '2d') => {
     const current = get().projects.find((p) => p.id === get().activeId);
-    capturePoster(get().activeId);
+    if (current?.mode === mode) capturePoster(get().activeId);
     flushProject(current);
     setAutosaveTarget(null);
     setThreeDSaveTarget(null);
@@ -163,6 +183,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     // state a missing slice falls back to — so either way a fresh project opens
     // an empty studio.
     reset3DMemory();
+    if (mode === 'mockup') prepareMockupStudio();
     setThreeDSaveTarget(mode === 'mockup' ? meta.id : null, null);
     if (mode === 'mockup') flushThreeD();
     else flushScene();

--- a/three3d/gltfCache.ts
+++ b/three3d/gltfCache.ts
@@ -1,0 +1,24 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+// Parsing a device GLB is substantially more expensive than fetching it from
+// the browser cache. Keep the untouched parsed scene here so the main preview
+// and its thumbnail sheet share one request and one parse.
+const scenePromises = new Map<string, Promise<THREE.Group>>();
+const loader = new GLTFLoader();
+
+export function loadGLBSource(url: string): Promise<THREE.Group> {
+  const cached = scenePromises.get(url);
+  if (cached) return cached;
+
+  const pending = new Promise<THREE.Group>((resolve, reject) => {
+    loader.load(url, (gltf) => resolve(gltf.scene), undefined, reject);
+  }).catch((error) => {
+    // A transient failure must remain retryable.
+    scenePromises.delete(url);
+    throw error;
+  });
+
+  scenePromises.set(url, pending);
+  return pending;
+}

--- a/three3d/mockup.ts
+++ b/three3d/mockup.ts
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 import type { AsciiOptions } from './ascii';
@@ -12,6 +11,7 @@ import { use3DStore } from '../store/use3DStore';
 import { useSceneStore } from '../store/useSceneStore';
 import { apply3DAnimation } from './animations';
 import { createCardVideo, seekVideoToTime } from '@/lib/videoTexture';
+import { loadGLBSource } from './gltfCache';
 import {
   advancedRasterSize,
   gradientFromFill,
@@ -50,7 +50,9 @@ export function initMockup(
 
   let animId = 0;
   let disposed = false;
+  let exportMode = false;
   let lastCenterNonce = 0;
+  delete canvas.dataset.modelReady;
 
   const scene = new THREE.Scene();
   // near 0.1 / far 100, NOT 0.01 / 1000. These device meshes stack several
@@ -255,17 +257,20 @@ export function initMockup(
     ground.position.y = Math.min(groundBaseY, bottomNow);
   }
 
-  // Render at the scene's EXPORT resolution and let CSS shrink the canvas into
-  // whatever box the stage gives it — the reference tool does exactly
-  // this: measured there, a 1080x1440 backing store displayed in a 416x555 box,
-  // a 2.6x supersample. Sizing the backing store to the element instead (the
-  // obvious reading of "resize") renders 1:1 and is what left this preview soft.
+  // The editor only needs enough pixels for the visible stage. Rendering every
+  // live frame at export resolution made a tall project shade 3M+ pixels at
+  // 60fps while the GLB was still parsing. Keep a modest supersample for a
+  // crisp preview; setCaptureScale still switches to exact export dimensions.
   // `updateStyle = false` keeps the canvas' CSS box owned by the stylesheet.
   let lastW = 0, lastH = 0;
   function resize() {
-    if (!stage.clientWidth || !stage.clientHeight) return;
+    if (exportMode || !stage.clientWidth || !stage.clientHeight) return;
     const st = useSceneStore.getState();
-    const W = Math.max(2, Math.round(st.width)), H = Math.max(2, Math.round(st.height));
+    const displayScale = Math.min(stage.clientWidth / st.width, stage.clientHeight / st.height);
+    const previewDensity = Math.min(2, Math.max(1.5, window.devicePixelRatio || 1));
+    const previewScale = Math.min(1, displayScale * previewDensity);
+    const W = Math.max(2, Math.round(st.width * previewScale));
+    const H = Math.max(2, Math.round(st.height * previewScale));
     if (W === lastW && H === lastH) return;
     lastW = W; lastH = H;
     renderer.setSize(W, H, false);
@@ -852,11 +857,12 @@ export function initMockup(
   scene.add(pivot);
   let model: THREE.Object3D | null = null;
 
-  if (MODEL_URL) new GLTFLoader().load(
-    MODEL_URL,
-    (gltf) => {
+  if (MODEL_URL) loadGLBSource(MODEL_URL).then(
+    (source) => {
       if (disposed) return;
-      model = gltf.scene;
+      // Keep the cached source pristine: this renderer fits the root and owns
+      // per-instance material state, while thumbnail rendering has its own clone.
+      model = source.clone(true);
       const keys: string[] = [];
       model.traverse((o) => {
         const mesh = o as THREE.Mesh;
@@ -915,8 +921,8 @@ export function initMockup(
         restoreScreenMaterial();
       }
       opts.onParts?.(keys);
+      canvas.dataset.modelReady = 'true';
     },
-    () => {},
     (err) => { console.error('GLB load failed:', err); },
   );
 
@@ -1278,6 +1284,15 @@ export function initMockup(
   };
 
   const setCaptureScale = (k: number): void => {
+    // ExportDialog calls endVideoExport before restoring scale 1. At that point
+    // return to the lightweight editor backing store rather than leaving the
+    // live preview at full export cost.
+    if (!exportMode && k === 1) {
+      lastW = 0;
+      lastH = 0;
+      resize();
+      return;
+    }
     const st = useSceneStore.getState();
     renderer.setSize(Math.round(st.width * k), Math.round(st.height * k), false);
     // Invalidate resize()'s cache, or it would see the scene dims unchanged and
@@ -1299,6 +1314,7 @@ export function initMockup(
   // on 'seeked', so it holds with or without a compositor. The sequential pass
   // exists to amortise GOP decodes across MANY card videos; a screen has one.
   const beginVideoExport = async (): Promise<void> => {
+    exportMode = true;
     const v = screenVideoEl;
     if (!v) return;
     screenVideoExporting = true;
@@ -1316,6 +1332,7 @@ export function initMockup(
   };
 
   const endVideoExport = (): void => {
+    exportMode = false;
     screenVideoExporting = false;
     screenVideoSeekTarget = -1;
     if (screenVideoEl) screenVideoEl.loop = true;
@@ -1353,7 +1370,8 @@ export function initMockup(
       if (sm && sm !== screenMesh.userData.origMaterial) sm.dispose();
     }
     for (const m of materials) m.dispose();
-    if (model) model.traverse((o) => { const g = (o as THREE.Mesh).geometry; if (g) g.dispose(); });
+    // Geometry belongs to the shared parsed GLB cache. Materials are cloned
+    // above and disposed here; shared geometry remains reusable on navigation.
     renderer.dispose();
   };
 }


### PR DESCRIPTION
Fixes the Library to Mockup project transition so the correct 3D device mounts on the first pass. Preloads and shares parsed GLB models between the main preview and thumbnails, prioritizes the canvas, adds thumbnail skeletons and caching, and keeps live preview resolution lightweight while preserving full export resolution. Validation: TypeScript, full test suite, and production build.