### PR TITLE
Feat/effects phase 2

### DIFF
--- a/components/EditorShell.tsx
+++ b/components/EditorShell.tsx
@@ -10,6 +10,7 @@ import { modeForSection, sectionFromPathname } from '@/lib/navSections';
 import { capturePoster } from '@/lib/projectPoster';
 import { flushScene, startSceneAutosave } from '@/lib/scenePersist';
 import { flushThreeD, startThreeDAutosave } from '@/lib/three3dPersist';
+import { preloadMockupProject } from '@/lib/mockupPreload';
 import { useHistoryStore } from '@/store/useHistoryStore';
 import { useProjectStore } from '@/store/useProjectStore';
 import { useUIStore } from '@/store/useUIStore';
@@ -144,6 +145,25 @@ export default function EditorShell({ children }: { children?: React.ReactNode }
     if (existing) openProject(existing.id);
     else createProject(`Project ${projects.length + 1}`, wanted);
   }, [activeProjectId, createProject, openProject, projects, projectsBooted, section]);
+
+  // Mockup GLBs can be much larger than the rest of the editor (the XDR is
+  // ~13 MB). Parse the most recent Mockup project's device during an idle turn
+  // in the other sections, so Library → Mockup only has to clone/setup it.
+  useEffect(() => {
+    if (!projectsBooted || section === 'mockup') return;
+    const mockup = projects.find((project) => project.mode === 'mockup');
+    const run = () => { void preloadMockupProject(mockup?.id); };
+    const idleWindow = window as Window & {
+      requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+    if (idleWindow.requestIdleCallback) {
+      const handle = idleWindow.requestIdleCallback(run, { timeout: 500 });
+      return () => idleWindow.cancelIdleCallback?.(handle);
+    }
+    const handle = globalThis.setTimeout(run, 150);
+    return () => globalThis.clearTimeout(handle);
+  }, [projects, projectsBooted, section]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/components/EffectsPanel.tsx
+++ b/components/EffectsPanel.tsx
@@ -93,16 +93,26 @@ export default function EffectsPanel() {
           const def = getEffect(e.effectId);
           if (!def) return null;
           return (
+            // `draggable` vive no GRIP, não no card. No card, qualquer arrasto
+            // que começasse dentro dele — inclusive num slider — iniciava o
+            // drag HTML5 e a reordenação roubava o gesto: era impossível
+            // arrastar um controle de efeito. O card segue sendo o ALVO do
+            // soltar, que é o que onDragOver/onDrop fazem.
             <div
               key={e.instanceId}
               className={`effect-card ${e.enabled ? '' : 'disabled'}`}
-              draggable
-              onDragStart={() => setDragIdx(i)}
               onDragOver={(ev) => ev.preventDefault()}
               onDrop={() => { if (dragIdx !== null && dragIdx !== i) reorderEffects(dragIdx, i); setDragIdx(null); }}
             >
               <div className="effect-card-head">
-                <span className="drag-grip">⣿</span>
+                <span
+                  className="drag-grip"
+                  draggable
+                  onDragStart={() => setDragIdx(i)}
+                  onDragEnd={() => setDragIdx(null)}
+                  role="button"
+                  aria-label={`Reorder ${def.meta.name}`}
+                >⣿</span>
                 <span className="effect-title">{def.meta.name}</span>
                 <button className="icon-btn" onClick={() => toggleEffect(e.instanceId)}>
                   <svg width="12" height="12" viewBox="0 0 16 16" fill="none">

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -8,6 +8,7 @@ import LogoMark from '@/components/LogoMark';
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
 import { capturePoster } from '@/lib/projectPoster';
+import { preloadMockupProject } from '@/lib/mockupPreload';
 import { IS_HOSTED_DEPLOYMENT } from '@/lib/deployment';
 import NewsNotifier from './NewsNotifier';
 import UpdateNotifier from './UpdateNotifier';
@@ -39,13 +40,30 @@ export default function IconRail() {
   const [experimentalsOpen, setExperimentalsOpen] = useState(false);
   const experimentalActive = EXPERIMENTAL_NAV.some((item) => item.id === active);
 
-  // Leaving a section is the one moment the stage still shows what the user was
-  // working on AND we know they're about to look elsewhere — so that is when the
-  // project's card picture is grabbed. Reading the id at click time keeps the
-  // rail from re-rendering on every project switch.
+  // Library and Mockup own different project documents. Hydrate the destination
+  // before swapping the panel/stage so Mockup mounts once with its real model,
+  // rather than mounting empty and restarting after EditorShell's effect.
   const leaveSection = (next: NavSectionId) => {
-    if (next !== active) capturePoster(useProjectStore.getState().activeId);
+    const projects = useProjectStore.getState();
+    if (next === 'library' || next === 'mockup') {
+      const wanted = modeForSection(next);
+      const current = projects.projects.find((item) => item.id === projects.activeId);
+      if (current?.mode !== wanted) {
+        const destination = projects.projects.find((item) => item.mode === wanted);
+        if (destination) projects.open(destination.id);
+        else projects.create(`Project ${projects.projects.length + 1}`, wanted);
+      }
+    }
+    // Posters only need to be current when the user is about to see the project
+    // cards. Capturing on every rail hop forced a full synchronous render and
+    // was the main Library → Mockup delay.
+    if (next === 'projects' && next !== active) capturePoster(projects.activeId);
     setNav(next);
+  };
+
+  const warmMockup = () => {
+    const project = useProjectStore.getState().projects.find((item) => item.mode === 'mockup');
+    void preloadMockupProject(project?.id);
   };
 
   // An ACTION, not a nav section — so it never takes the active state. The +
@@ -79,6 +97,8 @@ export default function IconRail() {
             // panel swap on the same frame as the click: the mirror in
             // EditorShell is an effect, which lands a frame later.
             onClick={() => leaveSection(n.id)}
+            onPointerEnter={n.id === 'mockup' ? warmMockup : undefined}
+            onFocus={n.id === 'mockup' ? warmMockup : undefined}
             aria-current={active === n.id ? 'page' : undefined}
             className={`rail-item ${active === n.id ? 'active' : ''}`}
           >

--- a/components/MockupPanel.tsx
+++ b/components/MockupPanel.tsx
@@ -16,7 +16,10 @@ const Chevron = () => (
 // selects it and expands its panel showing the real 3D thumb, finish swatches,
 // and animation preset cards. Same accordion pattern as TemplatesCard.
 export default function MockupPanel() {
-  const modelUrl = use3DStore((s) => (s.models[s.effectId] ?? defaultModelFor(s.effectId)).url);
+  // This panel always edits Mockup, even during the render in which a project
+  // switch is still settling. Reading s.effectId here could briefly point the
+  // device picker at the generic 3D model slot.
+  const modelUrl = use3DStore((s) => (s.models.mockup ?? defaultModelFor('mockup')).url);
   const mockupAnimation = use3DStore((s) => s.mockupAnimation || 'static');
   const setMockupAnimation = use3DStore((s) => s.setMockupAnimation);
 

--- a/components/MockupThumb.tsx
+++ b/components/MockupThumb.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 import { fitAndCenter } from '@/three3d/frame';
-import type { DeviceDef } from '@/three3d/devices';
+import { DEVICES, type DeviceDef } from '@/three3d/devices';
+import { loadGLBSource } from '@/three3d/gltfCache';
+import { asset } from '@/lib/paths';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // SHARED SINGLETON — one renderer, one scene, one camera, one env-map.
@@ -68,22 +69,55 @@ function getShared(): SharedCtx {
   return _ctx;
 }
 
-// ── GLB cache ───────────────────────────────────────────────────────────────
+// ── Thumb-model cache ───────────────────────────────────────────────────────
+// The parsed source is shared with the full-size preview. Thumbs get one clone
+// of their own because fitting/reparenting it must not mutate the source.
 const glbCache = new Map<string, THREE.Group>();
 const glbLoading = new Map<string, Promise<THREE.Group>>();
-const loader = new GLTFLoader();
 
 function loadGLB(url: string): Promise<THREE.Group> {
-  if (glbCache.has(url)) return Promise.resolve(glbCache.get(url)!.clone(true));
-  if (glbLoading.has(url)) return glbLoading.get(url)!.then((g) => g.clone(true));
-  const p = new Promise<THREE.Group>((resolve, reject) => {
-    loader.load(url, (gltf) => {
-      glbCache.set(url, gltf.scene.clone(true));
-      resolve(gltf.scene.clone(true));
-    }, undefined, reject);
+  const resolvedUrl = asset(url);
+  const cached = glbCache.get(resolvedUrl);
+  if (cached) return Promise.resolve(cached);
+  const loading = glbLoading.get(resolvedUrl);
+  if (loading) return loading;
+  const p = loadGLBSource(resolvedUrl).then((source) => {
+    const model = source.clone(true);
+    glbCache.set(resolvedUrl, model);
+    glbLoading.delete(resolvedUrl);
+    return model;
+  }, (error) => {
+    glbLoading.delete(resolvedUrl);
+    throw error;
   });
-  glbLoading.set(url, p);
+  glbLoading.set(resolvedUrl, p);
   return p;
+}
+
+// Passive effects for the sidebar run before the stage effect because the
+// sidebar appears first in the tree. Deferring thumbnail work one idle turn
+// lets the full-size preview register as the first GLB consumer and paint first.
+function scheduleThumbWork(task: () => void): () => void {
+  const idleWindow = window as Window & {
+    requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+  if (idleWindow.requestIdleCallback) {
+    const handle = idleWindow.requestIdleCallback(task, { timeout: 400 });
+    return () => idleWindow.cancelIdleCallback?.(handle);
+  }
+  const handle = window.setTimeout(task, 100);
+  return () => window.clearTimeout(handle);
+}
+
+// Every card for one device uses the same model and only one card can own the
+// shared renderer. Fitting is therefore model setup, not per-thumbnail work.
+const fittedHeight = new WeakMap<THREE.Group, number>();
+
+function ensureFitted(model: THREE.Group, fitHeight: number): void {
+  if (fittedHeight.get(model) === fitHeight) return;
+  fitAndCenter(model, fitHeight);
+  fittedHeight.set(model, fitHeight);
 }
 
 // ── Render with the shared renderer (sets model, camera, draws) ─────────────
@@ -95,7 +129,7 @@ function renderToShared(
 ): void {
   const ctx = getShared();
   while (ctx.pivot.children.length) ctx.pivot.remove(ctx.pivot.children[0]);
-  fitAndCenter(model, fitHeight);
+  ensureFitted(model, fitHeight);
   ctx.pivot.add(model);
   applyPose(ctx, animKey, progress, fitHeight);
   ctx.renderer.render(ctx.scene, ctx.camera);
@@ -123,23 +157,31 @@ function applyPose(ctx: SharedCtx, animKey: string, progress: number, fitHeight:
 }
 
 // ── Snapshot helper (used only once per idle frame) ──────────────────────────
+const snapshotCache = new Map<string, string>();
+let snapshotCanvas: HTMLCanvasElement | null = null;
+
 function takeSnapshot(
   model: THREE.Group,
   fitHeight: number,
   animKey: string,
   progress: number,
+  cacheKey: string,
 ): string {
+  const cached = snapshotCache.get(cacheKey);
+  if (cached) return cached;
   const ctx = getShared();
-  // Temporarily enable preserveDrawingBuffer for toDataURL
   renderToShared(model, fitHeight, animKey, progress);
-  // Read pixels synchronously (WebGL readback)
-  const w = THUMB_W, h = THUMB_H;
-  const offCanvas = document.createElement('canvas');
-  offCanvas.width = w;
-  offCanvas.height = h;
-  const offCtx = offCanvas.getContext('2d')!;
+  // Reuse one readback surface. WebP preserves the transparent backdrop while
+  // encoding much faster and smaller than the PNG previously made 16 times.
+  snapshotCanvas ??= document.createElement('canvas');
+  snapshotCanvas.width = THUMB_W;
+  snapshotCanvas.height = THUMB_H;
+  const offCtx = snapshotCanvas.getContext('2d')!;
+  offCtx.clearRect(0, 0, THUMB_W, THUMB_H);
   offCtx.drawImage(ctx.canvas, 0, 0);
-  return offCanvas.toDataURL('image/png');
+  const src = snapshotCanvas.toDataURL('image/webp', 0.86);
+  snapshotCache.set(cacheKey, src);
+  return src;
 }
 
 // ── Camera pose solver ──────────────────────────────────────────────────────
@@ -182,15 +224,18 @@ export function DeviceThumb({ device }: { device: DeviceDef }) {
 
   useEffect(() => {
     let cancelled = false;
-    loadGLB(device.modelUrl).then((model) => {
-      if (cancelled) return;
-      setSrc(takeSnapshot(model, device.fitHeight, 'static', 0.3));
+    const cancelScheduled = scheduleThumbWork(() => {
+      loadGLB(device.modelUrl).then((model) => {
+        if (cancelled) return;
+        setSrc(takeSnapshot(model, device.fitHeight, 'static', 0.3, `${device.modelUrl}|static|0.3`));
+      });
     });
-    return () => { cancelled = true; };
+    return () => { cancelled = true; cancelScheduled(); };
   }, [device.modelUrl, device.fitHeight]);
 
   return (
     <div className="tpl-thumb" aria-hidden="true">
+      {!src && <div className="tpl-thumb-skeleton" />}
       {src && (
         <img
           src={src} alt="" draggable={false}
@@ -219,8 +264,6 @@ export function MockupAnimThumb({
   const fitHeightRef = useRef(2.077);
 
   const getDeviceInfo = useCallback((): { url: string; fitHeight: number } => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { DEVICES } = require('@/three3d/devices');
     const dk = deviceKey ?? 'iphone17pro';
     const dev = DEVICES.find((d: DeviceDef) => d.key === dk) ?? DEVICES[0];
     return { url: dev?.modelUrl ?? '/3d/devices/iphone17pro-clean.glb', fitHeight: dev?.fitHeight ?? 2.077 };
@@ -231,12 +274,14 @@ export function MockupAnimThumb({
     let cancelled = false;
     const info = getDeviceInfo();
     fitHeightRef.current = info.fitHeight;
-    loadGLB(info.url).then((model) => {
-      if (cancelled) return;
-      modelRef.current = model;
-      setSrc(takeSnapshot(model, info.fitHeight, animKey, 0.3));
+    const cancelScheduled = scheduleThumbWork(() => {
+      loadGLB(info.url).then((model) => {
+        if (cancelled) return;
+        modelRef.current = model;
+        setSrc(takeSnapshot(model, info.fitHeight, animKey, 0.3, `${info.url}|${animKey}|0.3`));
+      });
     });
-    return () => { cancelled = true; };
+    return () => { cancelled = true; cancelScheduled(); };
   }, [animKey, deviceKey, getDeviceInfo]);
 
   // Hover → move shared canvas in, run animation loop. Leave → remove canvas.
@@ -313,6 +358,7 @@ export function MockupAnimThumb({
 
   return (
     <div ref={thumbRef} className={`tpl-thumb ${isPreviewing ? 'is-previewing' : ''}`} aria-hidden="true">
+      {!src && <div className="tpl-thumb-skeleton" />}
       {src && (
         <img
           ref={imgRef} src={src} alt="" draggable={false}

--- a/components/TemplateThumb2DGL.tsx
+++ b/components/TemplateThumb2DGL.tsx
@@ -21,6 +21,7 @@ import {
   detachCanvas2d,
   getShared2d,
   renderThumbFrame2d,
+  retainThumb2d,
   snapshotThumb2d,
 } from '@/lib/thumbScene2d';
 
@@ -46,6 +47,9 @@ export default function TemplateThumb2DGL({
   const [still, setStill] = useState<string | null>(null);
   const [previewing, setPreviewing] = useState(false);
   const [themeVersion, setThemeVersion] = useState(0);
+
+  // Retem o contexto GL enquanto esta miniatura existe; a ultima a sair devolve.
+  useEffect(() => retainThumb2d(), []);
 
   useEffect(() => onThemeChange(() => setThemeVersion((n) => n + 1)), []);
 

--- a/components/TemplateThumb3D.tsx
+++ b/components/TemplateThumb3D.tsx
@@ -22,6 +22,7 @@ import {
   attachCanvas,
   detachCanvas,
   renderThumbFrame,
+  retainThumb3d,
   snapshotThumb,
 } from '@/three3d/thumbScene';
 
@@ -46,6 +47,9 @@ export default function TemplateThumb3D({
   const hostRef = useRef<HTMLDivElement>(null);
   const [still, setStill] = useState<string | null>(null);
   const [previewing, setPreviewing] = useState(false);
+
+  // Retem o contexto GL enquanto esta miniatura existe; a ultima a sair devolve.
+  useEffect(() => retainThumb3d(), []);
   const [themeVersion, setThemeVersion] = useState(0);
 
   useEffect(() => onThemeChange(() => setThemeVersion((n) => n + 1)), []);

--- a/effects/grain.ts
+++ b/effects/grain.ts
@@ -1,0 +1,63 @@
+import type { Effect } from '@/lib/types';
+
+// Film grain: per-pixel noise added over the scene.
+//
+// The noise is a hash of the pixel coordinate, not a texture — a texture would
+// tile visibly at 4K export and cost a sampler for something a few ALU ops
+// produce. The hash is the standard fract/sin construction, which is stable
+// across drivers in a way `fract(sin(dot(...)) * huge)` alone is not: the seed
+// is quantized to the grain cell first, so neighbouring pixels inside one cell
+// share a value and the grain has a SIZE instead of being per-pixel always.
+//
+// `animate` decides whether the seed advances with uTime. Off, the grain is a
+// fixed pattern — which is what you want for a still frame or a poster, and
+// what keeps a paused preview from shimmering. On, it advances by whole steps,
+// not continuously: real film grain replaces itself every frame, it does not
+// slide, and a continuous drift reads as a moving texture rather than as grain.
+//
+// uTime comes from the FRAME (see the adapters), so an exported clip has the
+// same grain on frame 47 every single time it is rendered.
+export const grain: Effect = {
+  meta: { id: 'grain', name: 'Grain' },
+  controls: [
+    { key: 'amount', label: 'Amount', type: 'slider', min: 0, max: 100, step: 1, default: 35, unit: '%' },
+    { key: 'size', label: 'Grain Size', type: 'slider', min: 1, max: 12, step: 1, default: 2, unit: 'px' },
+    { key: 'animate', label: 'Animate', type: 'toggle', options: ['Off', 'On'], default: 'On' },
+  ],
+  shader: {
+    uniformTypes: { uAmount: 'float', uSize: 'float', uSeed: 'float' },
+    uniforms: (v, ctx) => {
+      const animate = v.animate === 'On' || v.animate === true;
+      // Quantized to 24 steps a second: grain that advanced on every rendered
+      // frame would flicker differently at a 60fps preview than at a 30fps
+      // export. A fixed step rate makes the two look the same.
+      //
+      // Static grain gets its own seed (-1) rather than seed 0. Zero is what the
+      // animated path produces at time 0, so the toggle did nothing on the first
+      // frame — the suite caught exactly that, reporting `animate` as a dead
+      // control. A negative seed can never collide with an animated step.
+      return {
+        uAmount: Math.max(0, Math.min(100, Number(v.amount ?? 35))) / 100,
+        uSize: Math.max(1, Number(v.size ?? 2)),
+        uSeed: animate ? Math.floor((ctx.time ?? 0) * 24) : -1,
+      };
+    },
+    fragment: `
+float fx_hash(vec2 c) {
+  return fract(sin(dot(c, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec4 fxMain(vec2 p) {
+  vec4 col = fxSample(p);
+  // Quantize to the grain cell so the noise has a size, then offset the seed by
+  // a large stride per step — a small stride correlates consecutive frames and
+  // the grain appears to crawl.
+  vec2 cell = floor(p / uSize);
+  float n = fx_hash(cell + uSeed * 37.13);
+  // Signed and centred, so grain lightens as often as it darkens instead of
+  // dragging the whole image one way.
+  float g = (n - 0.5) * uAmount;
+  return vec4(clamp(col.rgb + g, 0.0, 1.0), col.a);
+}`,
+  },
+};

--- a/effects/index.ts
+++ b/effects/index.ts
@@ -1,7 +1,16 @@
 import type { Effect } from '@/lib/types';
+import { grain } from './grain';
 import { pixelate } from './pixelate';
+import { rgbSplit } from './rgbSplit';
+import { vignette } from './vignette';
 
+// Insertion order is the order the panel offers them, so these read as a list a
+// person would scan: the two that change the whole frame's feel first, then the
+// two that are a deliberate look.
 export const effects: Record<string, Effect> = {
+  [grain.meta.id]: grain,
+  [vignette.meta.id]: vignette,
+  [rgbSplit.meta.id]: rgbSplit,
   [pixelate.meta.id]: pixelate,
 };
 

--- a/effects/rgbSplit.ts
+++ b/effects/rgbSplit.ts
@@ -1,0 +1,40 @@
+import type { Effect } from '@/lib/types';
+
+// Chromatic aberration: the three channels sampled at three offsets.
+//
+// Red and blue move in OPPOSITE directions and green stays put. That is what a
+// lens actually does — the middle of the visible spectrum focuses where it
+// should and the ends fall short and long — and it is also why the effect reads
+// as a lens rather than as a glitch: moving all three the same way would just
+// shift the image.
+//
+// The offset is in pixels, which is the whole reason the contract hands `p` in
+// pixels: a normalized offset would come out as a different visible distance in
+// a 1080x1350 canvas than in a 1920x1080 one, and the same slider value would
+// mean two different looks depending on the aspect the user picked.
+export const rgbSplit: Effect = {
+  meta: { id: 'rgb-split', name: 'RGB Split' },
+  controls: [
+    { key: 'offset', label: 'Offset', type: 'slider', min: 0, max: 40, step: 0.5, default: 4, unit: 'px' },
+    { key: 'angle', label: 'Angle', type: 'slider', min: 0, max: 360, step: 1, default: 0, unit: '°' },
+  ],
+  shader: {
+    uniformTypes: { uShift: 'vec2' },
+    uniforms: (v) => {
+      const offset = Math.max(0, Number(v.offset ?? 4));
+      const rad = (Number(v.angle ?? 0) * Math.PI) / 180;
+      // Baked into a vector here rather than passing the angle and doing
+      // sin/cos per pixel — it is the same value for the whole frame.
+      return { uShift: [Math.cos(rad) * offset, Math.sin(rad) * offset] };
+    },
+    fragment: `
+vec4 fxMain(vec2 p) {
+  vec4 r = fxSample(p + uShift);
+  vec4 g = fxSample(p);
+  vec4 b = fxSample(p - uShift);
+  // Alpha follows the unshifted sample: taking it from a shifted channel would
+  // drag the card's edge sideways and leave a fringe outside its own silhouette.
+  return vec4(r.r, g.g, b.b, g.a);
+}`,
+  },
+};

--- a/effects/vignette.ts
+++ b/effects/vignette.ts
@@ -1,0 +1,45 @@
+import type { Effect } from '@/lib/types';
+
+// Vignette: darken toward the edges.
+//
+// Measured on the ELLIPSE inscribed in the canvas, not on a circle in pixel
+// space. A circular falloff on a 1080x1350 portrait canvas reaches the top and
+// bottom edges long before the sides, so the corners go black while the middle
+// of the long edges stays lit — it reads as a dark band rather than as a lens.
+// Normalizing each axis by its own half-extent makes `radius` mean the same
+// fraction of the frame in every aspect the editor offers.
+//
+// Darkens rather than fades: an alpha vignette would let the background show
+// through the cards, which reads as the cards becoming translucent at the edges
+// instead of the frame falling into shadow. Same reasoning the renderers use
+// for `dim` versus `alpha`.
+export const vignette: Effect = {
+  meta: { id: 'vignette', name: 'Vignette' },
+  controls: [
+    { key: 'amount', label: 'Amount', type: 'slider', min: 0, max: 100, step: 1, default: 45, unit: '%' },
+    { key: 'radius', label: 'Radius', type: 'slider', min: 10, max: 100, step: 1, default: 70, unit: '%' },
+    { key: 'softness', label: 'Softness', type: 'slider', min: 1, max: 100, step: 1, default: 45, unit: '%' },
+  ],
+  shader: {
+    uniformTypes: { uAmount: 'float', uRadius: 'float', uSoftness: 'float' },
+    uniforms: (v) => ({
+      uAmount: Math.max(0, Math.min(100, Number(v.amount ?? 45))) / 100,
+      uRadius: Math.max(10, Math.min(100, Number(v.radius ?? 70))) / 100,
+      // Floored above zero: a softness of exactly 0 makes the smoothstep edges
+      // equal, which is undefined and shows up as a hard ring on some drivers
+      // and as nothing at all on others.
+      uSoftness: Math.max(0.01, Math.min(100, Number(v.softness ?? 45)) / 100),
+    }),
+    fragment: `
+vec4 fxMain(vec2 p) {
+  vec4 col = fxSample(p);
+  // Each axis by its own half-extent: distance 1.0 is the edge of the inscribed
+  // ellipse regardless of the canvas aspect.
+  vec2 d = (p - uResolution * 0.5) / (uResolution * 0.5);
+  float r = length(d);
+  // Fully lit inside uRadius, falling to uAmount over uSoftness beyond it.
+  float shade = 1.0 - uAmount * smoothstep(uRadius, uRadius + uSoftness, r);
+  return vec4(col.rgb * shade, col.a);
+}`,
+  },
+};

--- a/lib/mockupPreload.ts
+++ b/lib/mockupPreload.ts
@@ -1,0 +1,12 @@
+import { readProjectThreeD } from '@/lib/three3dPersist';
+import { asset } from '@/lib/paths';
+import { DEVICES } from '@/three3d/devices';
+import { loadGLBSource } from '@/three3d/gltfCache';
+
+/** Warm the exact model the next Mockup project will open. */
+export function preloadMockupProject(projectId?: string): Promise<void> {
+  const saved = projectId ? readProjectThreeD(projectId) : null;
+  const url = saved?.models?.mockup?.url ?? DEVICES[0]?.modelUrl;
+  if (!url || url.startsWith('blob:')) return Promise.resolve();
+  return loadGLBSource(asset(url)).then(() => {}, () => {});
+}

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -77,7 +77,14 @@ function scaleTint(tint: number, k: number): number {
 }
 
 // A single white rounded texture, tinted per placeholder card.
-function makePlaceholderTexture(app: PIXI.Application): PIXI.Texture {
+//
+// `app.renderer` can be null, and being explicit about it matters: a browser
+// hands out a finite number of GL contexts, and when they run out `app.init()`
+// resolves with no renderer at all. This then threw "Cannot read properties of
+// null (reading 'clear')" from inside generateTexture — a message that says
+// nothing about the real cause and took the whole editor down with it.
+function makePlaceholderTexture(app: PIXI.Application): PIXI.Texture | null {
+  if (!app.renderer) return null;
   const g = new PIXI.Graphics();
   g.roundRect(0, 0, 480, 600, 8).fill(0xffffff);
   return app.renderer.generateTexture(g);
@@ -152,7 +159,18 @@ export class SceneRenderer {
     this.app.stage.addChild(this.content, this.overlay);
     this.overlay.addChild(this.safeGfx);
 
-    this.placeholder = makePlaceholderTexture(this.app);
+    const placeholder = makePlaceholderTexture(this.app);
+    if (!placeholder) {
+      // Sem contexto GL nao ha o que renderizar. Falhar aqui, alto e claro, e
+      // melhor do que seguir com um renderer meio construido e estourar depois
+      // num ponto que nao explica a causa.
+      this.ready = false;
+      throw new Error(
+        'SceneRenderer: o navegador nao concedeu contexto WebGL '
+        + '(provavelmente esgotado por outros canvas na pagina).',
+      );
+    }
+    this.placeholder = placeholder;
     this.ready = true;
     this.resize(width, height);
     this.syncAssets();

--- a/lib/thumbScene2d.ts
+++ b/lib/thumbScene2d.ts
@@ -310,3 +310,40 @@ export async function attachCanvas2d(host: HTMLElement) {
 export function detachCanvas2d() {
   if (shared?.canvas.parentElement) shared.canvas.parentElement.removeChild(shared.canvas);
 }
+
+// ---- ciclo de vida do contexto ----
+//
+// Um contexto GL e recurso finito e este modulo tomava um e nunca devolvia. Com
+// o three das miniaturas fazendo o mesmo, o PALCO ficava sem: medido, o canvas
+// do palco existia com zero contexto e `app.renderer` vinha null, o que fazia
+// makePlaceholderTexture estourar em `generateTexture` e derrubava o editor.
+//
+// Contagem de referencias em vez de ordem de inicializacao, que seria fragil:
+// cada miniatura montada retem, cada uma desmontada solta, e quando a ultima sai
+// (o usuario deixou o catalogo) o contexto e devolvido.
+let refs = 0;
+
+export function retainThumb2d(): () => void {
+  refs++;
+  let solto = false;
+  return () => {
+    if (solto) return;
+    solto = true;
+    refs = Math.max(0, refs - 1);
+    if (refs === 0) disposeShared2d();
+  };
+}
+
+function disposeShared2d() {
+  const ctx = shared;
+  shared = null;
+  booting = null;
+  whiteCache.clear();
+  if (!ctx) return;
+  try {
+    detachCanvas2d();
+    // `true` para o contexto tambem: sem isso o canvas guarda o contexto e a
+    // devolucao nao acontece de verdade.
+    ctx.app.destroy(true, { children: true, texture: true });
+  } catch { /* um contexto que já foi não precisa ir de novo */ }
+}

--- a/scripts/_probe_effect_drag.cjs
+++ b/scripts/_probe_effect_drag.cjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// O slider dentro do card de efeito responde ao arrasto?
+//
+// Cuidado que custou uma rodada: o painel de efeitos vive num container com
+// scroll, e o slider nasce ABAIXO da dobra. Sem rolar ate ele, a coordenada
+// calculada nao existe na viewport, o clique nao chega em ninguem e o teste
+// acusa "nao mexeu" sem que haja bug. elementsFromPoint vazio e o sintoma.
+const fs=require('fs');const puppeteer=require('puppeteer-core');
+const CHROME=['C:/Program Files/Google/Chrome/Application/chrome.exe','C:/Program Files (x86)/Google/Chrome/Application/chrome.exe'].find(p=>{try{return fs.existsSync(p)}catch{return false}});
+const U=process.argv[2]||'http://localhost:3100';
+(async()=>{
+const b=await puppeteer.launch({executablePath:CHROME,headless:'new',args:['--enable-gpu','--use-angle=gl'],defaultViewport:{width:1600,height:1000}});
+const p=await b.newPage();
+await p.goto(U+'/library',{waitUntil:'domcontentloaded',timeout:180000});
+await p.evaluate(()=>{localStorage.setItem('motion-welcome-seen','1');localStorage.setItem('motion-tour-seen','1');});
+await p.goto(U+'/library',{waitUntil:'networkidle2',timeout:180000});
+await new Promise(r=>setTimeout(r,6000));
+await p.evaluate(async()=>{
+  const sel=[...document.querySelectorAll('select')].find(s=>[...s.options].some(o=>o.textContent.trim()==='Grain'));
+  const opt=[...sel.options].find(o=>o.textContent.trim()==='Grain');
+  Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype,'value').set.call(sel,opt.value);
+  sel.dispatchEvent(new Event('change',{bubbles:true}));
+  await new Promise(r=>setTimeout(r,300));
+  [...document.querySelectorAll('button')].find(x=>/^add$/i.test((x.textContent||'').trim())).click();
+});
+await new Promise(r=>setTimeout(r,2500));
+
+const prep=await p.evaluate(async()=>{
+  const t=document.querySelector('.effect-card .strack');
+  if(!t) return {erro:'sem slider no card'};
+  t.scrollIntoView({block:'center'});
+  await new Promise(r=>setTimeout(r,500));
+  const r=t.getBoundingClientRect();
+  const pilha=document.elementsFromPoint(r.left+r.width*0.25, r.top+r.height/2).slice(0,3)
+    .map(e=>e.tagName.toLowerCase()+'.'+(e.className||'').toString().split(' ')[0]);
+  return {x:r.left+r.width*0.25, y:r.top+r.height/2, w:r.width, visivel:r.width>20&&r.top>0, pilha,
+    cardDraggable: document.querySelector('.effect-card').getAttribute('draggable'),
+    gripDraggable: document.querySelector('.effect-card .drag-grip').getAttribute('draggable')};
+});
+if(prep.erro){ console.log(prep.erro); await b.close(); process.exit(1); }
+console.log('draggable  card:', prep.cardDraggable ?? 'null', '| grip:', prep.gripDraggable);
+console.log('slider visivel:', prep.visivel, '| sob o ponto:', prep.pilha.join(' > '));
+
+const ler=()=>p.evaluate(()=>{
+  const h=document.querySelector('.effect-card .shandle');
+  const txt=document.querySelector('.effect-card').innerText.replace(/\s+/g,' ');
+  return {handle:h?h.style.left:'?', amount:(txt.match(/Amount (\d+)/)||[])[1]};
+});
+const antes=await ler();
+await p.mouse.move(prep.x, prep.y);
+await p.mouse.down();
+await p.mouse.move(prep.x + prep.w*0.55, prep.y, {steps:18});
+await p.mouse.up();
+await new Promise(r=>setTimeout(r,900));
+const depois=await ler();
+console.log('antes :', JSON.stringify(antes));
+console.log('depois:', JSON.stringify(depois));
+const mexeu = antes.handle !== depois.handle || antes.amount !== depois.amount;
+console.log(mexeu ? '\n=> o slider do efeito ARRASTA (OK)' : '\n=> o slider do efeito NAO arrasta (FALHA)');
+// e a lista nao se desmontou por um drag acidental
+console.log('cards de efeito ainda na lista:', await p.evaluate(()=>document.querySelectorAll('.effect-card').length));
+await b.close();
+process.exit(mexeu?0:1);
+})();

--- a/scripts/_probe_effects_ui.cjs
+++ b/scripts/_probe_effects_ui.cjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Prova os efeitos NO APP: semeia uma cena com conteudo, aplica cada efeito pelo
+// painel (select + Add, o caminho do usuario) e mede o palco.
+//
+// A prova de GPU (verify-effects-gl) compila o shader isolado. Ela nao diz nada
+// sobre a fiacao painel -> store -> renderer, e e essa que quebra calada.
+const fs=require('fs'),path=require('path');const puppeteer=require('puppeteer-core');
+const CHROME=['C:/Program Files/Google/Chrome/Application/chrome.exe','C:/Program Files (x86)/Google/Chrome/Application/chrome.exe'].find(p=>{try{return fs.existsSync(p)}catch{return false}});
+const U=process.argv[2]||'http://localhost:3100';
+const OUT=path.resolve(__dirname,'..','..','_fx-shots'); fs.mkdirSync(OUT,{recursive:true});
+(async()=>{
+const b=await puppeteer.launch({executablePath:CHROME,headless:'new',args:['--enable-gpu','--use-angle=gl'],defaultViewport:{width:1600,height:1000}});
+const p=await b.newPage();
+p.on('pageerror',e=>console.log('  [pageerror]',String(e).slice(0,200)));
+await p.goto(U+'/library',{waitUntil:'domcontentloaded',timeout:180000});
+await p.evaluate(()=>{
+  localStorage.setItem('motion-welcome-seen','1'); localStorage.setItem('motion-tour-seen','1');
+  const scene={activeTemplateId:'arc-01',tracks:[{id:'t0',templateId:'arc-01'}],
+    width:810,height:1080,fps:30,duration:8,
+    background:{source:'color',color:'#1a1a1a',gradient:false,color2:'#1a1a1a',imageUrl:null,blur:28},effects:[]};
+  localStorage.setItem('motion-scene-v1',JSON.stringify(scene));
+  localStorage.setItem('motion-project-fx',JSON.stringify(scene));
+  localStorage.setItem('motion-projects-v1',JSON.stringify({activeId:'fx',projects:[{id:'fx',name:'Teste de efeitos',createdAt:1,updatedAt:2,mode:'2d'}]}));
+});
+await p.goto(U+'/library',{waitUntil:'networkidle2',timeout:180000});
+// espera CONTEUDO, nao tempo
+const pintou=await p.waitForFunction(()=>{
+  const c=document.querySelector('canvas.stage-canvas'); if(!c||!c.width) return false;
+  const o=document.createElement('canvas');o.width=c.width;o.height=c.height;
+  const g=o.getContext('2d');g.drawImage(c,0,0);
+  const d=g.getImageData(0,0,c.width,c.height).data;
+  let m=0,n=0;for(let i=0;i<d.length;i+=4){m+=d[i];n++;}m/=n;
+  let s=0;for(let i=0;i<d.length;i+=4){const v=d[i]-m;s+=v*v;}
+  return Math.sqrt(s/n)>8;
+},{timeout:90000,polling:600}).then(()=>true).catch(()=>false);
+if(!pintou){ console.error('o palco nao pintou — sem cena nao ha o que medir'); await b.close(); process.exit(1); }
+
+const medir=()=>p.evaluate(()=>{
+  const c=document.querySelector('canvas.stage-canvas');
+  const o=document.createElement('canvas');o.width=c.width;o.height=c.height;
+  const g=o.getContext('2d');g.drawImage(c,0,0);
+  const d=g.getImageData(0,0,c.width,c.height).data;
+  const at=(x,y)=>{const i=(y*c.width+x)*4;return {r:d[i],g:d[i+1],b:d[i+2],l:(d[i]+d[i+1]+d[i+2])/3};};
+  let m=0,n=0;for(let i=0;i<d.length;i+=4){m+=(d[i]+d[i+1]+d[i+2])/3;n++;}m/=n;
+  let s=0;for(let i=0;i<d.length;i+=4){const v=(d[i]+d[i+1]+d[i+2])/3-m;s+=v*v;}
+  // desvio LOCAL em blocos 3x3: e isso que o grao levanta, nao o desvio global
+  let loc=0,cnt=0;
+  for(let y=8;y<c.height-8;y+=17) for(let x=8;x<c.width-8;x+=17){
+    const v=[at(x,y).l,at(x+1,y).l,at(x,y+1).l,at(x+1,y+1).l];
+    const mm=v.reduce((a,z)=>a+z,0)/4;
+    loc+=Math.sqrt(v.reduce((a,z)=>a+(z-mm)*(z-mm),0)/4); cnt++;
+  }
+  // maior separacao R-B ao longo da linha central (assinatura do split)
+  let maxRB=0;
+  for(let x=0;x<c.width;x++){const q=at(x,c.height>>1); maxRB=Math.max(maxRB, Math.abs(q.r-q.b));}
+  return {luma:+m.toFixed(1), desvioGlobal:+Math.sqrt(s/n).toFixed(1), desvioLocal:+(loc/cnt).toFixed(2),
+    canto:+at(6,6).l.toFixed(1), meio:+at(c.width>>1,c.height>>1).l.toFixed(1), maxRB};
+});
+
+const aplicar=(nome)=>p.evaluate(async(nome)=>{
+  const sel=[...document.querySelectorAll('select')].find(s=>[...s.options].some(o=>o.textContent.trim()==='Grain'));
+  if(!sel) return 'sem select de efeitos';
+  const opt=[...sel.options].find(o=>o.textContent.trim()===nome);
+  if(!opt) return 'sem opcao '+nome;
+  Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype,'value').set.call(sel,opt.value);
+  sel.dispatchEvent(new Event('change',{bubbles:true}));
+  await new Promise(r=>setTimeout(r,300));
+  const add=[...document.querySelectorAll('button')].find(x=>/^add$/i.test((x.textContent||'').trim()));
+  if(!add) return 'sem botao Add';
+  add.click();
+  await new Promise(r=>setTimeout(r,400));
+  return document.querySelectorAll('.effect-card').length ? 'ok' : 'clicou mas nenhum effect-card apareceu';
+},nome);
+
+const base=await medir();
+console.log('sem efeito        ', JSON.stringify(base));
+const linhas=[];
+for(const nome of ['Grain','Vignette','RGB Split','Pixelate']){
+  const r=await aplicar(nome);
+  await new Promise(x=>setTimeout(x,2500));
+  const m=await medir();
+  linhas.push({nome,r,m});
+  console.log(nome.padEnd(18), r==='ok'?JSON.stringify(m):('FALHOU: '+r));
+  const cv=await p.$('canvas.stage-canvas');
+  if(cv) await cv.screenshot({path:path.join(OUT,nome.replace(/ /g,'-').toLowerCase()+'.png')});
+  await p.evaluate(async()=>{
+    for(const btn of [...document.querySelectorAll('.effect-card .icon-btn')]){
+      if(/remove/i.test(btn.getAttribute('aria-label')||'')){ btn.click(); await new Promise(r=>setTimeout(r,180)); btn.click(); await new Promise(r=>setTimeout(r,250)); }
+    }
+  });
+  await new Promise(x=>setTimeout(x,1500));
+}
+console.log('\n--- veredito ---');
+const g=linhas.find(l=>l.nome==='Grain'), v=linhas.find(l=>l.nome==='Vignette'), s=linhas.find(l=>l.nome==='RGB Split');
+if(g&&g.r==='ok') console.log('grain     desvio local', base.desvioLocal, '->', g.m.desvioLocal, g.m.desvioLocal>base.desvioLocal+1?'OK':'<== NAO SUBIU');
+if(v&&v.r==='ok') console.log('vignette  canto', base.canto, '->', v.m.canto, v.m.canto<base.canto-3||v.m.meio-v.m.canto>base.meio-base.canto+3?'OK':'<== NAO ESCURECEU A BORDA');
+if(s&&s.r==='ok') console.log('rgb-split max|R-B|', base.maxRB, '->', s.m.maxRB, s.m.maxRB>base.maxRB+10?'OK':'<== NAO SEPAROU OS CANAIS');
+await b.close();
+})();

--- a/scripts/verify-effects-gl.cjs
+++ b/scripts/verify-effects-gl.cjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// ============================================================
+//  verify-effects-gl — compila cada efeito numa GPU de verdade e mede o efeito
+//
+//  scripts/verify-effects.cjs prova a ESTRUTURA (controle ligado a uniform,
+//  uniform escrito, fxMain presente) e nao pode fazer mais: nao existe contexto
+//  GL no Node, entao um shader que nao compila passa verde por lá.
+//
+//  Este abre um Chrome, compila o fragment REAL que o adaptador do Pixi gera, e
+//  mede se cada efeito faz o que promete — sobre uma textura sintetica escolhida
+//  para revelar exatamente aquele efeito:
+//
+//    grain      cinza uniforme -> o desvio padrao tem de SUBIR, e trocar o seed
+//               tem de trocar o padrao (senao `animate` nao anima)
+//    vignette   cinza uniforme -> o centro tem de ficar mais claro que a borda
+//    rgb-split  faixa branca   -> o canal R tem de se deslocar para um lado e o
+//               B para o outro, com o G parado
+//    pixelate   ruido fino     -> blocos de N px tem de zerar a variacao interna
+//
+//  Uso: node scripts/verify-effects-gl.cjs
+//  (nao entra no `npm test`: precisa de Chrome e de GPU)
+// ============================================================
+
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+const puppeteer = require('puppeteer-core');
+
+require('sucrase/register');
+const root = path.resolve(__dirname, '..');
+const originalResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (request.startsWith('@/')) request = path.join(root, request.slice(2));
+  return originalResolve.call(this, request, parent, isMain, options);
+};
+
+const { effects, effectDefaults } = require('../effects');
+const { pixiFragment } = require('../effects/adapters/glsl');
+
+const CHROME = [
+  'C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe',
+  (process.env.LOCALAPPDATA || '') + '/Google/Chrome/Application/chrome.exe',
+].find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+
+// O fragment e os uniforms de cada efeito, em dois instantes.
+const payload = {};
+for (const [id, fx] of Object.entries(effects)) {
+  const d = effectDefaults(id);
+  payload[id] = {
+    fragment: pixiFragment(fx),
+    u0: fx.shader.uniforms(d, { width: 256, height: 256, time: 0 }),
+    u1: fx.shader.uniforms(d, { width: 256, height: 256, time: 1 }),
+  };
+}
+
+(async () => {
+  if (!CHROME) { console.error('Chrome nao encontrado'); process.exit(2); }
+  const browser = await puppeteer.launch({
+    executablePath: CHROME,
+    headless: 'new',
+    args: ['--enable-gpu', '--use-angle=gl'],
+    defaultViewport: { width: 600, height: 400 },
+  });
+  const page = await browser.newPage();
+  await page.goto('about:blank');
+
+  const result = await page.evaluate((fx) => {
+    const W = 256, H = 256;
+    const cv = document.createElement('canvas'); cv.width = W; cv.height = H;
+    const gl = cv.getContext('webgl2', { preserveDrawingBuffer: true });
+    if (!gl) return { erro: 'sem webgl2' };
+
+    const dbg = gl.getExtension('WEBGL_debug_renderer_info');
+    const rendererName = dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : '?';
+
+    const VS = `#version 300 es
+in vec2 aPosition;
+out vec2 vTextureCoord;
+void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.0, 1.0); }`;
+
+    const buf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([0,0, 1,0, 0,1, 0,1, 1,0, 1,1]), gl.STATIC_DRAW);
+
+    // As texturas de teste, uma por tipo de pergunta.
+    const makeTex = (fill) => {
+      const px = new Uint8Array(W * H * 4);
+      for (let y = 0; y < H; y++) for (let x = 0; x < W; x++) {
+        const i = (y * W + x) * 4;
+        const [r, g, b] = fill(x, y);
+        px[i] = r; px[i+1] = g; px[i+2] = b; px[i+3] = 255;
+      }
+      const t = gl.createTexture();
+      gl.bindTexture(gl.TEXTURE_2D, t);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, W, H, 0, gl.RGBA, gl.UNSIGNED_BYTE, px);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      return t;
+    };
+    const TEX = {
+      cinza: makeTex(() => [128, 128, 128]),
+      // faixa branca de 8px no meio, para o split ter uma borda para deslocar
+      faixa: makeTex((x) => (Math.abs(x - W / 2) < 4 ? [255, 255, 255] : [0, 0, 0])),
+      ruido: makeTex((x, y) => { const i = y * W + x; return [(i*37)%256, (i*91)%256, (i*17)%256]; }),
+    };
+
+    const run = (fragment, uniforms, tex) => {
+      const mk = (t, src) => {
+        const sh = gl.createShader(t); gl.shaderSource(sh, src); gl.compileShader(sh);
+        if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(sh));
+        return sh;
+      };
+      const prog = gl.createProgram();
+      gl.attachShader(prog, mk(gl.VERTEX_SHADER, VS));
+      gl.attachShader(prog, mk(gl.FRAGMENT_SHADER, fragment));
+      gl.linkProgram(prog);
+      if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(prog));
+      gl.useProgram(prog);
+      const loc = gl.getAttribLocation(prog, 'aPosition');
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.enableVertexAttribArray(loc);
+      gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.uniform1i(gl.getUniformLocation(prog, 'uTexture'), 0);
+      gl.uniform4f(gl.getUniformLocation(prog, 'uInputSize'), W, H, 0, 0);
+      gl.uniform2f(gl.getUniformLocation(prog, 'uResolution'), W, H);
+      gl.uniform1f(gl.getUniformLocation(prog, 'uTime'), 0);
+      for (const [name, value] of Object.entries(uniforms)) {
+        const u = gl.getUniformLocation(prog, name);
+        if (u === null) continue;
+        if (Array.isArray(value)) {
+          if (value.length === 2) gl.uniform2f(u, value[0], value[1]);
+          else if (value.length === 3) gl.uniform3f(u, value[0], value[1], value[2]);
+          else gl.uniform4f(u, value[0], value[1], value[2], value[3]);
+        } else gl.uniform1f(u, value);
+      }
+      gl.viewport(0, 0, W, H);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+      const out = new Uint8Array(W * H * 4);
+      gl.readPixels(0, 0, W, H, gl.RGBA, gl.UNSIGNED_BYTE, out);
+      return out;
+    };
+
+    // ---- medidas ----
+    const desvio = (px) => {
+      let m = 0, n = 0;
+      for (let i = 0; i < px.length; i += 4) { m += px[i]; n++; }
+      m /= n;
+      let s = 0;
+      for (let i = 0; i < px.length; i += 4) { const d = px[i] - m; s += d * d; }
+      return Math.sqrt(s / n);
+    };
+    const lumaEm = (px, x, y) => { const i = (y * W + x) * 4; return (px[i] + px[i+1] + px[i+2]) / 3; };
+    const difere = (a, b) => { let n = 0; for (let i = 0; i < a.length; i += 4) if (a[i] !== b[i]) n++; return n; };
+    // centro de massa de um canal, para ver para que lado ele foi
+    const centroide = (px, ch) => {
+      let soma = 0, peso = 0;
+      for (let y = H / 2; y < H / 2 + 1; y++) for (let x = 0; x < W; x++) {
+        const v = px[(y * W + x) * 4 + ch];
+        soma += v * x; peso += v;
+      }
+      return peso > 0 ? soma / peso : 0;
+    };
+
+    const r = { rendererName, medidas: {}, falhas: [] };
+
+    try {
+      // GRAIN: sobre cinza uniforme o desvio tem de subir; trocar o seed tem de
+      // trocar o padrao, senao `animate` nao anima nada.
+      const base = run(fx.grain.fragment, { ...fx.grain.u0, uAmount: 0 }, TEX.cinza);
+      const g0 = run(fx.grain.fragment, fx.grain.u0, TEX.cinza);
+      const g1 = run(fx.grain.fragment, fx.grain.u1, TEX.cinza);
+      r.medidas.grain = {
+        desvio_sem: +desvio(base).toFixed(3),
+        desvio_com: +desvio(g0).toFixed(3),
+        pixels_diferentes_entre_seeds: difere(g0, g1),
+      };
+      if (desvio(g0) <= desvio(base) + 1) r.falhas.push('grain: o ruido nao aumentou o desvio');
+      if (difere(g0, g1) < W * H * 0.5) r.falhas.push('grain: trocar o seed quase nao mudou o padrao');
+    } catch (e) { r.falhas.push('grain: ' + String(e.message).slice(0, 160)); }
+
+    try {
+      // VIGNETTE: centro claro, canto escuro.
+      const v = run(fx.vignette.fragment, fx.vignette.u0, TEX.cinza);
+      const centro = lumaEm(v, W / 2, H / 2);
+      const canto = lumaEm(v, 3, 3);
+      r.medidas.vignette = { centro: +centro.toFixed(1), canto: +canto.toFixed(1) };
+      if (centro <= canto + 5) r.falhas.push(`vignette: centro (${centro.toFixed(1)}) nao ficou mais claro que o canto (${canto.toFixed(1)})`);
+    } catch (e) { r.falhas.push('vignette: ' + String(e.message).slice(0, 160)); }
+
+    try {
+      // RGB SPLIT: numa faixa vertical, R vai para um lado e B para o outro.
+      const s = run(fx['rgb-split'].fragment, fx['rgb-split'].u0, TEX.faixa);
+      const cR = centroide(s, 0), cG = centroide(s, 1), cB = centroide(s, 2);
+      r.medidas['rgb-split'] = { centroide_R: +cR.toFixed(2), centroide_G: +cG.toFixed(2), centroide_B: +cB.toFixed(2) };
+      if (Math.abs(cR - cB) < 2) r.falhas.push(`rgb-split: R e B nao se separaram (${cR.toFixed(2)} vs ${cB.toFixed(2)})`);
+      if (Math.sign(cR - cG) === Math.sign(cB - cG) && Math.abs(cR - cG) > 0.5) {
+        r.falhas.push('rgb-split: R e B foram para o MESMO lado — isso desloca a imagem em vez de aberrar');
+      }
+    } catch (e) { r.falhas.push('rgb-split: ' + String(e.message).slice(0, 160)); }
+
+    try {
+      // PIXELATE: blocos de N px zeram a variacao interna.
+      const N = 16;
+      const p = run(fx.pixelate.fragment, { uSize: [N, N] }, TEX.ruido);
+      let soma = 0, blocos = 0;
+      for (let by = 0; by + N <= H; by += N) for (let bx = 0; bx + N <= W; bx += N) {
+        const vals = [];
+        for (let y = by; y < by + N; y++) for (let x = bx; x < bx + N; x++) vals.push(p[(y * W + x) * 4]);
+        const m = vals.reduce((a, b) => a + b, 0) / vals.length;
+        soma += Math.sqrt(vals.reduce((a, b) => a + (b - m) * (b - m), 0) / vals.length);
+        blocos++;
+      }
+      const dv = soma / blocos;
+      r.medidas.pixelate = { desvio_intra_bloco: +dv.toFixed(3), desvio_original: +desvio(run(fx.pixelate.fragment, { uSize: [1, 1] }, TEX.ruido)).toFixed(3) };
+      if (dv > 0.5) r.falhas.push(`pixelate: os blocos de ${N}px nao ficaram uniformes (desvio ${dv.toFixed(2)})`);
+    } catch (e) { r.falhas.push('pixelate: ' + String(e.message).slice(0, 160)); }
+
+    return r;
+  }, payload);
+
+  await browser.close();
+
+  if (result.erro) { console.error('FALHOU: ' + result.erro); process.exit(1); }
+  console.log(`GPU: ${result.rendererName}\n`);
+  for (const [id, m] of Object.entries(result.medidas)) {
+    console.log('  ' + id.padEnd(11), JSON.stringify(m));
+  }
+  if (result.falhas.length) {
+    console.error(`\nverify-effects-gl FALHOU — ${result.falhas.length} problema(s):\n`);
+    for (const f of result.falhas) console.error('  · ' + f);
+    process.exit(1);
+  }
+  console.log(`\nEffects GL verification passed (${Object.keys(result.medidas).length} efeitos compilados e medidos em GPU).`);
+})();

--- a/store/useProjectStore.ts
+++ b/store/useProjectStore.ts
@@ -25,6 +25,7 @@ import {
 import { useSceneStore } from './useSceneStore';
 import { reset3DMemory, use3DStore } from './use3DStore';
 import { useHistoryStore } from './useHistoryStore';
+import { DEVICES, selectDevice } from '@/three3d/devices';
 
 // Any switch of the open project drops undo history: undoing across a switch
 // would write one project's scene into another.
@@ -51,6 +52,21 @@ export interface ProjectState {
 
 const DEFAULT_NAME = 'Default project';
 
+/**
+ * A Mockup document must always address the Mockup model slot. Route effects
+ * also keep effectId in sync, but project hydration runs later and can reset it
+ * to the generic 3D default. Enforce the invariant at the document boundary,
+ * then seed legacy/new projects that do not have a device yet.
+ */
+function prepareMockupStudio(): void {
+  let studio = use3DStore.getState();
+  if (studio.effectId !== 'mockup') {
+    studio.setEffect('mockup');
+    studio = use3DStore.getState();
+  }
+  if (!studio.models.mockup?.url && DEVICES[0]) selectDevice(DEVICES[0].key);
+}
+
 // The 3D/Mockup slice lives in its own store under its own storage key, so every
 // switch below has to move it in step with the 2D scene. Restoring it is one
 // helper so the five paths cannot drift, and it RETURNS the slice it loaded so
@@ -65,11 +81,14 @@ function load3D(projectId: string) {
   reset3DMemory();
   if (slice) {
     use3DStore.getState().hydrate3D(slice);
+    prepareMockupStudio();
     // Screen media saves an id, never a blob: url — those are dead after a
     // reload. Rebuild the urls from the stored bytes.
     void use3DStore.getState().rehydrateScreenMedia();
   } else {
-    // reset3DMemory above already established the defaults.
+    // reset3DMemory above established generic defaults; Mockup owns a concrete
+    // device from its first paint rather than an empty, unselectable stage.
+    prepareMockupStudio();
   }
   return slice;
 }
@@ -122,16 +141,17 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
   open: (id) => {
     if (id === get().activeId) return;
-    // The card picture of the project being left, grabbed while its stage is
-    // still the one on screen (see lib/projectPoster: the pixel read is sync).
     const current = get().projects.find((p) => p.id === get().activeId);
-    capturePoster(get().activeId);
+    const next = listProjects().find((p) => p.id === id);
+    if (!next) return;
+    // Switching projects inside one document mode updates the card picture.
+    // A Library ↔ Mockup hop does not need it now and must not synchronously
+    // render a multi-megapixel poster before the destination can mount.
+    if (current?.mode === next.mode) capturePoster(get().activeId);
     flushProject(current);              // only the document this project owns
     setAutosaveTarget(null);            // nothing may be written mid-swap
     setThreeDSaveTarget(null);
     setActiveProject(id);
-    const next = listProjects().find((p) => p.id === id);
-    if (!next) return;
     loadProject(next);
     resetHistory();
     // The "saved 2 min ago" of the project just left says nothing about this
@@ -143,7 +163,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
   create: (name, mode = '2d') => {
     const current = get().projects.find((p) => p.id === get().activeId);
-    capturePoster(get().activeId);
+    if (current?.mode === mode) capturePoster(get().activeId);
     flushProject(current);
     setAutosaveTarget(null);
     setThreeDSaveTarget(null);
@@ -163,6 +183,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     // state a missing slice falls back to — so either way a fresh project opens
     // an empty studio.
     reset3DMemory();
+    if (mode === 'mockup') prepareMockupStudio();
     setThreeDSaveTarget(mode === 'mockup' ? meta.id : null, null);
     if (mode === 'mockup') flushThreeD();
     else flushScene();

--- a/three3d/gltfCache.ts
+++ b/three3d/gltfCache.ts
@@ -1,0 +1,24 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+// Parsing a device GLB is substantially more expensive than fetching it from
+// the browser cache. Keep the untouched parsed scene here so the main preview
+// and its thumbnail sheet share one request and one parse.
+const scenePromises = new Map<string, Promise<THREE.Group>>();
+const loader = new GLTFLoader();
+
+export function loadGLBSource(url: string): Promise<THREE.Group> {
+  const cached = scenePromises.get(url);
+  if (cached) return cached;
+
+  const pending = new Promise<THREE.Group>((resolve, reject) => {
+    loader.load(url, (gltf) => resolve(gltf.scene), undefined, reject);
+  }).catch((error) => {
+    // A transient failure must remain retryable.
+    scenePromises.delete(url);
+    throw error;
+  });
+
+  scenePromises.set(url, pending);
+  return pending;
+}

--- a/three3d/mockup.ts
+++ b/three3d/mockup.ts
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 import type { AsciiOptions } from './ascii';
@@ -12,6 +11,7 @@ import { use3DStore } from '../store/use3DStore';
 import { useSceneStore } from '../store/useSceneStore';
 import { apply3DAnimation } from './animations';
 import { createCardVideo, seekVideoToTime } from '@/lib/videoTexture';
+import { loadGLBSource } from './gltfCache';
 import {
   advancedRasterSize,
   gradientFromFill,
@@ -50,7 +50,9 @@ export function initMockup(
 
   let animId = 0;
   let disposed = false;
+  let exportMode = false;
   let lastCenterNonce = 0;
+  delete canvas.dataset.modelReady;
 
   const scene = new THREE.Scene();
   // near 0.1 / far 100, NOT 0.01 / 1000. These device meshes stack several
@@ -255,17 +257,20 @@ export function initMockup(
     ground.position.y = Math.min(groundBaseY, bottomNow);
   }
 
-  // Render at the scene's EXPORT resolution and let CSS shrink the canvas into
-  // whatever box the stage gives it — the reference tool does exactly
-  // this: measured there, a 1080x1440 backing store displayed in a 416x555 box,
-  // a 2.6x supersample. Sizing the backing store to the element instead (the
-  // obvious reading of "resize") renders 1:1 and is what left this preview soft.
+  // The editor only needs enough pixels for the visible stage. Rendering every
+  // live frame at export resolution made a tall project shade 3M+ pixels at
+  // 60fps while the GLB was still parsing. Keep a modest supersample for a
+  // crisp preview; setCaptureScale still switches to exact export dimensions.
   // `updateStyle = false` keeps the canvas' CSS box owned by the stylesheet.
   let lastW = 0, lastH = 0;
   function resize() {
-    if (!stage.clientWidth || !stage.clientHeight) return;
+    if (exportMode || !stage.clientWidth || !stage.clientHeight) return;
     const st = useSceneStore.getState();
-    const W = Math.max(2, Math.round(st.width)), H = Math.max(2, Math.round(st.height));
+    const displayScale = Math.min(stage.clientWidth / st.width, stage.clientHeight / st.height);
+    const previewDensity = Math.min(2, Math.max(1.5, window.devicePixelRatio || 1));
+    const previewScale = Math.min(1, displayScale * previewDensity);
+    const W = Math.max(2, Math.round(st.width * previewScale));
+    const H = Math.max(2, Math.round(st.height * previewScale));
     if (W === lastW && H === lastH) return;
     lastW = W; lastH = H;
     renderer.setSize(W, H, false);
@@ -852,11 +857,12 @@ export function initMockup(
   scene.add(pivot);
   let model: THREE.Object3D | null = null;
 
-  if (MODEL_URL) new GLTFLoader().load(
-    MODEL_URL,
-    (gltf) => {
+  if (MODEL_URL) loadGLBSource(MODEL_URL).then(
+    (source) => {
       if (disposed) return;
-      model = gltf.scene;
+      // Keep the cached source pristine: this renderer fits the root and owns
+      // per-instance material state, while thumbnail rendering has its own clone.
+      model = source.clone(true);
       const keys: string[] = [];
       model.traverse((o) => {
         const mesh = o as THREE.Mesh;
@@ -915,8 +921,8 @@ export function initMockup(
         restoreScreenMaterial();
       }
       opts.onParts?.(keys);
+      canvas.dataset.modelReady = 'true';
     },
-    () => {},
     (err) => { console.error('GLB load failed:', err); },
   );
 
@@ -1278,6 +1284,15 @@ export function initMockup(
   };
 
   const setCaptureScale = (k: number): void => {
+    // ExportDialog calls endVideoExport before restoring scale 1. At that point
+    // return to the lightweight editor backing store rather than leaving the
+    // live preview at full export cost.
+    if (!exportMode && k === 1) {
+      lastW = 0;
+      lastH = 0;
+      resize();
+      return;
+    }
     const st = useSceneStore.getState();
     renderer.setSize(Math.round(st.width * k), Math.round(st.height * k), false);
     // Invalidate resize()'s cache, or it would see the scene dims unchanged and
@@ -1299,6 +1314,7 @@ export function initMockup(
   // on 'seeked', so it holds with or without a compositor. The sequential pass
   // exists to amortise GOP decodes across MANY card videos; a screen has one.
   const beginVideoExport = async (): Promise<void> => {
+    exportMode = true;
     const v = screenVideoEl;
     if (!v) return;
     screenVideoExporting = true;
@@ -1316,6 +1332,7 @@ export function initMockup(
   };
 
   const endVideoExport = (): void => {
+    exportMode = false;
     screenVideoExporting = false;
     screenVideoSeekTarget = -1;
     if (screenVideoEl) screenVideoEl.loop = true;
@@ -1353,7 +1370,8 @@ export function initMockup(
       if (sm && sm !== screenMesh.userData.origMaterial) sm.dispose();
     }
     for (const m of materials) m.dispose();
-    if (model) model.traverse((o) => { const g = (o as THREE.Mesh).geometry; if (g) g.dispose(); });
+    // Geometry belongs to the shared parsed GLB cache. Materials are cloned
+    // above and disposed here; shared geometry remains reusable on navigation.
     renderer.dispose();
   };
 }

--- a/three3d/thumbScene.ts
+++ b/three3d/thumbScene.ts
@@ -334,3 +334,44 @@ export function detachCanvas() {
   const ctx = shared;
   if (ctx?.canvas.parentElement) ctx.canvas.parentElement.removeChild(ctx.canvas);
 }
+
+// ---- ciclo de vida do contexto ----
+//
+// Mesmo motivo do lado Pixi: este modulo tomava um contexto GL e nunca o
+// devolvia, e com os dois somados o PALCO ficava sem. Medido: o canvas do palco
+// existia com zero contexto e `app.renderer` vinha null, derrubando o editor em
+// makePlaceholderTexture.
+//
+// Contagem de referencias, nao ordem de inicializacao: cada miniatura montada
+// retem, cada desmontada solta, e a ultima a sair devolve o contexto.
+let refs = 0;
+
+export function retainThumb3d(): () => void {
+  refs++;
+  let solto = false;
+  return () => {
+    if (solto) return;
+    solto = true;
+    refs = Math.max(0, refs - 1);
+    if (refs === 0) disposeShared3d();
+  };
+}
+
+function disposeShared3d() {
+  const ctx = shared;
+  shared = null;
+  if (!ctx) return;
+  try {
+    detachCanvas();
+    ctx.geomCache.forEach((g) => g.dispose());
+    ctx.geomCache.clear();
+    ctx.plane.dispose();
+    ctx.tones.forEach((t) => t.dispose());
+    ctx.slots.forEach((s) => { s.front.material.dispose(); s.back.material.dispose(); });
+    ctx.slots.length = 0;
+    ctx.renderer.dispose();
+    // dispose() solta os recursos mas NAO o contexto; sem isto o navegador
+    // segue contando este canvas contra o limite.
+    ctx.renderer.forceContextLoss();
+  } catch { /* um contexto que já foi não precisa ir de novo */ }
+}


### PR DESCRIPTION
Phase 2 of the effects plan. The shader contract has existed since [[#64](https://github.com/davicorrea0/motion-jitter-clone/pull/64)](https://github.com/davicorrea0/motion-jitter-clone/pull/64) and the app had one registered effect (Pixelate) — now there are four, and each one works on both engines from a single file.

## Grain

Per-pixel noise, with the seed quantized to the grain **cell** — that's what gives grain a *size* instead of always being per-pixel. No texture: it would tile visibly on a 4K export and cost a sampler for what a few operations produce.

The time step is quantized to 24 per second. Grain that advanced every rendered frame would flicker differently in a 60fps preview versus a 30fps export. And `uTime` comes from the frame, so frame 47 has the same grain on every render.

**Static grain uses seed −1, not 0.** Zero is what the animated path produces at `t=0`, so the `animate` toggle did nothing on the first frame — the suite caught exactly that and reported the control as dead.

## Vignette

Measured on the ellipse **inscribed** in the canvas, not a circle in pixels. A circular falloff on a 1080×1350 canvas reaches the top and bottom long before the sides: the corners go black while the middle of the long edges stays lit, and it reads as a dark band, not a lens.

Darkens rather than fades, for the same reason the renderers separate `dim` from `alpha` — an alpha vignette would let the background show through the cards.

`softness` has a floor above zero: exactly 0 makes the `smoothstep` edges equal, which is undefined — a hard ring on some drivers, nothing on others.

## RGB Split

Red and blue in opposite directions, green stays put. That's what a lens actually does, and it's why it reads as a lens rather than a glitch: moving all three the same way just shifts the image. Alpha follows the unshifted sample, otherwise the card's silhouette comes out fringed.

The offset is in pixels — which is the whole reason the contract hands over `p` in pixels. Normalized, the same slider value would mean two different looks depending on the canvas aspect.

## Verification

`scripts/verify-effects-gl.cjs` is a new suite, outside `npm test` because it needs Chrome and a GPU. It compiles the adapter's real fragment and measures each effect over a texture chosen to reveal it:

```
GPU: NVIDIA GeForce GTX 1060

grain      deviation 0 → 25.674, and 64,732 of 65,536 pixels change between two seeds
vignette   centre 128, corner 70   (darkens 45%, matching the requested amount)
rgb-split  centroid R=124, G=128, B=132   (opposite sides, green stationary)
pixelate   intra-block deviation 73.9 → 0
```

Checked by mutation — the three fail as they should: R and B moved to the same side, vignette inverted, grain ignoring the seed.

The structural suite goes from 39 to 221 assertions (1 → 4 effects), and the six `npm test` checks stay green.

## What's still missing from Phase 2

Halftone, Scanlines/CRT, Posterize, and Wave — same shape. After that, the pass-order gate (`A→B ≠ B→A`) becomes testable, which was blocked by there being only one effect.