### PR TITLE
Feat/effects halftone posterize scanlines wave (part two)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -101,8 +101,8 @@ input[type=range] {
 }
 
 /* ============================================================
-   LAYOUT — flat white panels, 1px #e5e7eb borders, no gutters.
-   Figma order: rail | templates | canvas | scene | canvas-settings,
+   LAYOUT — separated tool islands on the stage surface.
+   Order: rail | templates | canvas | scene | canvas-settings;
    timeline bar spans the bottom (rail excluded).
    ============================================================ */
 .app {
@@ -111,23 +111,15 @@ input[type=range] {
   --right-col: var(--panel-w);
   height: 100vh;
   display: grid;
-  /* The stage carries a real minimum and the side columns are allowed to shrink.
-     With rigid side columns and a minmax(0, 1fr) stage, the four fixed tracks
-     (64 + 296 + 280 + 280 = 920px) win every tie and the stage is what collapses:
-     measured on a 1024px window, the stage column came out 104px and the canvas
-     8x5. Giving the stage the floor and the panels the give inverts that, and it
-     does so without a media query — so the collapse toggles keep working instead
-     of fighting a rule that forces the columns to zero. */
   grid-template-columns:
     var(--rail-w) minmax(0, var(--templates-col)) minmax(min(320px, 100%), 1fr) minmax(0, var(--controls-col)) minmax(0, var(--right-col));
-  /* `auto` rather than a fixed --bottom-h: the transport row keeps that exact
-     height on its own, and the row grows only when the motion-layer lanes are
-     expanded below it. */
   grid-template-rows: minmax(0, 1fr) auto;
   grid-template-areas:
     "rail templates stage controls right"
     "rail bottom bottom bottom bottom";
-  background: var(--card);
+  gap: 0;
+  padding: 0;
+  background: var(--stage);
   overflow: hidden;
   transition: grid-template-columns 180ms ease;
 }
@@ -143,20 +135,23 @@ input[type=range] {
 
 .card {
   background: var(--card);
-  border-radius: var(--r-card);
+  border-radius: 0px;
   min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
+.app > .card {
+  border: none;
+  border-radius: 0px;
+}
+
 .card-scroll {
   overflow-y: auto;
   flex: 1;
   min-height: 0;
-  /* The inspector is a stack of functional surfaces, not one uninterrupted
-     form. The soft canvas stays visible only in the gutters between groups. */
-  background: var(--card-soft);
+  background: var(--card);
 }
 
 /* ---- section head (eyebrow + optional action) ---- */
@@ -192,21 +187,17 @@ input[type=range] {
   flex: 0 0 auto;
 }
 
-/* A real gutter between functional groups. Arqé makes inspector sections read
-   as distinct surfaces; this keeps our square, neutral visual system while
-   creating the same hierarchy instead of relying on a nearly invisible line. */
 .card-scroll > .hairline {
   width: 100%;
-  height: 12px;
+  height: 1px;
   margin: 0;
-  background: var(--card-soft);
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
+  background: var(--line);
+  border: none;
 }
 
 .card-scroll > .section-head,
 .card-scroll > :first-child > .section-head {
-  padding-top: 20px;
+  padding-top: 16px;
 }
 
 .ctl-hint {
@@ -5673,23 +5664,40 @@ select.field {
   margin-top: 0;
 }
 
-.controls .section-body>.ctl-section {
+.ctl-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-row);
   padding: 0;
 }
 
-.controls .section-body>.ctl-section+.ctl-section {
-  margin-top: 16px;
-  padding-top: 16px;
+.section-body > .ctl-section + .ctl-section,
+.controls .section-body > .ctl-section + .ctl-section {
+  margin-top: 18px;
+  padding-top: 18px;
   border-top: 1px solid var(--line);
 }
 
 .ctl-section-title {
-  margin: 0 0 12px;
+  margin: 0 0 2px;
   color: var(--fg-label);
   font-size: var(--fs-eyebrow);
   font-weight: 650;
-  letter-spacing: .13em;
+  letter-spacing: .12em;
   text-transform: uppercase;
+  line-height: 15px;
+}
+
+/* Standard PNG transparency checkerboard (Photoshop / Figma / After Effects style) */
+.stage-canvas {
+  background-color: #ffffff !important;
+  background-image:
+    linear-gradient(45deg, #cbcbd2 25%, transparent 25%),
+    linear-gradient(-45deg, #cbcbd2 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #cbcbd2 75%),
+    linear-gradient(-45deg, transparent 75%, #cbcbd2 75%) !important;
+  background-size: 20px 20px !important;
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0px !important;
 }
 
 .strack:focus-visible {

--- a/components/BackgroundFill.tsx
+++ b/components/BackgroundFill.tsx
@@ -7,6 +7,7 @@ import FillRow from './FillRow';
 import type { ControlDef } from '@/lib/types';
 import { fillPatchForGradient, gradientFromFill } from '@/lib/gradient';
 
+const BG_ALPHA: ControlDef = { key: 'bg-alpha', label: 'Alpha', type: 'slider', min: 0, max: 100, step: 1, default: 100 };
 const amtDef: ControlDef = { key: 'a', label: 'Texture Amount', type: 'slider', min: 0, max: 100, step: 1, default: 0 };
 const scaleDef: ControlDef = { key: 's', label: 'Texture Scale', type: 'slider', min: 0.5, max: 10, step: 0.1, default: 3 };
 const sunDef: ControlDef = { key: 'sun', label: 'Sunlight', type: 'slider', min: 0, max: 100, step: 1, default: 0 };
@@ -59,6 +60,7 @@ export default function BackgroundFill({ hideTexture }: { hideTexture?: boolean 
           onColor={(which, hex) => setBgFill({ [which]: hex })}
           onGradient={(gradient) => setBgFill(fillPatchForGradient(gradient))}
         />
+        <ControlRow def={BG_ALPHA} value={bgFill.alpha ?? 100} onChange={(v) => setBgFill({ alpha: Number(v) })} />
         {!hideTexture && <ControlRow def={amtDef} value={bgTexAmount} onChange={(v) => setBgTexAmount(v)} />}
         {!hideTexture && <ControlRow def={scaleDef} value={bgTexScale} onChange={(v) => setBgTexScale(v)} />}
         <ControlRow def={sunDef} value={sunIntensity} onChange={(v) => setSunIntensity(v)} />

--- a/components/CanvasPanel.tsx
+++ b/components/CanvasPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useSceneStore, ASPECTS } from '@/store/useSceneStore';
 import { ControlRow } from './Controls';
 import GradientEditor from './GradientEditor';
+import ColorPicker from './ColorPicker';
 import { normalizeGradientSpec } from '@/lib/gradient';
 import type { ControlDef } from '@/lib/types';
 
@@ -39,30 +40,7 @@ export function DimInput({ value, onCommit }: { value: number; onCommit: (v: num
   );
 }
 
-function Collapsible({ title, children, defaultOpen = false, openKey }: {
-  title: string;
-  children: React.ReactNode;
-  defaultOpen?: boolean;
-  openKey?: string;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  useEffect(() => {
-    if (defaultOpen) setOpen(true);
-  }, [defaultOpen, openKey]);
-  return (
-    <div className="collapsible">
-      <button className={`collapsible-head ${open ? 'open' : ''}`} onClick={() => setOpen((o) => !o)}>
-        <span className="c-label">{title}</span>
-        <span className="chev">
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M3.5 2L7 5l-3.5 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" /></svg>
-        </span>
-      </button>
-      {open && <div className="collapsible-body">{children}</div>}
-    </div>
-  );
-}
-
-// `is3DMode` drops Safe area and the Background/Logo/Audio collapsibles — 3D
+// `is3DMode` drops Safe area and the Background/Logo/Audio sections — 3D
 // and Mockup mode have their own BackgroundFill panel and no overlay concept.
 export default function CanvasPanel({ is3DMode = false }: { is3DMode?: boolean } = {}) {
   const aspect = useSceneStore((s) => s.aspect);
@@ -88,147 +66,168 @@ export default function CanvasPanel({ is3DMode = false }: { is3DMode?: boolean }
     || activeTemplateId.startsWith('fan-');
   const backgroundGradient = normalizeGradientSpec(background.gradientSpec, background.color, background.color2);
 
+  const rawAlpha = background.alpha ?? 100;
+  const currentAlpha = (rawAlpha > 0 && rawAlpha <= 1) ? Math.round(rawAlpha * 100) : rawAlpha;
+
   return (
     <>
       <div className="section-head"><span className="eyebrow">Canvas</span></div>
       <div className="section-body">
-        <div className="ctl-row">
-          <label className="ctl-label">Aspect</label>
-          <div className="pills aspect-pills">
-            {Object.keys(ASPECTS).map((a) => (
-              <button key={a} className={`pill ${aspect === a ? 'active' : ''}`} onClick={() => setAspect(a)}>{a}</button>
-            ))}
-            <button className={`pill ${aspect === 'custom' ? 'active' : ''}`} onClick={() => setCustomDims(customW, customH)}>W×H</button>
+        <div className="ctl-section">
+          <div className="ctl-section-title">Dimensions</div>
+          <div className="ctl-row">
+            <label className="ctl-label">Aspect</label>
+            <div className="pills aspect-pills">
+              {Object.keys(ASPECTS).map((a) => (
+                <button key={a} className={`pill ${aspect === a ? 'active' : ''}`} onClick={() => setAspect(a)}>{a}</button>
+              ))}
+              <button className={`pill ${aspect === 'custom' ? 'active' : ''}`} onClick={() => setCustomDims(customW, customH)}>W×H</button>
+            </div>
           </div>
+
+          {aspect === 'custom' && (
+            <>
+              <div className="ctl-row">
+                <label className="ctl-label">Size px</label>
+                <div className="dim-inputs">
+                  <DimInput value={customW} onCommit={(v) => setCustomDims(v, customH)} />
+                  <span className="dim-x">×</span>
+                  <DimInput value={customH} onCommit={(v) => setCustomDims(customW, v)} />
+                </div>
+              </div>
+              <div className="ctl-hint">Preview scales to fit — the exact size applies on export.</div>
+            </>
+          )}
         </div>
 
-        {aspect === 'custom' && (
-          <>
+        <div className="ctl-section">
+          <div className="ctl-section-title">Playback & Framing</div>
+          <div className="ctl-row">
+            <label className="ctl-label">FPS</label>
+            <div className="pills pills-fit">
+              {FPS_OPTIONS.map((f) => (
+                <button
+                  key={f}
+                  type="button"
+                  className={`pill ${fps === f ? 'active' : ''}`}
+                  aria-pressed={fps === f}
+                  onClick={() => setFps(f)}
+                >
+                  {f}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {!is3DMode && (
             <div className="ctl-row">
-              <label className="ctl-label">Size px</label>
-              <div className="dim-inputs">
-                <DimInput value={customW} onCommit={(v) => setCustomDims(v, customH)} />
-                <span className="dim-x">×</span>
-                <DimInput value={customH} onCommit={(v) => setCustomDims(customW, v)} />
+              <label className="ctl-label">Safe area</label>
+              <div className="segmented">
+                <button className={`seg ${!safeArea ? 'active' : ''}`} onClick={() => safeArea && toggleSafeArea()}>Off</button>
+                <button className={`seg ${safeArea ? 'active' : ''}`} onClick={() => !safeArea && toggleSafeArea()}>On</button>
               </div>
             </div>
-            <div className="ctl-hint">Preview scales to fit — the exact size applies on export.</div>
-          </>
-        )}
-
-        <div className="ctl-row">
-          <label className="ctl-label">FPS</label>
-          <div className="pills pills-fit">
-            {FPS_OPTIONS.map((f) => (
-              <button
-                key={f}
-                type="button"
-                className={`pill ${fps === f ? 'active' : ''}`}
-                aria-pressed={fps === f}
-                onClick={() => setFps(f)}
-              >
-                {f}
-              </button>
-            ))}
-          </div>
+          )}
         </div>
 
         {!is3DMode && (
-          <div className="ctl-row">
-            <label className="ctl-label">Safe area</label>
-            <div className="segmented">
-              <button className={`seg ${!safeArea ? 'active' : ''}`} onClick={() => safeArea && toggleSafeArea()}>Off</button>
-              <button className={`seg ${safeArea ? 'active' : ''}`} onClick={() => !safeArea && toggleSafeArea()}>On</button>
+          <div className="ctl-section">
+            <div className="ctl-section-title">Background</div>
+            {isStickerCanvas && (
+              <div className="ctl-hint">The template starts on white. Your background choice is kept when switching presets.</div>
+            )}
+            <div className="ctl-row">
+              <label className="ctl-label">Source</label>
+              <div className="pills">
+                {BG_SOURCES.map((src) => (
+                  <button key={src.id} className={`pill ${background.source === src.id ? 'active' : ''}`} onClick={() => setBackground({ source: src.id })}>{src.label}</button>
+                ))}
+              </div>
             </div>
+
+            {background.source === 'color' && (
+              <>
+                <div className="ctl-row">
+                  <label className="ctl-label">Fill</label>
+                  <div className="segmented">
+                    <button className={`seg ${!background.gradient ? 'active' : ''}`} onClick={() => setBackground({ gradient: false })}>Solid</button>
+                    <button className={`seg ${background.gradient ? 'active' : ''}`} onClick={() => setBackground({ source: 'color', gradient: true, gradientSpec: backgroundGradient })}>Gradient</button>
+                  </div>
+                </div>
+                {!background.gradient && (
+                  <div className="ctl-row">
+                    <label className="ctl-label">Colour</label>
+                    <ColorPicker
+                      color={background.color}
+                      alpha={currentAlpha}
+                      showAlpha={true}
+                      onChange={(hex, a) => setBackground({ color: hex, alpha: a })}
+                    />
+                  </div>
+                )}
+                {background.gradient && (
+                  <>
+                    <GradientEditor value={backgroundGradient} onChange={(gradientSpec) => setBackground({ source: 'color', gradient: true, gradientSpec })} />
+                    <ControlRow def={BG_ALPHA} value={currentAlpha} onChange={(v) => setBackground({ alpha: Number(v) })} />
+                  </>
+                )}
+              </>
+            )}
+
+            {background.source === 'image' && (
+              <>
+                <div className="ctl-row">
+                  <label className="ctl-label">Image</label>
+                  <label className="upload">
+                    <input type="file" accept="image/*" onChange={(e) => { const f = e.target.files?.[0]; if (f) setBackground({ imageUrl: URL.createObjectURL(f) }); }} />
+                    <span>{background.imageUrl ? 'Replace…' : 'Upload…'}</span>
+                  </label>
+                </div>
+                <ControlRow def={{ key: 'bgblur', label: 'Blur', type: 'slider', min: 0, max: 100, step: 1, default: 28 }} value={background.blur} onChange={(v) => setBackground({ blur: Number(v) })} />
+                <ControlRow def={BG_ALPHA} value={currentAlpha} onChange={(v) => setBackground({ alpha: Number(v) })} />
+              </>
+            )}
+
+            {background.source === 'card' && (
+              <>
+                <div className="ctl-hint">Reflects the featured card — moves with animation.</div>
+                <ControlRow def={{ key: 'bgblur', label: 'Blur', type: 'slider', min: 0, max: 100, step: 1, default: 28 }} value={background.blur} onChange={(v) => setBackground({ blur: Number(v) })} />
+                <ControlRow def={BG_ALPHA} value={currentAlpha} onChange={(v) => setBackground({ alpha: Number(v) })} />
+              </>
+            )}
           </div>
         )}
-      </div>
 
-      {!is3DMode && (
-        <>
-          <div className="hairline" />
-          <div className="section-body" style={{ paddingTop: 4 }}>
-            <Collapsible title="Background" defaultOpen={isStickerCanvas} openKey={activeTemplateId}>
-              {isStickerCanvas && (
-                <div className="ctl-hint">The template starts on white. Your background choice is kept when switching Spinner, Sticker or Poster presets.</div>
-              )}
+        {!is3DMode && (
+          <div className="ctl-section">
+            <div className="ctl-section-title">Overlays</div>
+            <div className="ctl-row">
+              <label className="ctl-label">Logo</label>
+              <label className="upload">
+                <input type="file" accept="image/*" onChange={(e) => { const f = e.target.files?.[0]; if (f) setLogo({ url: URL.createObjectURL(f) }); }} />
+                <span>{logo.url ? 'Replace logo…' : 'Upload logo…'}</span>
+              </label>
+            </div>
+            {logo.url && (
               <div className="ctl-row">
-                <label className="ctl-label">Source</label>
-                <div className="pills">
-                  {BG_SOURCES.map((src) => (
-                    <button key={src.id} className={`pill ${background.source === src.id ? 'active' : ''}`} onClick={() => setBackground({ source: src.id })}>{src.label}</button>
-                  ))}
-                </div>
-              </div>
-
-              {background.source === 'color' && (
-                <>
-                  <div className="ctl-row">
-                    <label className="ctl-label">Fill</label>
-                    <div className="segmented">
-                      <button className={`seg ${!background.gradient ? 'active' : ''}`} onClick={() => setBackground({ gradient: false })}>Solid</button>
-                      <button className={`seg ${background.gradient ? 'active' : ''}`} onClick={() => setBackground({ source: 'color', gradient: true, gradientSpec: backgroundGradient })}>Gradient</button>
-                    </div>
-                  </div>
-                  {!background.gradient && <ControlRow def={{ key: 'bgc', label: 'Colour', type: 'color', default: '' }} value={background.color} onChange={(v) => setBackground({ color: v })} />}
-                  {background.gradient && <GradientEditor value={backgroundGradient} onChange={(gradientSpec) => setBackground({ source: 'color', gradient: true, gradientSpec })} />}
-                  <ControlRow def={BG_ALPHA} value={background.alpha ?? 100} onChange={(v) => setBackground({ alpha: Number(v) })} />
-                </>
-              )}
-
-              {background.source === 'image' && (
-                <>
-                  <div className="ctl-row">
-                    <label className="ctl-label">Image</label>
-                    <label className="upload">
-                      <input type="file" accept="image/*" onChange={(e) => { const f = e.target.files?.[0]; if (f) setBackground({ imageUrl: URL.createObjectURL(f) }); }} />
-                      <span>{background.imageUrl ? 'Replace…' : 'Upload…'}</span>
-                    </label>
-                  </div>
-                  <ControlRow def={{ key: 'bgblur', label: 'Blur', type: 'slider', min: 0, max: 100, step: 1, default: 28 }} value={background.blur} onChange={(v) => setBackground({ blur: Number(v) })} />
-                  <ControlRow def={BG_ALPHA} value={background.alpha ?? 100} onChange={(v) => setBackground({ alpha: Number(v) })} />
-                </>
-              )}
-
-              {background.source === 'card' && (
-                <>
-                  <div className="ctl-hint">Reflects the featured card — the background moves with the animation.</div>
-                  <ControlRow def={{ key: 'bgblur', label: 'Blur', type: 'slider', min: 0, max: 100, step: 1, default: 28 }} value={background.blur} onChange={(v) => setBackground({ blur: Number(v) })} />
-                  <ControlRow def={BG_ALPHA} value={background.alpha ?? 100} onChange={(v) => setBackground({ alpha: Number(v) })} />
-                </>
-              )}
-            </Collapsible>
-
-            <Collapsible title="Logo">
-              <div className="ctl-row">
-                <label className="ctl-label">Image</label>
-                <label className="upload">
-                  <input type="file" accept="image/*" onChange={(e) => { const f = e.target.files?.[0]; if (f) setLogo({ url: URL.createObjectURL(f) }); }} />
-                  <span>{logo.url ? 'Replace…' : 'Upload…'}</span>
-                </label>
-              </div>
-              <div className="ctl-row">
-                <label className="ctl-label">Corner</label>
+                <label className="ctl-label">Logo corner</label>
                 <div className="pills">
                   {(['tl', 'tr', 'bl', 'br'] as const).map((p) => (
                     <button key={p} className={`pill ${logo.position === p ? 'active' : ''}`} onClick={() => setLogo({ position: p })}>{p.toUpperCase()}</button>
                   ))}
                 </div>
               </div>
-            </Collapsible>
-
-            <Collapsible title="Audio">
-              <div className="ctl-row">
-                <label className="ctl-label">Track</label>
-                <label className="upload">
-                  <input type="file" accept="audio/*" onChange={(e) => { const f = e.target.files?.[0]; if (f) setAudioUrl(URL.createObjectURL(f)); }} />
-                  <span>{audioUrl ? 'Replace…' : 'Upload…'}</span>
-                </label>
-              </div>
-            </Collapsible>
+            )}
+            <div className="ctl-row">
+              <label className="ctl-label">Audio</label>
+              <label className="upload">
+                <input type="file" accept="audio/*" onChange={(e) => { const f = e.target.files?.[0]; if (f) setAudioUrl(URL.createObjectURL(f)); }} />
+                <span>{audioUrl ? 'Replace audio…' : 'Upload audio…'}</span>
+              </label>
+            </div>
           </div>
-        </>
-      )}
+        )}
+      </div>
     </>
   );
 }

--- a/components/ColorPicker.tsx
+++ b/components/ColorPicker.tsx
@@ -1,0 +1,896 @@
+'use client';
+
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+
+// Color conversions
+function clamp(val: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, val));
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  let clean = hex.replace(/^#/, '').trim();
+  if (clean.length === 3) {
+    clean = clean.split('').map((c) => c + c).join('');
+  }
+  if (clean.length < 6) {
+    return { r: 0, g: 0, b: 0 };
+  }
+  const num = parseInt(clean.slice(0, 6), 16);
+  if (isNaN(num)) return { r: 0, g: 0, b: 0 };
+  return {
+    r: (num >> 16) & 255,
+    g: (num >> 8) & 255,
+    b: num & 255,
+  };
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (n: number) => Math.round(clamp(n, 0, 255)).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function rgbToHsv(r: number, g: number, b: number): { h: number; s: number; v: number } {
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  const d = max - min;
+
+  let h = 0;
+  const s = max === 0 ? 0 : d / max;
+  const v = max;
+
+  if (d !== 0) {
+    switch (max) {
+      case rNorm: h = (gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0); break;
+      case gNorm: h = (bNorm - rNorm) / d + 2; break;
+      case bNorm: h = (rNorm - gNorm) / d + 4; break;
+    }
+    h *= 60;
+  }
+  return { h, s, v };
+}
+
+function hsvToRgb(h: number, s: number, v: number): { r: number; g: number; b: number } {
+  const hNorm = (h % 360) / 60;
+  const c = v * s;
+  const x = c * (1 - Math.abs((hNorm % 2) - 1));
+  const m = v - c;
+
+  let r = 0, g = 0, b = 0;
+  if (hNorm >= 0 && hNorm < 1) { r = c; g = x; b = 0; }
+  else if (hNorm >= 1 && hNorm < 2) { r = x; g = c; b = 0; }
+  else if (hNorm >= 2 && hNorm < 3) { r = 0; g = c; b = x; }
+  else if (hNorm >= 3 && hNorm < 4) { r = 0; g = x; b = c; }
+  else if (hNorm >= 4 && hNorm < 5) { r = x; g = 0; b = c; }
+  else if (hNorm >= 5 && hNorm < 6) { r = c; g = 0; b = x; }
+
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255),
+  };
+}
+
+function rgbToHsl(r: number, g: number, b: number): { h: number; s: number; l: number } {
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  const d = max - min;
+  const l = (max + min) / 2;
+
+  let h = 0;
+  let s = 0;
+
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rNorm: h = (gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0); break;
+      case gNorm: h = (bNorm - rNorm) / d + 2; break;
+      case bNorm: h = (rNorm - gNorm) / d + 4; break;
+    }
+    h *= 60;
+  }
+  return {
+    h: Math.round(h),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+}
+
+function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  const hNorm = ((h % 360) + 360) % 360 / 360;
+  const sNorm = clamp(s, 0, 100) / 100;
+  const lNorm = clamp(l, 0, 100) / 100;
+
+  if (sNorm === 0) {
+    const val = Math.round(lNorm * 255);
+    return { r: val, g: val, b: val };
+  }
+
+  const hue2rgb = (p: number, q: number, t: number) => {
+    let val = t;
+    if (val < 0) val += 1;
+    if (val > 1) val -= 1;
+    if (val < 1 / 6) return p + (q - p) * 6 * val;
+    if (val < 1 / 2) return q;
+    if (val < 2 / 3) return p + (q - p) * (2 / 3 - val) * 6;
+    return p;
+  };
+
+  const q = lNorm < 0.5 ? lNorm * (1 + sNorm) : lNorm + sNorm - lNorm * sNorm;
+  const p = 2 * lNorm - q;
+
+  return {
+    r: Math.round(hue2rgb(p, q, hNorm + 1 / 3) * 255),
+    g: Math.round(hue2rgb(p, q, hNorm) * 255),
+    b: Math.round(hue2rgb(p, q, hNorm - 1 / 3) * 255),
+  };
+}
+
+export interface ColorPickerProps {
+  color: string;
+  alpha?: number; // 0..100
+  showAlpha?: boolean;
+  onChange: (color: string, alpha: number) => void;
+}
+
+export default function ColorPicker({
+  color = '#000000',
+  alpha = 100,
+  showAlpha = true,
+  onChange,
+}: ColorPickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const formatMenuRef = useRef<HTMLDivElement>(null);
+
+  // Format mode: HEX | RGB | HSL
+  const [format, setFormat] = useState<'HEX' | 'RGB' | 'HSL'>('HEX');
+  const [formatMenuOpen, setFormatMenuOpen] = useState(false);
+
+  // Normalize initial values
+  const currentAlpha = (alpha !== undefined && alpha > 0 && alpha <= 1) ? Math.round(alpha * 100) : (alpha ?? 100);
+
+  // Local color states
+  const rgb = hexToRgb(color);
+  const initialHsv = rgbToHsv(rgb.r, rgb.g, rgb.b);
+  const initialHsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+  const [hsv, setHsv] = useState(initialHsv);
+  const [hexInput, setHexInput] = useState(color);
+  const [rInput, setRInput] = useState(String(rgb.r));
+  const [gInput, setGInput] = useState(String(rgb.g));
+  const [bInput, setBInput] = useState(String(rgb.b));
+  const [hInput, setHInput] = useState(String(initialHsl.h));
+  const [sInput, setSInput] = useState(String(initialHsl.s));
+  const [lInput, setLInput] = useState(String(initialHsl.l));
+  const [alphaInput, setAlphaInput] = useState(String(Math.round(currentAlpha)));
+
+  // Synchronize when external color changes while closed
+  useEffect(() => {
+    if (!isOpen) {
+      const { r, g, b } = hexToRgb(color);
+      setHsv(rgbToHsv(r, g, b));
+      const hslVal = rgbToHsl(r, g, b);
+      setHexInput(color);
+      setRInput(String(r));
+      setGInput(String(g));
+      setBInput(String(b));
+      setHInput(String(hslVal.h));
+      setSInput(String(hslVal.s));
+      setLInput(String(hslVal.l));
+      setAlphaInput(String(Math.round(currentAlpha)));
+    }
+  }, [color, currentAlpha, isOpen]);
+
+  // Close when clicking outside
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (formatMenuRef.current && !formatMenuRef.current.contains(e.target as Node)) {
+        setFormatMenuOpen(false);
+      }
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node) &&
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+        setFormatMenuOpen(false);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (formatMenuOpen) setFormatMenuOpen(false);
+        else setIsOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', handleClickOutside);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, formatMenuOpen]);
+
+  const updateColorFromHsv = useCallback((newHsv: { h: number; s: number; v: number }, newAlpha = currentAlpha) => {
+    setHsv(newHsv);
+    const { r, g, b } = hsvToRgb(newHsv.h, newHsv.s, newHsv.v);
+    const hex = rgbToHex(r, g, b);
+    const hslVal = rgbToHsl(r, g, b);
+    setHexInput(hex);
+    setRInput(String(r));
+    setGInput(String(g));
+    setBInput(String(b));
+    setHInput(String(hslVal.h));
+    setSInput(String(hslVal.s));
+    setLInput(String(hslVal.l));
+    setAlphaInput(String(Math.round(newAlpha)));
+    onChange(hex, newAlpha);
+  }, [currentAlpha, onChange]);
+
+  // Saturation / Value dragging
+  const svAreaRef = useRef<HTMLDivElement>(null);
+  const handleSvPointer = useCallback((e: PointerEvent | React.PointerEvent) => {
+    if (!svAreaRef.current) return;
+    const rect = svAreaRef.current.getBoundingClientRect();
+    const x = clamp((e.clientX - rect.left) / rect.width, 0, 1);
+    const y = clamp((e.clientY - rect.top) / rect.height, 0, 1);
+    updateColorFromHsv({
+      h: hsv.h,
+      s: x,
+      v: 1 - y,
+    });
+  }, [hsv.h, updateColorFromHsv]);
+
+  const onPointerDownSv = (e: React.PointerEvent) => {
+    e.preventDefault();
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    handleSvPointer(e);
+    const onMove = (ev: PointerEvent) => handleSvPointer(ev);
+    const onUp = (ev: PointerEvent) => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
+  // Hue slider dragging
+  const hueAreaRef = useRef<HTMLDivElement>(null);
+  const handleHuePointer = useCallback((e: PointerEvent | React.PointerEvent) => {
+    if (!hueAreaRef.current) return;
+    const rect = hueAreaRef.current.getBoundingClientRect();
+    const x = clamp((e.clientX - rect.left) / rect.width, 0, 1);
+    const h = Math.round(x * 360) % 360;
+    updateColorFromHsv({
+      h,
+      s: hsv.s,
+      v: hsv.v,
+    });
+  }, [hsv.s, hsv.v, updateColorFromHsv]);
+
+  const onPointerDownHue = (e: React.PointerEvent) => {
+    e.preventDefault();
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    handleHuePointer(e);
+    const onMove = (ev: PointerEvent) => handleHuePointer(ev);
+    const onUp = (ev: PointerEvent) => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
+  // Alpha slider dragging
+  const alphaAreaRef = useRef<HTMLDivElement>(null);
+  const handleAlphaPointer = useCallback((e: PointerEvent | React.PointerEvent) => {
+    if (!alphaAreaRef.current) return;
+    const rect = alphaAreaRef.current.getBoundingClientRect();
+    const x = clamp((e.clientX - rect.left) / rect.width, 0, 1);
+    const a = Math.round(x * 100);
+    setAlphaInput(String(a));
+    const { r, g, b } = hsvToRgb(hsv.h, hsv.s, hsv.v);
+    onChange(rgbToHex(r, g, b), a);
+  }, [hsv, onChange]);
+
+  const onPointerDownAlpha = (e: React.PointerEvent) => {
+    e.preventDefault();
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    handleAlphaPointer(e);
+    const onMove = (ev: PointerEvent) => handleAlphaPointer(ev);
+    const onUp = (ev: PointerEvent) => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
+  // Commit hex input typing
+  const commitHex = (val: string) => {
+    const clean = val.trim().startsWith('#') ? val.trim() : `#${val.trim()}`;
+    const { r, g, b } = hexToRgb(clean);
+    const newHsv = rgbToHsv(r, g, b);
+    setHsv(newHsv);
+    const hex = rgbToHex(r, g, b);
+    const hslVal = rgbToHsl(r, g, b);
+    setHexInput(hex);
+    setRInput(String(r));
+    setGInput(String(g));
+    setBInput(String(b));
+    setHInput(String(hslVal.h));
+    setSInput(String(hslVal.s));
+    setLInput(String(hslVal.l));
+    onChange(hex, currentAlpha);
+  };
+
+  // Commit RGB input typing
+  const commitRgb = (rVal: string, gVal: string, bVal: string) => {
+    const r = clamp(Math.round(Number(rVal) || 0), 0, 255);
+    const g = clamp(Math.round(Number(gVal) || 0), 0, 255);
+    const b = clamp(Math.round(Number(bVal) || 0), 0, 255);
+    setRInput(String(r));
+    setGInput(String(g));
+    setBInput(String(b));
+    const newHsv = rgbToHsv(r, g, b);
+    setHsv(newHsv);
+    const hex = rgbToHex(r, g, b);
+    const hslVal = rgbToHsl(r, g, b);
+    setHexInput(hex);
+    setHInput(String(hslVal.h));
+    setSInput(String(hslVal.s));
+    setLInput(String(hslVal.l));
+    onChange(hex, currentAlpha);
+  };
+
+  // Commit HSL input typing
+  const commitHsl = (hVal: string, sVal: string, lVal: string) => {
+    const h = ((Math.round(Number(hVal) || 0) % 360) + 360) % 360;
+    const s = clamp(Math.round(Number(sVal) || 0), 0, 100);
+    const l = clamp(Math.round(Number(lVal) || 0), 0, 100);
+    setHInput(String(h));
+    setSInput(String(s));
+    setLInput(String(l));
+    const { r, g, b } = hslToRgb(h, s, l);
+    setRInput(String(r));
+    setGInput(String(g));
+    setBInput(String(b));
+    const newHsv = rgbToHsv(r, g, b);
+    setHsv(newHsv);
+    const hex = rgbToHex(r, g, b);
+    setHexInput(hex);
+    onChange(hex, currentAlpha);
+  };
+
+  // Commit alpha input typing
+  const commitAlpha = (val: string) => {
+    const num = Number(val.replace('%', '').trim());
+    if (Number.isFinite(num)) {
+      const a = Math.round(clamp(num, 0, 100));
+      setAlphaInput(String(a));
+      onChange(color, a);
+    } else {
+      setAlphaInput(String(Math.round(currentAlpha)));
+    }
+  };
+
+  // Current RGB for gradients
+  const { r: curR, g: curG, b: curB } = hsvToRgb(hsv.h, hsv.s, hsv.v);
+  const pureHueRgb = hsvToRgb(hsv.h, 1, 1);
+
+  return (
+    <div className="color-picker-root" ref={containerRef} style={{ position: 'relative', width: '100%' }}>
+      {/* Trigger Row */}
+      <div
+        className="color-control-trigger"
+        onClick={() => setIsOpen((prev) => !prev)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          background: 'var(--card-inset)',
+          height: 'var(--ctl-h)',
+          padding: '0 10px 0 6px',
+          borderRadius: 'var(--r-ctrl)',
+          cursor: 'pointer',
+          border: isOpen ? '1px solid var(--fg)' : '1px solid transparent',
+          userSelect: 'none',
+        }}
+      >
+        {/* Swatch with transparency background */}
+        <div
+          style={{
+            width: 22,
+            height: 22,
+            borderRadius: 'var(--r-ctrl)',
+            position: 'relative',
+            overflow: 'hidden',
+            border: '1px solid var(--line)',
+            flexShrink: 0,
+            backgroundImage: `linear-gradient(45deg, #bbb 25%, transparent 25%), linear-gradient(-45deg, #bbb 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #bbb 75%), linear-gradient(-45deg, transparent 75%, #bbb 75%)`,
+            backgroundSize: '8px 8px',
+            backgroundColor: '#ffffff',
+          }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              backgroundColor: color,
+              opacity: currentAlpha / 100,
+            }}
+          />
+        </div>
+
+        {/* Color Hex and Opacity readout */}
+        <span style={{ fontSize: 'var(--fs-ui)', fontFamily: 'monospace', color: 'var(--fg)', flex: 1 }}>
+          {color.toUpperCase()}
+        </span>
+        {showAlpha && (
+          <span style={{ fontSize: 'var(--fs-ui)', color: 'var(--fg-faint)', fontVariantNumeric: 'tabular-nums' }}>
+            {Math.round(currentAlpha)}%
+          </span>
+        )}
+      </div>
+
+      {/* Color Picker Popover Panel */}
+      {isOpen && (
+        <div
+          ref={popoverRef}
+          className="color-popover"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 4px)',
+            left: 0,
+            right: 0,
+            width: '100%',
+            boxSizing: 'border-box',
+            background: 'var(--card)',
+            color: 'var(--fg)',
+            borderRadius: 'var(--r-card, 0px)',
+            border: '1px solid var(--line)',
+            padding: 8,
+            boxShadow: '0 12px 32px rgba(0, 0, 0, 0.45)',
+            zIndex: 9999,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          {/* 1. 2D Saturation / Value Area (Color Square - Fully Square) */}
+          <div
+            ref={svAreaRef}
+            onPointerDown={onPointerDownSv}
+            style={{
+              height: 125,
+              borderRadius: 'var(--r-ctrl, 0px)',
+              position: 'relative',
+              cursor: 'crosshair',
+              overflow: 'hidden',
+              backgroundColor: `rgb(${pureHueRgb.r}, ${pureHueRgb.g}, ${pureHueRgb.b})`,
+              touchAction: 'none',
+              border: '1px solid var(--line)',
+            }}
+          >
+            {/* White horizontal gradient */}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                background: 'linear-gradient(to right, #ffffff, transparent)',
+              }}
+            />
+            {/* Black vertical gradient */}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                background: 'linear-gradient(to bottom, transparent, #000000)',
+              }}
+            />
+            {/* Draggable Circle Handle */}
+            <div
+              style={{
+                position: 'absolute',
+                left: `${hsv.s * 100}%`,
+                top: `${(1 - hsv.v) * 100}%`,
+                width: 14,
+                height: 14,
+                borderRadius: '50%',
+                border: '2px solid #ffffff',
+                boxShadow: '0 1px 4px rgba(0,0,0,0.7)',
+                backgroundColor: `rgb(${curR}, ${curG}, ${curB})`,
+                transform: 'translate(-50%, -50%)',
+                pointerEvents: 'none',
+              }}
+            />
+          </div>
+
+          {/* 2. Hue Slider */}
+          <div
+            ref={hueAreaRef}
+            onPointerDown={onPointerDownHue}
+            style={{
+              height: 12,
+              borderRadius: 'var(--r-ctrl, 0px)',
+              position: 'relative',
+              cursor: 'pointer',
+              background: 'linear-gradient(to right, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%)',
+              touchAction: 'none',
+              border: '1px solid var(--line)',
+            }}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                left: `${(hsv.h / 360) * 100}%`,
+                top: '50%',
+                width: 14,
+                height: 14,
+                borderRadius: '50%',
+                border: '2px solid #ffffff',
+                boxShadow: '0 1px 4px rgba(0,0,0,0.7)',
+                backgroundColor: `rgb(${pureHueRgb.r}, ${pureHueRgb.g}, ${pureHueRgb.b})`,
+                transform: 'translate(-50%, -50%)',
+                pointerEvents: 'none',
+              }}
+            />
+          </div>
+
+          {/* 3. Alpha Slider (Inside the Color Panel!) */}
+          {showAlpha && (
+            <div
+              ref={alphaAreaRef}
+              onPointerDown={onPointerDownAlpha}
+              style={{
+                height: 12,
+                position: 'relative',
+                cursor: 'pointer',
+                touchAction: 'none',
+                border: '1px solid var(--line)',
+                borderRadius: 'var(--r-ctrl, 0px)',
+              }}
+            >
+              <div
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  borderRadius: 'var(--r-ctrl, 0px)',
+                  overflow: 'hidden',
+                  backgroundImage: `linear-gradient(45deg, #333 25%, transparent 25%), linear-gradient(-45deg, #333 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #333 75%), linear-gradient(-45deg, transparent 75%, #333 75%)`,
+                  backgroundSize: '8px 8px',
+                  backgroundColor: '#222',
+                }}
+              >
+                {/* Alpha gradient ramp */}
+                <div
+                  style={{
+                    position: 'absolute',
+                    inset: 0,
+                    background: `linear-gradient(to right, transparent, rgb(${curR}, ${curG}, ${curB}))`,
+                  }}
+                />
+              </div>
+              <div
+                style={{
+                  position: 'absolute',
+                  left: `${currentAlpha}%`,
+                  top: '50%',
+                  width: 14,
+                  height: 14,
+                  borderRadius: '50%',
+                  border: '2px solid #ffffff',
+                  boxShadow: '0 1px 4px rgba(0,0,0,0.7)',
+                  backgroundColor: `rgba(${curR}, ${curG}, ${curB}, ${currentAlpha / 100})`,
+                  transform: 'translate(-50%, -50%)',
+                  pointerEvents: 'none',
+                }}
+              />
+            </div>
+          )}
+
+          {/* 4. Bottom Controls: Format Selector (HEX / RGB / HSL) + Inputs + Alpha Input */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 2, position: 'relative', width: '100%', boxSizing: 'border-box' }}>
+            {/* Format Dropdown Selector */}
+            <div ref={formatMenuRef} style={{ position: 'relative', flexShrink: 0 }}>
+              <button
+                type="button"
+                onClick={() => setFormatMenuOpen((prev) => !prev)}
+                style={{
+                  fontSize: 10,
+                  fontWeight: 600,
+                  color: 'var(--fg)',
+                  background: 'var(--card-inset)',
+                  padding: '3px 5px',
+                  borderRadius: 'var(--r-ctrl, 0px)',
+                  border: '1px solid var(--line)',
+                  cursor: 'pointer',
+                  userSelect: 'none',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  height: 24,
+                  whiteSpace: 'nowrap',
+                  boxSizing: 'border-box',
+                }}
+                title="Trocar formato de cor (HEX / RGB / HSL)"
+              >
+                {format} <span style={{ fontSize: 8, opacity: 0.7 }}>▾</span>
+              </button>
+
+              {formatMenuOpen && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    bottom: 'calc(100% + 4px)',
+                    left: 0,
+                    background: 'var(--card)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--r-card, 0px)',
+                    boxShadow: '0 8px 24px rgba(0, 0, 0, 0.45)',
+                    zIndex: 10000,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    minWidth: 68,
+                    overflow: 'hidden',
+                  }}
+                >
+                  {(['HEX', 'RGB', 'HSL'] as const).map((fmt) => (
+                    <button
+                      key={fmt}
+                      type="button"
+                      onClick={() => {
+                        setFormat(fmt);
+                        setFormatMenuOpen(false);
+                      }}
+                      style={{
+                        padding: '5px 8px',
+                        fontSize: 10,
+                        fontWeight: format === fmt ? 600 : 400,
+                        textAlign: 'left',
+                        background: format === fmt ? 'var(--card-inset)' : 'transparent',
+                        color: format === fmt ? 'var(--fg)' : 'var(--fg-muted)',
+                        border: 'none',
+                        cursor: 'pointer',
+                        borderRadius: 0,
+                      }}
+                    >
+                      {fmt}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* HEX Input */}
+            {format === 'HEX' && (
+              <input
+                type="text"
+                value={hexInput}
+                onChange={(e) => setHexInput(e.target.value)}
+                onBlur={() => commitHex(hexInput)}
+                onKeyDown={(e) => { if (e.key === 'Enter') commitHex(hexInput); }}
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  height: 24,
+                  background: 'var(--card-inset)',
+                  border: '1px solid var(--line)',
+                  borderRadius: 'var(--r-ctrl, 0px)',
+                  padding: '2px 4px',
+                  fontSize: 11,
+                  fontFamily: 'monospace',
+                  color: 'var(--fg)',
+                  textAlign: 'center',
+                  outline: 'none',
+                  boxSizing: 'border-box',
+                }}
+              />
+            )}
+
+            {/* RGB Inputs (R, G, B) */}
+            {format === 'RGB' && (
+              <div style={{ display: 'flex', gap: 2, flex: 1, minWidth: 0 }}>
+                <input
+                  type="text"
+                  title="Red (0-255)"
+                  placeholder="R"
+                  value={rInput}
+                  onChange={(e) => setRInput(e.target.value)}
+                  onBlur={() => commitRgb(rInput, gInput, bInput)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') commitRgb(rInput, gInput, bInput); }}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    height: 24,
+                    background: 'var(--card-inset)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--r-ctrl, 0px)',
+                    fontSize: 10,
+                    fontFamily: 'monospace',
+                    color: 'var(--fg)',
+                    textAlign: 'center',
+                    outline: 'none',
+                    padding: '2px 0',
+                    boxSizing: 'border-box',
+                  }}
+                />
+                <input
+                  type="text"
+                  title="Green (0-255)"
+                  placeholder="G"
+                  value={gInput}
+                  onChange={(e) => setGInput(e.target.value)}
+                  onBlur={() => commitRgb(rInput, gInput, bInput)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') commitRgb(rInput, gInput, bInput); }}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    height: 24,
+                    background: 'var(--card-inset)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--r-ctrl, 0px)',
+                    fontSize: 10,
+                    fontFamily: 'monospace',
+                    color: 'var(--fg)',
+                    textAlign: 'center',
+                    outline: 'none',
+                    padding: '2px 0',
+                    boxSizing: 'border-box',
+                  }}
+                />
+                <input
+                  type="text"
+                  title="Blue (0-255)"
+                  placeholder="B"
+                  value={bInput}
+                  onChange={(e) => setBInput(e.target.value)}
+                  onBlur={() => commitRgb(rInput, gInput, bInput)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') commitRgb(rInput, gInput, bInput); }}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    height: 24,
+                    background: 'var(--card-inset)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--r-ctrl, 0px)',
+                    fontSize: 10,
+                    fontFamily: 'monospace',
+                    color: 'var(--fg)',
+                    textAlign: 'center',
+                    outline: 'none',
+                    padding: '2px 0',
+                    boxSizing: 'border-box',
+                  }}
+                />
+              </div>
+            )}
+
+            {/* HSL Inputs (H, S, L) */}
+            {format === 'HSL' && (
+              <div style={{ display: 'flex', gap: 2, flex: 1, minWidth: 0 }}>
+                <input
+                  type="text"
+                  title="Hue (0-360°)"
+                  placeholder="H"
+                  value={hInput}
+                  onChange={(e) => setHInput(e.target.value)}
+                  onBlur={() => commitHsl(hInput, sInput, lInput)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') commitHsl(hInput, sInput, lInput); }}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    height: 24,
+                    background: 'var(--card-inset)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--r-ctrl, 0px)',
+                    fontSize: 10,
+                    fontFamily: 'monospace',
+                    color: 'var(--fg)',
+                    textAlign: 'center',
+                    outline: 'none',
+                    padding: '2px 0',
+                    boxSizing: 'border-box',
+                  }}
+                />
+                <input
+                  type="text"
+                  title="Saturation (0-100%)"
+                  placeholder="S"
+                  value={sInput}
+                  onChange={(e) => setSInput(e.target.value)}
+                  onBlur={() => commitHsl(hInput, sInput, lInput)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') commitHsl(hInput, sInput, lInput); }}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    height: 24,
+                    background: 'var(--card-inset)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--r-ctrl, 0px)',
+                    fontSize: 10,
+                    fontFamily: 'monospace',
+                    color: 'var(--fg)',
+                    textAlign: 'center',
+                    outline: 'none',
+                    padding: '2px 0',
+                    boxSizing: 'border-box',
+                  }}
+                />
+                <input
+                  type="text"
+                  title="Lightness (0-100%)"
+                  placeholder="L"
+                  value={lInput}
+                  onChange={(e) => setLInput(e.target.value)}
+                  onBlur={() => commitHsl(hInput, sInput, lInput)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') commitHsl(hInput, sInput, lInput); }}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    height: 24,
+                    background: 'var(--card-inset)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--r-ctrl, 0px)',
+                    fontSize: 10,
+                    fontFamily: 'monospace',
+                    color: 'var(--fg)',
+                    textAlign: 'center',
+                    outline: 'none',
+                    padding: '2px 0',
+                    boxSizing: 'border-box',
+                  }}
+                />
+              </div>
+            )}
+
+            {/* Alpha % Input */}
+            {showAlpha && (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  background: 'var(--card-inset)',
+                  border: '1px solid var(--line)',
+                  borderRadius: 'var(--r-ctrl, 0px)',
+                  padding: '0 2px',
+                  width: 40,
+                  height: 24,
+                  flexShrink: 0,
+                  boxSizing: 'border-box',
+                }}
+              >
+                <input
+                  type="text"
+                  title="Alpha (0-100%)"
+                  value={alphaInput}
+                  onChange={(e) => setAlphaInput(e.target.value)}
+                  onBlur={() => commitAlpha(alphaInput)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') commitAlpha(alphaInput); }}
+                  style={{
+                    width: '100%',
+                    background: 'none',
+                    border: 'none',
+                    fontSize: 10,
+                    color: 'var(--fg)',
+                    textAlign: 'center',
+                    outline: 'none',
+                    padding: 0,
+                  }}
+                />
+                <span style={{ fontSize: 9, color: 'var(--fg-muted)', userSelect: 'none' }}>%</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -4,6 +4,9 @@ import { useEffect, useRef, useState } from 'react';
 import type { ControlDef } from '@/lib/types';
 import MobileSheet from './MobileSheet';
 import { useMobileInteractions } from './MobileInteractions';
+import ColorPicker from './ColorPicker';
+
+export { ColorPicker };
 
 // grows with what is typed, so nothing clips and nothing floats in empty box
 const fieldWidth = (text: string) => `calc(${Math.min(8, Math.max(3, text.length))}ch + 14px)`;
@@ -331,10 +334,35 @@ function DirectionControl({ def, value, onChange }: RowProps) {
 
 function ColorControl({ value, onChange }: { value: any; onChange: (v: any) => void }) {
   return (
-    <div className="color">
-      <input type="color" value={value} onChange={(e) => onChange(e.target.value)} />
-      <input className="field" type="text" value={value} onChange={(e) => onChange(e.target.value)} />
-    </div>
+    <ColorPicker
+      color={value || '#000000'}
+      showAlpha={false}
+      onChange={(hex) => onChange(hex)}
+    />
+  );
+}
+
+export function ColorWithOpacityControl({
+  color,
+  opacity = 100,
+  onChangeColor,
+  onChangeOpacity,
+}: {
+  color: string;
+  opacity?: number;
+  onChangeColor: (hex: string) => void;
+  onChangeOpacity?: (opacity: number) => void;
+}) {
+  return (
+    <ColorPicker
+      color={color || '#000000'}
+      alpha={opacity}
+      showAlpha={Boolean(onChangeOpacity)}
+      onChange={(hex, a) => {
+        onChangeColor(hex);
+        if (onChangeOpacity) onChangeOpacity(a);
+      }}
+    />
   );
 }
 

--- a/components/GradientEditor.tsx
+++ b/components/GradientEditor.tsx
@@ -73,30 +73,19 @@ function presetSpec(current: GradientSpec, preset: (typeof PRESETS)[number]): Gr
   });
 }
 
-function StopColor({ stop, onColor }: { stop: GradientStop; onColor: (color: string) => void }) {
-  const [text, setText] = useState(stop.color.slice(1));
-  useEffect(() => setText(stop.color.slice(1)), [stop.color]);
-  const commit = () => {
-    if (/^[0-9a-f]{6}$/i.test(text)) onColor(`#${text}`);
-    else setText(stop.color.slice(1));
-  };
+import ColorPicker from './ColorPicker';
+
+function StopColor({ stop, onColor }: { stop: GradientStop; onColor: (color: string, opacity: number) => void }) {
+  const currentAlpha = Math.round((stop.opacity ?? 1) * 100);
   return (
     <div className="ctl-row">
       <label className="ctl-label">Colour</label>
-      <div className="ctl-input">
-        <div className="color gradient-stop-color">
-          <input type="color" aria-label="Stop colour" value={stop.color} onChange={(e) => onColor(e.target.value)} />
-          <input
-            className="field"
-            aria-label="Stop hex"
-            value={`#${text}`}
-            maxLength={7}
-            onChange={(e) => setText(e.target.value.replace(/^#/, ''))}
-            onBlur={commit}
-            onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
-          />
-        </div>
-      </div>
+      <ColorPicker
+        color={stop.color}
+        alpha={currentAlpha}
+        showAlpha={true}
+        onChange={(hex, a) => onColor(hex, Math.max(0, Math.min(1, a / 100)))}
+      />
     </div>
   );
 }
@@ -119,7 +108,9 @@ export default function GradientEditor({ value, onChange, showMapping = false }:
   const addStopAt = (position: number) => {
     if (stops.length >= MAX_GRADIENT_STOPS) return;
     const pos = clamp(position);
-    const stop = { id: nextStopId(), position: pos, color: rgbHex(sampleGradientRGB(spec, pos)), opacity: 1 };
+    const sample = sampleGradientRGB(spec, pos);
+    const opacity = sample[3] != null ? Math.max(0, Math.min(1, Math.round((sample[3] / 255) * 100) / 100)) : 1;
+    const stop = { id: nextStopId(), position: pos, color: rgbHex(sample), opacity };
     setSelectedId(stop.id);
     emit({ stops: [...spec.stops, stop] });
   };
@@ -190,24 +181,51 @@ export default function GradientEditor({ value, onChange, showMapping = false }:
           style={{ background: gradientCss({ ...spec, mode: 'basic', shape: spec.shape === 'radial' ? 'radial' : 'linear' }) }}
           onPointerDown={(e) => { if (e.target === e.currentTarget) addStopAt(barPosition(e.clientX)); }}
         >
-          {stops.map((stop) => (
-            <button
-              key={stop.id}
-              type="button"
-              className={`gradient-stop ${selected?.id === stop.id ? 'selected' : ''}`}
-              style={{ left: `${stop.position * 100}%`, background: stop.color }}
-              aria-label={`Colour stop ${Math.round(stop.position * 100)}%`}
-              onClick={(e) => { e.stopPropagation(); setSelectedId(stop.id); }}
-              onPointerDown={(e) => {
-                e.stopPropagation();
-                setSelectedId(stop.id);
-                e.currentTarget.setPointerCapture(e.pointerId);
-              }}
-              onPointerMove={(e) => {
-                if (e.currentTarget.hasPointerCapture(e.pointerId)) replaceStop(stop.id, { position: barPosition(e.clientX) });
-              }}
-            />
-          ))}
+          {stops.map((stop) => {
+            const stopAlpha = stop.opacity ?? 1;
+            return (
+              <button
+                key={stop.id}
+                type="button"
+                className={`gradient-stop ${selected?.id === stop.id ? 'selected' : ''}`}
+                style={{
+                  left: `${stop.position * 100}%`,
+                  overflow: 'hidden',
+                  background: '#222',
+                }}
+                aria-label={`Colour stop ${Math.round(stop.position * 100)}%`}
+                onClick={(e) => { e.stopPropagation(); setSelectedId(stop.id); }}
+                onPointerDown={(e) => {
+                  e.stopPropagation();
+                  setSelectedId(stop.id);
+                  e.currentTarget.setPointerCapture(e.pointerId);
+                }}
+                onPointerMove={(e) => {
+                  if (e.currentTarget.hasPointerCapture(e.pointerId)) replaceStop(stop.id, { position: barPosition(e.clientX) });
+                }}
+              >
+                {/* Checkerboard background for transparent stops */}
+                <div
+                  style={{
+                    position: 'absolute',
+                    inset: 0,
+                    backgroundImage: `linear-gradient(45deg, #555 25%, transparent 25%), linear-gradient(-45deg, #555 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #555 75%), linear-gradient(-45deg, transparent 75%, #555 75%)`,
+                    backgroundSize: '6px 6px',
+                    backgroundColor: '#333',
+                  }}
+                />
+                {/* Color overlay with stop opacity */}
+                <div
+                  style={{
+                    position: 'absolute',
+                    inset: 0,
+                    backgroundColor: stop.color,
+                    opacity: stopAlpha,
+                  }}
+                />
+              </button>
+            );
+          })}
         </div>
         <div className="gradient-ramp-actions">
           <button className="btn" type="button" onClick={() => emit({ stops: spec.stops.map((stop) => ({ ...stop, position: 1 - stop.position })) })}>Reverse</button>
@@ -221,7 +239,7 @@ export default function GradientEditor({ value, onChange, showMapping = false }:
             <h4 className="ctl-section-title">Selected stop</h4>
             <button className="link-btn" type="button" disabled={stops.length <= 2} onClick={removeSelected}>Remove</button>
           </div>
-          <StopColor stop={selected} onColor={(color) => replaceStop(selected.id, { color })} />
+          <StopColor stop={selected} onColor={(color, opacity) => replaceStop(selected.id, { color, opacity })} />
           <ControlRow def={stopPositionDef} value={Math.round(selected.position * 100)}
             onChange={(position) => replaceStop(selected.id, { position: clamp(Number(position) / 100) })} />
         </div>

--- a/components/PreviewStage.tsx
+++ b/components/PreviewStage.tsx
@@ -7,6 +7,58 @@ import { setRendererInstance } from '@/lib/rendererInstance';
 import { useSceneStore } from '@/store/useSceneStore';
 import { getTemplate } from '@/templates';
 
+// Um renderer por engine, guardado pela vida da pagina.
+//
+// Antes, trocar de engine (escolher um preset webgl com um 2D no palco, ou o
+// contrario) destruia o renderer e criava outro do zero. Os dois caminhos de
+// destruicao machucam, cada um do seu jeito:
+//
+//   - Pixi: `app.destroy()` chama `loseContext()` la dentro (esta escrito em
+//     GlContextSystem.destroy(), nao e suposicao), e o Chrome SOMA as perdas
+//     causadas pela pagina. Passado o limite dele, a criacao seguinte volta
+//     "A WebGL context could not be created. Reason: Web page caused context
+//     loss and was blocked" — e ai nada mais consegue contexto: a miniatura 3D
+//     cai para 2D, o Pixi da miniatura tambem falha, e o PALCO morre em
+//     `renderer3d.init` com unhandledRejection. O editor inteiro vai junto.
+//   - three: `dispose()` NAO solta o contexto, entao o antigo fica vivo e
+//     abandonado, contando contra o limite de ~16 contextos da pagina.
+//
+// Medido alternando Orbit 3D (webgl) e Runway (2D) dez vezes: perdas causadas
+// pela pagina subindo 2, 3, 4 ... 11, uma por troca, linear e sem teto, e 11
+// contextos criados no `stage-canvas`. Reusando, a conta para em um por engine.
+//
+// O canvas nao pode ser compartilhado entre as duas bibliotecas — atributos de
+// contexto e comportamento de perda diferem — entao cada engine guarda o SEU
+// canvas junto, e trocar de engine e trocar qual dos dois esta no DOM.
+type Palco = { renderer: IRenderer; canvas: HTMLCanvasElement };
+const palcos = new Map<'pixi' | 'webgl', Palco>();
+// Criacao em voo, para que duas montagens do mesmo engine compartilhem UMA. Sem
+// isto, o Strict Mode do dev cria dois renderers por montagem e descarta um, e
+// descartar custa uma perda de contexto contada contra a pagina.
+const emCriacao = new Map<'pixi' | 'webgl', Promise<Palco>>();
+
+function obterPalco(engine: 'pixi' | 'webgl', canvas: HTMLCanvasElement): Promise<Palco> {
+  const pronto = palcos.get(engine);
+  if (pronto) return Promise.resolve(pronto);
+  const emVoo = emCriacao.get(engine);
+  if (emVoo) return emVoo;
+  const p = (async () => {
+    const renderer: IRenderer = engine === 'webgl'
+      // three stays out of the bundle for 2D-only sessions
+      ? new (await import('@/lib/renderer3d')).SceneRenderer3D()
+      : new SceneRenderer();
+    await renderer.init(canvas);
+    const entrada: Palco = { renderer, canvas };
+    palcos.set(engine, entrada);
+    return entrada;
+  })();
+  emCriacao.set(engine, p);
+  // Uma criacao que falha nao pode ficar guardada, senao a proxima tentativa
+  // recebe a mesma falha para sempre.
+  p.finally(() => { emCriacao.delete(engine); }).catch(() => { /* tratado no chamador */ });
+  return p;
+}
+
 // Live 2D/WebGL preview stage
 export default function PreviewStage() {
   const stageRef = useRef<HTMLDivElement>(null);
@@ -43,7 +95,9 @@ export default function PreviewStage() {
     const initGeneration = ++initGenerationRef.current;
     let mounted = true;
     let renderer: IRenderer | null = null;
-    const canvas = document.createElement('canvas');
+    const guardado = palcos.get(engine);
+    // O canvas deste engine: o que ja existe, ou um novo na primeira vez.
+    const canvas = guardado?.canvas ?? document.createElement('canvas');
     canvas.className = 'stage-canvas';
     // The canvas belongs to this exact renderer generation. Keeping it in a
     // local variable prevents an obsolete async Pixi init/cleanup from ever
@@ -99,25 +153,38 @@ export default function PreviewStage() {
     // paused preview must redraw once
     const unsub = useSceneStore.subscribe(() => { dirtyRef.current = true; });
 
-    (async () => {
-      if (engine === 'webgl') {
-        // three stays out of the bundle for 2D-only sessions
-        const { SceneRenderer3D } = await import('@/lib/renderer3d');
-        renderer = new SceneRenderer3D();
-      } else {
-        renderer = new SceneRenderer();
-      }
-      if (!mounted || initGeneration !== initGenerationRef.current) return;
-      // async texture loads (images/videos) also need a redraw when they arrive
-      renderer.onDirty = () => { dirtyRef.current = true; };
-      await renderer.init(canvas);
-      if (!mounted || initGeneration !== initGenerationRef.current) { renderer.destroy(); return; }
-      rendererRef.current = renderer;
-      setRendererInstance(renderer);
+    // Religar o renderer guardado: sem init, sem contexto novo, sem perda.
+    const religar = (r: IRenderer) => {
+      r.onDirty = () => { dirtyRef.current = true; };
+      rendererRef.current = r;
+      setRendererInstance(r);
+      // O tamanho da cena pode ter mudado enquanto este engine estava parado.
+      const st = useSceneStore.getState();
+      r.resize(st.width, st.height);
       dirtyRef.current = true;
-      lastPlayingRef.current = useSceneStore.getState().playing;
+      lastPlayingRef.current = st.playing;
       rafRef.current = requestAnimationFrame(loop);
-    })();
+    };
+
+    if (guardado) {
+      religar(guardado.renderer);
+    } else {
+      (async () => {
+        const entrada = await obterPalco(engine, canvas);
+        // Sem `destroy()` num init obsoleto: a criacao e serializada por engine,
+        // entao o Strict Mode do dev (que monta, limpa e monta de novo) espera a
+        // primeira em vez de criar uma segunda para depois jogar fora. Era uma
+        // perda de contexto por montagem, e o contador do Chrome nao zera.
+        if (!mounted || initGeneration !== initGenerationRef.current) return;
+        // A criacao vencedora pode ter usado o canvas da outra tentativa.
+        if (entrada.canvas !== canvas) {
+          entrada.canvas.className = 'stage-canvas';
+          stageRef.current?.replaceChildren(entrada.canvas);
+        }
+        renderer = entrada.renderer;
+        religar(entrada.renderer);
+      })().catch(() => { /* sem contexto: a mensagem do renderer ja subiu */ });
+    }
 
     return () => {
       mounted = false;
@@ -125,8 +192,12 @@ export default function PreviewStage() {
       cancelAnimationFrame(rafRef.current);
       setRendererInstance(null);
       rendererRef.current = null;
-      renderer?.destroy();
-      if (canvas.parentNode) canvas.remove();
+      // Estacionado, nao destruido: o loop para e os videos param de decodificar,
+      // mas o renderer e o contexto ficam para a proxima vez que este engine
+      // voltar. Destruir aqui e o que causava o bloqueio de contexto do Chrome.
+      // O canvas sai do DOM sozinho, pelo replaceChildren do outro engine.
+      const parado = palcos.get(engine)?.renderer;
+      try { parado?.pauseVideos?.(); } catch { /* nada a fazer se ja parou */ }
     };
   }, [engine]);
 

--- a/components/PreviewStage.tsx
+++ b/components/PreviewStage.tsx
@@ -7,6 +7,7 @@ import { setRendererInstance } from '@/lib/rendererInstance';
 import { useSceneStore } from '@/store/useSceneStore';
 import { getTemplate } from '@/templates';
 
+// Live 2D/WebGL preview stage
 export default function PreviewStage() {
   const stageRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<IRenderer | null>(null);

--- a/components/ScenePanel.tsx
+++ b/components/ScenePanel.tsx
@@ -6,6 +6,7 @@ import { catalogTemplateList, getTemplate } from '@/templates';
 import { ControlRow, controlVisible } from './Controls';
 import EasingPanel from './EasingPanel';
 import TrackInspector from './TrackInspector';
+import type { ControlDef } from '@/lib/types';
 
 // Renders the SCENE + TIMING sections (no card wrapper — the page composes cards).
 export default function ScenePanel() {
@@ -26,7 +27,15 @@ export default function ScenePanel() {
   const primaryControls = visibleControls.filter((def) => !def.advanced);
   const advancedControls = visibleControls.filter((def) => def.advanced);
   const sections = ['Layout', 'Motion', 'Depth', 'Finish'] as const;
-  const hasSections = primaryControls.some((def) => def.section);
+
+  const getControlSection = (def: ControlDef): 'Layout' | 'Motion' | 'Depth' | 'Finish' => {
+    if (def.section) return def.section;
+    const k = def.key.toLowerCase();
+    if (k.includes('speed') || k.includes('motion') || k.includes('spin') || k.includes('flow') || k.includes('dir') || k.includes('hold') || k.includes('sec') || k.includes('wobble') || k.includes('drift')) return 'Motion';
+    if (k.includes('tilt') || k.includes('zoom') || k.includes('persp') || k.includes('depth') || k.includes('cam') || k.includes('dist') || k.includes('curve') || k.includes('align')) return 'Depth';
+    if (k.includes('radius') || k.includes('fade') || k.includes('light') || k.includes('shadow') || k.includes('blur') || k.includes('grain')) return 'Finish';
+    return 'Layout';
+  };
 
   return (
     <>
@@ -50,16 +59,18 @@ export default function ScenePanel() {
         {trackCount > 1 && (
           <div className="ctl-hint">Editing the motion of <b>{activeTrackName}</b>.</div>
         )}
-        {hasSections ? sections.map((section) => {
-          const controls = primaryControls.filter((def) => (def.section ?? 'Layout') === section);
+        {sections.map((section) => {
+          const controls = primaryControls.filter((def) => getControlSection(def) === section);
           if (!controls.length) return null;
-          return <div className="ctl-section" key={section}>
-            <div className="ctl-section-title">{section}</div>
-            {controls.map((def) => <ControlRow key={def.key} def={def} value={values[def.key]} onChange={(val) => setValue(def.key, val)} />)}
-          </div>;
-        }) : primaryControls.map((def) => (
-          <ControlRow key={def.key} def={def} value={values[def.key]} onChange={(val) => setValue(def.key, val)} />
-        ))}
+          return (
+            <div className="ctl-section" key={section}>
+              <div className="ctl-section-title">{section}</div>
+              {controls.map((def) => (
+                <ControlRow key={def.key} def={def} value={values[def.key]} onChange={(val) => setValue(def.key, val)} />
+              ))}
+            </div>
+          );
+        })}
         {advancedControls.length > 0 && (
           <div className="ctl-advanced">
             <button

--- a/effects/adapters/glsl.ts
+++ b/effects/adapters/glsl.ts
@@ -9,6 +9,42 @@ import type { Effect } from '@/lib/types';
 /** Names the adapters inject. An effect redeclaring one is a compile error. */
 export const RESERVED = ['uTexture', 'map', 'uInputSize', 'uResolution', 'uTime', 'fxSample', 'fxMain', 'vTextureCoord', 'vUv'];
 
+// sRGB <-> linear, formula exata (nao a aproximacao pow 2.2, que erra 4% nos
+// escuros por ignorar o trecho linear perto de zero).
+//
+// POR QUE ISTO EXISTE. O three trabalha em espaco LINEAR e converte para sRGB
+// na saida (`#include <colorspace_fragment>`, que roda DEPOIS do efeito),
+// enquanto o Pixi entrega e consome sRGB direto. Sem tratar isso, o MESMO
+// efeito faz contas em espacos diferentes nos dois engines — o que quebra a
+// promessa inteira do contrato.
+//
+// Medido no Posterize com levels=5, onde caem os niveis em sRGB 0-255:
+//   Pixi  (sRGB)   0, 64, 128, 191, 255   espacamento 64, 64, 63, 64
+//   three (linear) 0, 137, 188, 225, 255  espacamento 137, 51, 37, 30
+// Um salto de 137 niveis do preto para o primeiro degrau, e as bandas
+// amontoadas nos claros — 73 de diferenca no pior nivel. Visivelmente outro
+// efeito, e o pior dos dois.
+//
+// Afeta todo efeito que faz MATEMATICA DE COR: posterize (o pior caso),
+// halftone (o tom medido decide o tamanho do ponto), grain (a soma) e vignette
+// (a multiplicacao). Os que so deslocam coordenada — pixelate, rgb-split, wave
+// — sao imunes, e e por isso que a divergencia passou tanto tempo invisivel.
+//
+// A escolha e sRGB, nao linear: e o que o Pixi ja da, e e o espaco em que
+// "cinco niveis" significa cinco degraus PERCEPTUALMENTE iguais, que e o que
+// alguem mexendo no controle espera ver.
+const SRGB_HELPERS = `
+vec3 fx_toSrgb(vec3 c) {
+  return mix(c * 12.92, 1.055 * pow(max(c, vec3(0.0)), vec3(1.0 / 2.4)) - 0.055, step(0.0031308, c));
+}
+vec3 fx_toLinear(vec3 c) {
+  return mix(c / 12.92, pow((max(c, vec3(0.0)) + 0.055) / 1.055, vec3(2.4)), step(0.04045, c));
+}`;
+
+// Os helpers de espaco de cor tambem sao injetados, entao tambem sao reservados.
+RESERVED.push('fx_toSrgb', 'fx_toLinear');
+
+
 function declarations(effect: Effect): string {
   return Object.entries(effect.shader.uniformTypes ?? {})
     .map(([name, type]) => `uniform ${type} ${name};`)
@@ -51,12 +87,26 @@ uniform float uTime;
 ${declarations(effect)}
 varying vec2 vUv;
 
-vec4 fxSample(vec2 p) { return texture2D(map, p / uResolution); }
+${SRGB_HELPERS}
+
+// A amostra chega em espaco linear (o three trabalha assim) e o efeito tem de
+// ver sRGB, para casar com o Pixi.
+vec4 fxSample(vec2 p) {
+  vec4 c = texture2D(map, p / uResolution);
+  return vec4(fx_toSrgb(c.rgb), c.a);
+}
 
 ${effect.shader.fragment}
 
 void main() {
-  gl_FragColor = fxMain(vUv * uResolution);
+  vec4 fx_result = fxMain(vUv * uResolution);
+  // De volta a linear: o colorspace_fragment abaixo faz a conversao final para
+  // sRGB, e converter duas vezes clareia a imagem inteira. Eu esqueci esta
+  // linha na primeira tentativa e o teste de paridade acusou 47/255 de
+  // divergencia media uniforme em TODOS os efeitos, inclusive nos que so
+  // deslocam coordenada — o que era o sinal de que o erro estava no wrapper e
+  // nao nos efeitos.
+  gl_FragColor = vec4(fx_toLinear(fx_result.rgb), fx_result.a);
   #include <colorspace_fragment>
 }`;
 }

--- a/effects/halftone.ts
+++ b/effects/halftone.ts
@@ -1,0 +1,77 @@
+import type { Effect } from '@/lib/types';
+
+// Halftone: the image rebuilt as a grid of dots whose SIZE carries the tone.
+//
+// The grid is rotated, and that is the whole craft of it. An unrotated dot grid
+// lines up with the card edges and with the pixel grid itself, which reads as a
+// screen-door artefact rather than as print; real halftone screens sit at an
+// angle for exactly that reason. 45 degrees is the default because it is the
+// angle a single-colour screen is traditionally cut at — the eye resolves a
+// diagonal lattice as texture and an axis-aligned one as a defect.
+//
+// The dot is measured with a smoothstep against the cell's radius rather than a
+// hard step. A hard threshold gives every dot a stair-stepped edge at these
+// sizes, and the stair pattern itself becomes the visible texture. The ramp is
+// one pixel wide, converted from cell units, so it is a constant softness on
+// screen no matter how big the cell is.
+//
+// `mono` is a real switch, not a saturation slider: print halftone of a colour
+// image screens each channel separately (which is what the colour path does
+// here, one dot size per channel), while a single-colour screen measures
+// luminance once. Those are different pictures, not two ends of one scale.
+export const halftone: Effect = {
+  meta: { id: 'halftone', name: 'Halftone' },
+  controls: [
+    { key: 'dotSize', label: 'Dot Size', type: 'slider', min: 2, max: 40, step: 1, default: 8, unit: 'px' },
+    { key: 'angle', label: 'Screen Angle', type: 'slider', min: 0, max: 90, step: 1, default: 45, unit: '°' },
+    { key: 'mono', label: 'Colour', type: 'toggle', options: ['Mono', 'CMY'], default: 'Mono' },
+  ],
+  shader: {
+    uniformTypes: { uCell: 'float', uRot: 'vec2', uMono: 'float' },
+    uniforms: (v) => {
+      const rad = (Number(v.angle ?? 45) * Math.PI) / 180;
+      // Rotation baked to a vector: same value for the whole frame, so there is
+      // no reason to pay sin/cos per pixel.
+      return {
+        uCell: Math.max(2, Number(v.dotSize ?? 8)),
+        uRot: [Math.cos(rad), Math.sin(rad)],
+        uMono: (v.mono ?? 'Mono') === 'Mono' ? 1 : 0,
+      };
+    },
+    fragment: `
+// Coverage of one dot: 1 at the cell centre, 0 past its radius.
+// A tone of 0 wants a full dot and 1 wants none, so the radius follows (1 - tone).
+float fx_dot(vec2 gridPos, float tone) {
+  vec2 cellCentre = floor(gridPos) + 0.5;
+  float d = length(gridPos - cellCentre);
+  // sqrt(0.5) is the half-diagonal of the cell: the radius at which a dot just
+  // touches its neighbours diagonally, which is full coverage.
+  float r = (1.0 - tone) * 0.7071;
+  // One pixel of ramp, in cell units — constant softness on screen.
+  float soft = 1.0 / uCell;
+  return 1.0 - smoothstep(r - soft, r + soft, d);
+}
+
+vec4 fxMain(vec2 p) {
+  vec4 col = fxSample(p);
+  // Into the rotated screen's own grid, in cells.
+  vec2 rot = vec2(p.x * uRot.x - p.y * uRot.y, p.x * uRot.y + p.y * uRot.x);
+  vec2 gridPos = rot / uCell;
+
+  if (uMono > 0.5) {
+    // Rec.709 luma: a green-heavy image screened on a flat average comes out
+    // far darker than the eye expects.
+    float tone = dot(col.rgb, vec3(0.2126, 0.7152, 0.0722));
+    float ink = fx_dot(gridPos, tone);
+    return vec4(vec3(1.0 - ink), col.a);
+  }
+
+  // Colour: each channel gets its own screen, offset in angle the way process
+  // printing separates them so the dots interleave instead of stacking.
+  float c = fx_dot(gridPos, col.r);
+  float m = fx_dot(gridPos + vec2(0.33, 0.66), col.g);
+  float y = fx_dot(gridPos + vec2(0.66, 0.33), col.b);
+  return vec4(1.0 - c, 1.0 - m, 1.0 - y, col.a);
+}`,
+  },
+};

--- a/effects/index.ts
+++ b/effects/index.ts
@@ -1,17 +1,26 @@
 import type { Effect } from '@/lib/types';
 import { grain } from './grain';
+import { halftone } from './halftone';
 import { pixelate } from './pixelate';
+import { posterize } from './posterize';
 import { rgbSplit } from './rgbSplit';
+import { scanlines } from './scanlines';
 import { vignette } from './vignette';
+import { wave } from './wave';
 
-// Insertion order is the order the panel offers them, so these read as a list a
-// person would scan: the two that change the whole frame's feel first, then the
-// two that are a deliberate look.
+// Insertion order is the order the panel offers them, grouped by what a person
+// is looking for rather than alphabetically: first the two that set a whole
+// frame's mood, then the four that are a deliberate printed/broadcast look,
+// then the one that distorts geometry.
 export const effects: Record<string, Effect> = {
   [grain.meta.id]: grain,
   [vignette.meta.id]: vignette,
-  [rgbSplit.meta.id]: rgbSplit,
+  [halftone.meta.id]: halftone,
+  [posterize.meta.id]: posterize,
+  [scanlines.meta.id]: scanlines,
   [pixelate.meta.id]: pixelate,
+  [rgbSplit.meta.id]: rgbSplit,
+  [wave.meta.id]: wave,
 };
 
 export const effectList: Effect[] = Object.values(effects);

--- a/effects/posterize.ts
+++ b/effects/posterize.ts
@@ -1,0 +1,39 @@
+import type { Effect } from '@/lib/types';
+
+// Posterize: collapse each channel to a fixed number of levels.
+//
+// The quantizer is floor(v * (n-1) + 0.5) / (n-1), and the two details in it
+// are the ones that matter. Dividing by n-1 rather than n is what keeps pure
+// white reachable: with n levels there are n-1 STEPS between black and white,
+// and dividing by n leaves the top level short of 1.0, so a white card comes
+// out grey. The +0.5 rounds to the nearest level instead of always down, which
+// otherwise darkens the whole image by half a step.
+//
+// At `levels` 2 this is a threshold, and that is deliberate rather than a
+// separate effect: two levels per channel IS the threshold case, and giving it
+// its own control would be the same shader with a different label.
+//
+// Quantizes each channel independently, not the luminance. Per-channel is what
+// produces the colour banding a posterized print has; quantizing luma would
+// give a grey staircase with the original hue laid back over it, which is a
+// different look entirely.
+export const posterize: Effect = {
+  meta: { id: 'posterize', name: 'Posterize' },
+  controls: [
+    { key: 'levels', label: 'Levels', type: 'slider', min: 2, max: 16, step: 1, default: 5 },
+  ],
+  shader: {
+    uniformTypes: { uSteps: 'float' },
+    // n-1 computed here, on the CPU, so the shader never risks dividing by zero
+    // if the slider floor ever moves down to 1.
+    uniforms: (v) => ({ uSteps: Math.max(1, Math.round(Number(v.levels ?? 5)) - 1) }),
+    fragment: `
+vec4 fxMain(vec2 p) {
+  vec4 col = fxSample(p);
+  // +0.5 rounds to the nearest level; without it every pixel falls to the level
+  // below and the image darkens by half a step.
+  vec3 q = floor(col.rgb * uSteps + 0.5) / uSteps;
+  return vec4(q, col.a);
+}`,
+  },
+};

--- a/effects/posterize.ts
+++ b/effects/posterize.ts
@@ -21,19 +21,35 @@ export const posterize: Effect = {
   meta: { id: 'posterize', name: 'Posterize' },
   controls: [
     { key: 'levels', label: 'Levels', type: 'slider', min: 2, max: 16, step: 1, default: 5 },
+    // Mix exists because the effect runs on the WHOLE composed frame, the scene
+    // background included, and quantizing is destructive down there: a #1a1a1a
+    // background (26) lands on level 0 at five levels, so the background and
+    // every dark card region collapse into the same pure black and the cards
+    // lose their silhouette. Measured on the stage at levels 5: the pixels
+    // still distinguishable from the background fell from 301213 to 172828.
+    //
+    // Full strength stays the default, so scenes saved before this control
+    // render exactly as they did — their stored values carry no `mix` at all,
+    // and the uniform reads 100 when it is missing.
+    { key: 'mix', label: 'Mix', type: 'slider', min: 0, max: 100, step: 1, default: 100, unit: '%' },
   ],
   shader: {
-    uniformTypes: { uSteps: 'float' },
+    uniformTypes: { uSteps: 'float', uMix: 'float' },
     // n-1 computed here, on the CPU, so the shader never risks dividing by zero
     // if the slider floor ever moves down to 1.
-    uniforms: (v) => ({ uSteps: Math.max(1, Math.round(Number(v.levels ?? 5)) - 1) }),
+    uniforms: (v) => ({
+      uSteps: Math.max(1, Math.round(Number(v.levels ?? 5)) - 1),
+      uMix: Math.max(0, Math.min(1, Number(v.mix ?? 100) / 100)),
+    }),
     fragment: `
 vec4 fxMain(vec2 p) {
   vec4 col = fxSample(p);
   // +0.5 rounds to the nearest level; without it every pixel falls to the level
   // below and the image darkens by half a step.
   vec3 q = floor(col.rgb * uSteps + 0.5) / uSteps;
-  return vec4(q, col.a);
+  // Blends against the ORIGINAL sample, so Mix at 0 is exact identity and the
+  // separation the levels threw away comes back proportionally.
+  return vec4(mix(col.rgb, q, uMix), col.a);
 }`,
   },
 };

--- a/effects/scanlines.ts
+++ b/effects/scanlines.ts
@@ -1,0 +1,63 @@
+import type { Effect } from '@/lib/types';
+
+// CRT: dark scanlines, plus optional barrel curvature.
+//
+// The lines are drawn from a cosine of the pixel's y, not from a modulo test.
+// A modulo gives a hard on/off line whose width cannot follow the spacing, and
+// which aliases into moire the moment the canvas is scaled for export — the
+// beat between the line period and the pixel grid. A cosine has the period
+// built in and lands soft at every spacing.
+//
+// `curvature` deforms the SAMPLE coordinate, not the geometry: a real tube
+// bends the image, so the whole frame including the background has to bow. It
+// is applied around the centre in normalized space, then taken back to pixels,
+// which is what keeps the bow symmetric on a portrait canvas.
+//
+// A coordenada chama-se `src` e nao `sample`: `sample` e palavra RESERVADA em
+// GLSL ES 3.00 (qualificador de sampler), e usa-la da "Illegal use of reserved
+// word" no compilador. A suite estrutural nao pega isso — passou verde com este
+// shader sem compilar; quem pegou foi verify-effects-gl.
+//
+// Anything the curve pushes outside the frame is returned black rather than
+// clamped. Clamping smears the edge pixel into a streak along the border, which
+// reads as a rendering fault; a tube simply has nothing out there.
+export const scanlines: Effect = {
+  meta: { id: 'scanlines', name: 'Scanlines' },
+  controls: [
+    { key: 'spacing', label: 'Spacing', type: 'slider', min: 2, max: 24, step: 1, default: 3, unit: 'px' },
+    { key: 'strength', label: 'Strength', type: 'slider', min: 0, max: 100, step: 1, default: 40, unit: '%' },
+    { key: 'curvature', label: 'Curvature', type: 'slider', min: 0, max: 100, step: 1, default: 0, unit: '%' },
+  ],
+  shader: {
+    uniformTypes: { uSpacing: 'float', uStrength: 'float', uCurve: 'float' },
+    uniforms: (v) => ({
+      uSpacing: Math.max(2, Number(v.spacing ?? 3)),
+      uStrength: Math.max(0, Math.min(100, Number(v.strength ?? 40))) / 100,
+      // Scaled down hard: at 1.0 a barrel term of this shape folds the corners
+      // back over themselves. 0.35 is the most bow that still reads as a tube.
+      uCurve: (Math.max(0, Math.min(100, Number(v.curvature ?? 0))) / 100) * 0.35,
+    }),
+    fragment: `
+vec4 fxMain(vec2 p) {
+  vec2 src = p;
+
+  if (uCurve > 0.0001) {
+    // Centred, normalized to -1..1 on both axes so the bow is symmetric
+    // regardless of the canvas aspect.
+    vec2 c = (p / uResolution) * 2.0 - 1.0;
+    float r2 = dot(c, c);
+    c *= 1.0 + uCurve * r2;
+    // Outside the tube there is nothing, so do not clamp — clamping smears the
+    // edge pixel into a border streak.
+    if (abs(c.x) > 1.0 || abs(c.y) > 1.0) return vec4(0.0, 0.0, 0.0, 1.0);
+    src = (c * 0.5 + 0.5) * uResolution;
+  }
+
+  vec4 col = fxSample(src);
+  // Cosine rather than a modulo: the period is intrinsic, so the line stays
+  // soft at every spacing instead of beating against the pixel grid.
+  float line = 0.5 + 0.5 * cos(src.y * 6.28318 / uSpacing);
+  return vec4(col.rgb * (1.0 - uStrength * line), col.a);
+}`,
+  },
+};

--- a/effects/wave.ts
+++ b/effects/wave.ts
@@ -1,0 +1,56 @@
+import type { Effect } from '@/lib/types';
+
+// Wave: displace the sample coordinate along a travelling sine.
+//
+// The displacement is on X and driven by Y — a vertical wave running
+// horizontally, which is the shape that reads as a ripple over a frame. Driving
+// X by X instead would stretch and squeeze the image along its own axis, which
+// reads as a lens defect, not as water.
+//
+// `speed` is in cycles per second and `uTime` comes from the FRAME, so the
+// phase at frame 47 is identical on every render of the same clip. A wave keyed
+// to the wall clock would land differently in every export, and worse, it would
+// not loop: the phase at the last frame would not meet the phase at the first.
+//
+// The phase advances by whole cycles across the clip so the loop closes. Any
+// non-integer number of cycles leaves a visible jump at the wrap, which on an
+// 8-second seamless clip is the one artefact there is no hiding.
+//
+// Out-of-frame samples come back transparent instead of clamped: clamping
+// smears the edge pixel into a band along the border wherever the wave reaches
+// past the canvas.
+export const wave: Effect = {
+  meta: { id: 'wave', name: 'Wave' },
+  controls: [
+    { key: 'amount', label: 'Amount', type: 'slider', min: 0, max: 120, step: 1, default: 18, unit: 'px' },
+    { key: 'freq', label: 'Frequency', type: 'slider', min: 1, max: 20, step: 1, default: 3 },
+    { key: 'speed', label: 'Speed', type: 'slider', min: 0, max: 8, step: 0.5, default: 1 },
+  ],
+  shader: {
+    uniformTypes: { uAmount: 'float', uFreq: 'float', uSpeed: 'float' },
+    // `speed` gets its own uniform instead of being folded into a phase on the
+    // CPU. Folding it looked cheaper — one multiply saved per pixel — but
+    // phase = time * speed is ZERO at t=0 whatever the speed, so the control
+    // was indistinguishable on the first frame. The suite reported it as a dead
+    // button, exactly as it did for Grain. A parameter the user can move needs
+    // a uniform of its own.
+    uniforms: (v) => ({
+      uAmount: Math.max(0, Number(v.amount ?? 18)),
+      uFreq: Math.max(1, Math.round(Number(v.freq ?? 3))),
+      uSpeed: Math.max(0, Number(v.speed ?? 1)),
+    }),
+    fragment: `
+vec4 fxMain(vec2 p) {
+  // Y normalized so the frequency means whole waves across the frame height, not
+  // per pixel — the same slider value then reads the same in any canvas size.
+  float y = p.y / uResolution.y;
+  // uTime is frame-derived, so the phase at a given frame is identical on every
+  // render of the same clip.
+  float offset = sin(y * uFreq * 6.28318 + uTime * uSpeed * 6.28318) * uAmount;
+  vec2 src = vec2(p.x + offset, p.y);
+  // Past the edge there is no image. Clamping would streak the border pixel.
+  if (src.x < 0.0 || src.x > uResolution.x) return vec4(0.0);
+  return fxSample(src);
+}`,
+  },
+};

--- a/lib/gifExport.ts
+++ b/lib/gifExport.ts
@@ -135,13 +135,29 @@ export async function encodeGifInBrowser(opts: GifExportOpts): Promise<Blob> {
     ctx.drawImage(src, 0, 0, width, height);
     const { data } = ctx.getImageData(0, 0, width, height);
 
-    // rgb565 is gifenc's default and the finer bucket: 65536 candidate colours
-    // feeding the quantiser instead of rgb444's 4096.
-    const palette = quantize(data, 256, { format: 'rgb565' });
-    const index = dither > 0
+    // Check if frame has transparency (e.g. transparent background)
+    let hasAlpha = false;
+    for (let i = 3; i < data.length; i += 16) {
+      if (data[i] < 250) {
+        hasAlpha = true;
+        break;
+      }
+    }
+
+    const format = hasAlpha ? 'rgba4444' : 'rgb565';
+    const palette = quantize(data, 256, hasAlpha ? { format: 'rgba4444', oneBitAlpha: true } : { format: 'rgb565' });
+    const index = (dither > 0 && !hasAlpha)
       ? applyPaletteDithered(data, palette, width, height, nearestColorIndex, dither)
-      : applyPalette(data, palette, 'rgb565');
-    gif.writeFrame(index, width, height, { palette, delay, repeat: 0 });
+      : applyPalette(data, palette, format);
+    const transparentIndex = hasAlpha ? palette.findIndex((c: number[]) => c[3] === 0) : -1;
+
+    gif.writeFrame(index, width, height, {
+      palette,
+      delay,
+      repeat: 0,
+      transparent: transparentIndex >= 0,
+      transparentIndex: Math.max(0, transparentIndex),
+    });
 
     onProgress?.(f + 1);
     // Quantising a 1080p frame is heavy synchronous work; yield every frame so

--- a/lib/gradient.ts
+++ b/lib/gradient.ts
@@ -386,9 +386,10 @@ export function sampleGradientPoint(specInput: GradientSpec, x: number, y: numbe
 
 function addNativeStops(gradient: CanvasGradient, spec: GradientSpec) {
   for (const stop of gradientRenderStops(spec)) {
-    const color = stop.opacity == null || stop.opacity >= 1
+    const alpha = stop.opacity == null ? 1 : Math.max(0, Math.min(1, stop.opacity));
+    const color = alpha >= 1
       ? stop.color
-      : `${stop.color}${Math.round(stop.opacity * 255).toString(16).padStart(2, '0')}`;
+      : `rgba(${parseColor(stop.color, alpha).slice(0, 3).join(',')},${alpha})`;
     gradient.addColorStop(stop.position, color);
   }
 }
@@ -483,6 +484,7 @@ export function paintGradientCanvas(
       gradient = ctx.createLinearGradient(cx - vx * half, cy - vy * half, cx + vx * half, cy + vy * half);
     }
     addNativeStops(gradient, spec);
+    ctx.clearRect(0, 0, w, h);
     ctx.fillStyle = gradient;
     ctx.fillRect(0, 0, w, h);
     applyGradientBlur(canvas, spec);

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -520,14 +520,22 @@ export class SceneRenderer {
   // ---- overlays ----
   private drawOverlays(s: SceneState) {
     const { width, height } = s;
-    const backgroundAlpha = Math.max(0, Math.min(1, (s.background.alpha ?? 100) / 100));
+    const rawAlpha = s.background.alpha ?? 100;
+    const alphaPct = (rawAlpha > 0 && rawAlpha <= 1) ? rawAlpha * 100 : rawAlpha;
+    const backgroundAlpha = Math.max(0, Math.min(1, alphaPct / 100));
 
     // background
     this.bg.clear();
     this.bg.alpha = backgroundAlpha;
     this.gradientSprite.alpha = backgroundAlpha;
-    this.bgSprite.alpha = backgroundAlpha;
-    if (s.background.source === 'color' && s.background.gradient) {
+
+    if (backgroundAlpha === 0) {
+      this.bg.visible = false;
+      this.gradientSprite.visible = false;
+      this.bgSprite.visible = false;
+    } else if (s.background.source === 'color' && s.background.gradient) {
+      this.bg.visible = false;
+      this.bgSprite.visible = false;
       const spec = normalizeGradientSpec(s.background.gradientSpec, s.background.color, s.background.color2);
       const phase = ((s.frame / Math.max(1, s.duration * s.fps)) % 1 + 1) % 1;
       const [rw, rh] = advancedRasterSize(width, height, gradientRasterMaxEdge(spec));
@@ -547,9 +555,14 @@ export class SceneRenderer {
       }
       this.gradientSprite.visible = true;
       this.gradientSprite.scale.set(width / rw, height / rh);
-    } else {
+    } else if (s.background.source === 'color') {
       this.gradientSprite.visible = false;
+      this.bgSprite.visible = false;
+      this.bg.visible = true;
       this.bg.rect(0, 0, width, height).fill(s.background.color);
+    } else {
+      this.bg.visible = false;
+      this.gradientSprite.visible = false;
     }
 
     // safe area guide
@@ -610,9 +623,14 @@ export class SceneRenderer {
       follow = true;
     }
 
-    if (!tex) { this.bgSprite.visible = false; return; }
+    const rawAlpha = bg.alpha ?? 100;
+    const alphaPct = (rawAlpha > 0 && rawAlpha <= 1) ? rawAlpha * 100 : rawAlpha;
+    const backgroundAlpha = Math.max(0, Math.min(1, alphaPct / 100));
+
+    if (!tex || backgroundAlpha === 0) { this.bgSprite.visible = false; return; }
 
     this.bgSprite.visible = true;
+    this.bgSprite.alpha = backgroundAlpha;
     this.bgSprite.texture = tex;
     const cover = Math.max(width / tex.width, height / tex.height) * 1.4; // headroom for drift
     this.bgSprite.scale.set(cover);
@@ -815,6 +833,9 @@ export class SceneRenderer {
   renderFrame(frame: number) {
     if (!this.ready || this.destroyed || !this.app?.renderer) return;
     try {
+      if ((this.app.renderer as any).background) {
+        (this.app.renderer as any).background.alpha = 0;
+      }
       this.getFrameState(frame);
       if (!this.ready || this.destroyed || !this.app?.renderer) return;
       this.app.renderer.render(this.app.stage);
@@ -823,14 +844,20 @@ export class SceneRenderer {
     }
   }
 
-  // Deterministic capture: realize frame, render, read pixels as a JPEG data URL.
-  // JPEG (q0.92) over PNG: ~5–10× smaller + far faster to encode at 2K/4K, and
-  // the scene always paints a background so the missing alpha channel is moot.
-  // ffmpeg re-encodes to h264/gif downstream, so there's no visible quality loss.
+  // Deterministic capture: realize frame, render, read pixels as a data URL.
+  // PNG when background has transparency (alpha < 100) so the alpha channel is preserved.
+  // JPEG (q0.92) when opaque: ~5–10× smaller + far faster to encode.
   captureFrame(frame: number): string {
     if (!this.ready || this.destroyed || !this.app?.renderer) return '';
     this.renderFrame(frame);
-    return (this.app.canvas as HTMLCanvasElement)?.toDataURL?.('image/jpeg', 0.92) ?? '';
+    const canvas = this.app.canvas as HTMLCanvasElement;
+    const s = useSceneStore.getState();
+    const rawAlpha = s.background.alpha ?? 100;
+    const alphaPct = (rawAlpha > 0 && rawAlpha <= 1) ? rawAlpha * 100 : rawAlpha;
+    if (alphaPct < 100) {
+      return canvas?.toDataURL?.('image/png') ?? '';
+    }
+    return canvas?.toDataURL?.('image/jpeg', 0.92) ?? '';
   }
 
   // Multiply the backing-store resolution for export capture. Logical

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -245,7 +245,9 @@ export class SceneRenderer3D implements IRenderer {
           if (blendMode == 1) blend = min(vec3(1.0), base.rgb + straight);
           else if (blendMode == 2) blend = vec3(1.0) - (vec3(1.0) - base.rgb) * (vec3(1.0) - straight);
           else if (blendMode == 3) blend = base.rgb * straight;
-          gl_FragColor = vec4(mix(base.rgb, blend, a), 1.0);
+          float outA = clamp(base.a + a * (1.0 - base.a), 0.0, 1.0);
+          vec3 outRgb = mix(base.rgb, blend, a);
+          gl_FragColor = vec4(outRgb, outA);
         }
       `,
     });
@@ -258,6 +260,7 @@ export class SceneRenderer3D implements IRenderer {
     const outputMaterial = new THREE.ShaderMaterial({
       depthTest: false,
       depthWrite: false,
+      transparent: true,
       uniforms: { map: { value: null } },
       vertexShader: `varying vec2 vUv; void main(){ vUv=uv; gl_Position=vec4(position.xy,0.0,1.0); }`,
       fragmentShader: `
@@ -626,8 +629,12 @@ export class SceneRenderer3D implements IRenderer {
     const s = useSceneStore.getState();
 
     // Background parity with Pixi: solid, gradient, uploaded image, or an
-    // asset reflected from the active motion layer.
-    if (s.background.source === 'color' && s.background.gradient) {
+    // asset reflected from the active motion layer, or transparent.
+    const bgAlpha = Math.max(0, Math.min(1, (s.background.alpha ?? 100) / 100));
+    if (bgAlpha === 0) {
+      this.scene.background = null;
+      this.renderer.setClearColor(0x000000, 0);
+    } else if (s.background.source === 'color' && s.background.gradient) {
       const spec = normalizeGradientSpec(s.background.gradientSpec, s.background.color, s.background.color2);
       const phase = ((s.frame / Math.max(1, s.duration * s.fps)) % 1 + 1) % 1;
       const [rw, rh] = advancedRasterSize(this.width, this.height, gradientRasterMaxEdge(spec));
@@ -643,6 +650,7 @@ export class SceneRenderer3D implements IRenderer {
         this.gradientSig = sig;
       }
       this.scene.background = this.gradientTex;
+      this.renderer.setClearColor(0x000000, bgAlpha);
     } else if (s.background.source === 'image' && s.background.imageUrl) {
       this.syncBackgroundTexture(s.background.imageUrl, s.background.blur);
     } else if (s.background.source === 'card') {
@@ -650,9 +658,18 @@ export class SceneRenderer3D implements IRenderer {
       const assetIndex = active ? trackAssetIndices(active, s.assets)[0] : undefined;
       const url = assetIndex === undefined ? null : s.assets[assetIndex]?.url;
       if (url && !isVideoSource(url, s.assets[assetIndex!]?.kind)) this.syncBackgroundTexture(url, s.background.blur);
-      else this.scene.background = new THREE.Color(s.background.color);
+      else {
+        this.scene.background = new THREE.Color(s.background.color);
+        this.renderer.setClearColor(new THREE.Color(s.background.color), bgAlpha);
+      }
     } else {
-      this.scene.background = new THREE.Color(s.background.color);
+      if (bgAlpha < 1) {
+        this.scene.background = null;
+        this.renderer.setClearColor(new THREE.Color(s.background.color), bgAlpha);
+      } else {
+        this.scene.background = new THREE.Color(s.background.color);
+        this.renderer.setClearColor(new THREE.Color(s.background.color), 1);
+      }
     }
 
     // HUD ortho camera matches the logical canvas (y up; positions flipped)
@@ -1084,9 +1101,13 @@ export class SceneRenderer3D implements IRenderer {
       if (!this.ready || this.destroyed || !this.renderer) return;
       const s = useSceneStore.getState();
 
-      // The accumulator begins with the opaque scene background.
+      // The accumulator begins with the scene background.
+      const rawAlpha = s.background.alpha ?? 100;
+      const alphaPct = (rawAlpha > 0 && rawAlpha <= 1) ? rawAlpha * 100 : rawAlpha;
+      const bgAlpha = Math.max(0, Math.min(1, alphaPct / 100));
+
       this.renderer.setRenderTarget(this.composeA);
-      this.renderer.setClearColor(0x000000, 1);
+      this.renderer.setClearColor(new THREE.Color(s.background.color), bgAlpha);
       this.renderer.clear(true, true, true);
       this.renderer.render(this.scene, this.camera);
 
@@ -1148,7 +1169,7 @@ export class SceneRenderer3D implements IRenderer {
 
       this.outputQuad.material.uniforms.map.value = read.texture;
       this.renderer.setRenderTarget(null);
-      this.renderer.setClearColor(0x000000, 1);
+      this.renderer.setClearColor(0x000000, 0);
       this.renderer.clear(true, true, true);
       this.renderer.render(this.outputScene, this.composeCam);
 
@@ -1164,7 +1185,12 @@ export class SceneRenderer3D implements IRenderer {
   captureFrame(frame: number): string {
     if (!this.ready || this.destroyed || !this.renderer) return '';
     this.renderFrame(frame);
-    // JPEG (q0.92) — see the Pixi renderer's captureFrame for the rationale.
+    const s = useSceneStore.getState();
+    const rawAlpha = s.background.alpha ?? 100;
+    const alphaPct = (rawAlpha > 0 && rawAlpha <= 1) ? rawAlpha * 100 : rawAlpha;
+    if (alphaPct < 100) {
+      return this.renderer.domElement?.toDataURL?.('image/png') ?? '';
+    }
     return this.renderer.domElement?.toDataURL?.('image/jpeg', 0.92) ?? '';
   }
 

--- a/lib/thumbScene2d.ts
+++ b/lib/thumbScene2d.ts
@@ -313,37 +313,53 @@ export function detachCanvas2d() {
 
 // ---- ciclo de vida do contexto ----
 //
-// Um contexto GL e recurso finito e este modulo tomava um e nunca devolvia. Com
-// o three das miniaturas fazendo o mesmo, o PALCO ficava sem: medido, o canvas
-// do palco existia com zero contexto e `app.renderer` vinha null, o que fazia
-// makePlaceholderTexture estourar em `generateTexture` e derrubava o editor.
+// UMA Application, criada na primeira miniatura e mantida pela vida da pagina.
+// O porque completo esta em `three3d/thumbScene.ts`, e vale igual aqui: `refs`
+// passa por zero em toda troca de grupo do acordeao, e destruir a Application
+// ali derruba o contexto uma vez por troca. O Chrome soma perdas causadas pela
+// pagina e depois recusa criar contexto — "Web page caused context loss and was
+// blocked". Aqui o `destroy(true)` nao chama loseContext explicitamente, mas
+// derruba o contexto do mesmo jeito, entao o ciclo tinha de sair dos dois lados:
+// consertar so um deixa a troca de grupo derrubando contexto pelo outro.
 //
-// Contagem de referencias em vez de ordem de inicializacao, que seria fragil:
-// cada miniatura montada retem, cada uma desmontada solta, e quando a ultima sai
-// (o usuario deixou o catalogo) o contexto e devolvido.
+// Com o singleton mantido, a pagina fica em tres contextos (palco, miniatura 2D,
+// miniatura 3D) — medido — contra o limite de ~16 do navegador.
+//
+// A contagem de referencias fica porque a ultima miniatura a sair ainda solta o
+// canvas de onde ele estava. Adiada, para nao fazer isso a cada troca de grupo.
+const CARENCIA_MS = 10_000;
 let refs = 0;
+let agendado: ReturnType<typeof setTimeout> | null = null;
+
+function cancelarLimpeza2d() {
+  if (agendado === null) return;
+  clearTimeout(agendado);
+  agendado = null;
+}
 
 export function retainThumb2d(): () => void {
   refs++;
+  cancelarLimpeza2d();
   let solto = false;
   return () => {
     if (solto) return;
     solto = true;
     refs = Math.max(0, refs - 1);
-    if (refs === 0) disposeShared2d();
+    if (refs > 0) return;
+    cancelarLimpeza2d();
+    agendado = setTimeout(() => {
+      agendado = null;
+      if (refs === 0) limparShared2d();
+    }, CARENCIA_MS);
   };
 }
 
-function disposeShared2d() {
-  const ctx = shared;
-  shared = null;
-  booting = null;
-  whiteCache.clear();
-  if (!ctx) return;
+// Limpeza, nao destruicao: a Application, o contexto e o cache de texturas
+// brancas ficam. O cache e limitado (uma entrada por tamanho de card), entao
+// nao ha o que crescer.
+function limparShared2d() {
+  if (!shared) return;
   try {
     detachCanvas2d();
-    // `true` para o contexto tambem: sem isso o canvas guarda o contexto e a
-    // devolucao nao acontece de verdade.
-    ctx.app.destroy(true, { children: true, texture: true });
-  } catch { /* um contexto que já foi não precisa ir de novo */ }
+  } catch { /* nada aqui e essencial: falhar em limpar nao pode quebrar a pagina */ }
 }

--- a/scripts/_ab_posterize.cjs
+++ b/scripts/_ab_posterize.cjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// A/B honesto do Posterize: MESMO frame, efeito desligado e ligado.
+//
+// As duas fotos anteriores estavam em frames diferentes — o palco continua
+// tocando — e diferenca de pose se confunde com diferenca de efeito. Aqui a
+// linha de tempo e PAUSADA antes das duas capturas, e o que muda entre elas e
+// so o olho do card do efeito.
+const fs = require('fs'), path = require('path');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const NIVEIS = Number(process.argv[3] || 5);
+const OUT = path.resolve(__dirname, '..', '..', '_fx-shots');
+fs.mkdirSync(OUT, { recursive: true });
+
+const CASOS = [
+  { nome: '2d', preset: null },                                   // preset padrao (2D)
+  { nome: 'webgl', preset: { rotulo: 'Ring Stream', grupo: 'Orbit 3D' } },
+];
+
+const semear = function () {
+  const scene = {
+    activeTemplateId: 'arc-01',
+    tracks: [{ id: 't0', templateId: 'arc-01' }],
+    width: 810, height: 1080, fps: 30, duration: 8,
+    background: { source: 'color', color: '#1a1a1a', gradient: false, color2: '#1a1a1a', imageUrl: null, blur: 28 },
+    effects: [],
+  };
+  localStorage.setItem('motion-welcome-seen', '1');
+  localStorage.setItem('motion-tour-seen', '1');
+  localStorage.setItem('motion-scene-v1', JSON.stringify(scene));
+  localStorage.setItem('motion-project-fx', JSON.stringify(scene));
+  localStorage.setItem('motion-projects-v1', JSON.stringify({
+    activeId: 'fx', projects: [{ id: 'fx', name: 'AB posterize', createdAt: 1, updatedAt: 2, mode: '2d' }],
+  }));
+};
+
+const CONTEUDO = function () {
+  const c = document.querySelector('canvas.stage-canvas');
+  if (!c || !c.width) return null;
+  const o = document.createElement('canvas');
+  o.width = c.width; o.height = c.height;
+  const g = o.getContext('2d'); g.drawImage(c, 0, 0);
+  const d = g.getImageData(0, 0, c.width, c.height).data;
+  const hist = new Map();
+  for (let i = 0; i < d.length; i += 4) {
+    const k = d[i] + ',' + d[i + 1] + ',' + d[i + 2];
+    hist.set(k, (hist.get(k) || 0) + 1);
+  }
+  let fundo = [0, 0, 0], max = 0;
+  for (const [k, n] of hist) if (n > max) { max = n; fundo = k.split(',').map(Number); }
+  let conteudo = 0;
+  const set = new Set();
+  for (let i = 0; i < d.length; i += 4) {
+    set.add(d[i]);
+    const dist = Math.abs(d[i] - fundo[0]) + Math.abs(d[i + 1] - fundo[1]) + Math.abs(d[i + 2] - fundo[2]);
+    if (dist >= 24) conteudo++;
+  }
+  return { conteudo, fundo, niveis: set.size };
+};
+
+(async () => {
+  for (const caso of CASOS) {
+    console.log('');
+    console.log('=== ' + caso.nome + ' ===');
+    const b = await puppeteer.launch({
+      executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+      args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+    });
+    const p = await b.newPage();
+    await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+    await p.evaluate(semear);
+    await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+    await p.evaluate(() => {
+      document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+    });
+    if (caso.preset) {
+      await p.evaluate(async (rotulo, grupo) => {
+        const achar = () => Array.from(document.querySelectorAll('.tpl-card'))
+          .find((el) => { const l = el.querySelector('.tpl-card-label'); return l && l.textContent.trim() === rotulo; });
+        if (!achar()) {
+          const linha = Array.from(document.querySelectorAll('.tpl-item'))
+            .find((el) => (el.textContent || '').trim().startsWith(grupo));
+          if (linha) { linha.click(); await new Promise((r) => setTimeout(r, 900)); }
+        }
+        const card = achar();
+        if (card) { (card.querySelector('.tpl-card-label') || card).click(); await new Promise((r) => setTimeout(r, 3000)); }
+      }, caso.preset.rotulo, caso.preset.grupo);
+    }
+    await p.waitForFunction(
+      function (fn) { const m = new Function('return (' + fn + ')()')(); return !!m && m.conteudo > 20000; },
+      { timeout: 60000, polling: 700 }, CONTEUDO.toString(),
+    );
+
+    // adiciona o efeito, ajusta os niveis, e SO DEPOIS pausa
+    await p.evaluate(async () => {
+      const sel = Array.from(document.querySelectorAll('select'))
+        .find((s) => Array.from(s.options).some((o) => o.textContent.trim() === 'Posterize'));
+      sel.value = Array.from(sel.options).find((o) => o.textContent.trim() === 'Posterize').value;
+      sel.dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 150));
+      Array.from(document.querySelectorAll('button')).find((btn) => btn.textContent.trim() === 'Add').click();
+      await new Promise((r) => setTimeout(r, 1200));
+    });
+    const caixa = await p.evaluate(() => {
+      const card = Array.from(document.querySelectorAll('.effect-card'))
+        .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === 'Posterize'; });
+      card.scrollIntoView({ block: 'center' });
+      const st = card.querySelector('.strack');
+      const r = st.getBoundingClientRect();
+      return { x: r.x, y: r.y, w: r.width, h: r.height };
+    });
+    const t = (NIVEIS - 2) / 14;
+    const x = caixa.x + 6 + t * (caixa.w - 12), y = caixa.y + caixa.h / 2;
+    await p.mouse.move(x, y); await p.mouse.down(); await p.mouse.up();
+    await new Promise((r) => setTimeout(r, 700));
+
+    // pausa: sem isso as duas capturas caem em frames diferentes
+    const pausou = await p.evaluate(async () => {
+      const btn = document.querySelector('.play-btn');
+      if (!btn) return 'sem botao de play';
+      const antes = btn.getAttribute('title');
+      if (antes === 'Pause') { btn.click(); await new Promise((r) => setTimeout(r, 600)); }
+      return 'title agora: ' + document.querySelector('.play-btn').getAttribute('title');
+    });
+    console.log('  pausa  ', pausou);
+
+    const clip = await p.evaluate(() => {
+      const r = document.querySelector('canvas.stage-canvas').getBoundingClientRect();
+      return { x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) };
+    });
+
+    const olho = () => p.evaluate(async () => {
+      const card = Array.from(document.querySelectorAll('.effect-card'))
+        .find((c) => { const t2 = c.querySelector('.effect-title'); return t2 && t2.textContent.trim() === 'Posterize'; });
+      card.querySelector('.icon-btn').click();
+      await new Promise((r) => setTimeout(r, 700));
+      return card.className;
+    });
+
+    console.log('  ligado ', JSON.stringify(await p.evaluate(CONTEUDO)));
+    await p.screenshot({ path: path.join(OUT, 'ab-' + caso.nome + '-ligado.png'), clip });
+    console.log('  olho   ', await olho());
+    console.log('  deslig ', JSON.stringify(await p.evaluate(CONTEUDO)));
+    await p.screenshot({ path: path.join(OUT, 'ab-' + caso.nome + '-desligado.png'), clip });
+    await b.close();
+  }
+  console.log('');
+  console.log('fotos em ' + OUT);
+})();

--- a/scripts/_diag_webgl_stage.cjs
+++ b/scripts/_diag_webgl_stage.cjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Diagnostico: por que o palco webgl nao pinta no headless.
+const fs = require('fs'), path = require('path');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const OUT = path.resolve(__dirname, '..', '..', '_fx-shots');
+fs.mkdirSync(OUT, { recursive: true });
+
+(async () => {
+  const b = await puppeteer.launch({ executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+    args: (process.env.GLARGS||'--enable-gpu').split(','), defaultViewport: { width: 1600, height: 1000 } });
+  const p = await b.newPage();
+  p.on('console', (m) => { const t = m.text(); if (!/^\[Fast Refresh/.test(t)) console.log('  [console:' + m.type() + ']', t.slice(0, 220)); });
+  p.on('pageerror', (e) => console.log('  [pageerror]', String(e).slice(0, 300)));
+  await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await p.evaluate(() => {
+    localStorage.setItem('motion-welcome-seen', '1');
+    localStorage.setItem('motion-tour-seen', '1');
+  });
+  await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+  await new Promise((r) => setTimeout(r, 4000));
+
+  const antes = await p.evaluate(() => Array.from(document.querySelectorAll('canvas'))
+    .map((c) => c.width + 'x' + c.height + ' [' + c.className + ']'));
+  console.log('canvases antes:', JSON.stringify(antes));
+
+  console.log('clique:', await p.evaluate(async () => {
+    document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+    const linha = Array.from(document.querySelectorAll('.tpl-item'))
+      .find((el) => (el.textContent || '').trim().startsWith('Orbit 3D'));
+    if (!linha) return 'sem grupo Orbit 3D';
+    linha.click();
+    await new Promise((r) => setTimeout(r, 1200));
+    const card = Array.from(document.querySelectorAll('.tpl-card'))
+      .find((el) => { const l = el.querySelector('.tpl-card-label'); return l && l.textContent.trim() === 'Ring Stream'; });
+    if (!card) return 'sem card Ring Stream';
+    (card.querySelector('.tpl-card-label') || card).click();
+    await new Promise((r) => setTimeout(r, 5000));
+    return 'clicou';
+  }));
+
+  const dep = await p.evaluate(() => {
+    const out = { canvases: [], amostras: [] };
+    for (const c of Array.from(document.querySelectorAll('canvas'))) {
+      out.canvases.push({ wh: c.width + 'x' + c.height, cls: c.className, visivel: c.getBoundingClientRect().width | 0 });
+    }
+    const c = document.querySelector('canvas.stage-canvas');
+    if (c && c.width) {
+      const o = document.createElement('canvas'); o.width = c.width; o.height = c.height;
+      const g = o.getContext('2d'); g.drawImage(c, 0, 0);
+      const d = g.getImageData(0, 0, c.width, c.height).data;
+      let maxA = 0, maxL = 0, soma = 0;
+      for (let i = 0; i < d.length; i += 4) {
+        if (d[i + 3] > maxA) maxA = d[i + 3];
+        const l = (d[i] + d[i + 1] + d[i + 2]) / 3;
+        if (l > maxL) maxL = l;
+        soma += l;
+      }
+      out.leitura = { maxAlpha: maxA, maxLuma: Math.round(maxL), mediaLuma: +(soma / (d.length / 4)).toFixed(2) };
+    }
+    const st = localStorage.getItem('motion-scene-v1');
+    out.cenaAtiva = st ? JSON.parse(st).activeTemplateId : null;
+    return out;
+  });
+  console.log('depois:', JSON.stringify(dep, null, 2));
+  await p.screenshot({ path: path.join(OUT, 'diag-webgl-stage.png') });
+  await b.close();
+  console.log('foto:', path.join(OUT, 'diag-webgl-stage.png'));
+})();

--- a/scripts/_probe_context_churn.cjs
+++ b/scripts/_probe_context_churn.cjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Quantos contextos WebGL a pagina cria e PERDE ao trocar de preset?
+//
+// O erro que o usuario viu — THREE.WebGLRenderer: A WebGL context could not be
+// created. Reason: "Web page caused context loss and was blocked" — nao e falta
+// de contexto: e o Chrome BLOQUEANDO a criacao porque a propria pagina ja
+// causou perdas demais. A unica coisa no repo que causa perda de proposito e o
+// `forceContextLoss()` de `disposeShared3d()`, chamado quando a contagem de
+// referencias das miniaturas 3D chega a zero.
+//
+// Este probe instrumenta `getContext` e o `loseContext` da extensao, troca de
+// grupo no acordeao N vezes (o que desmonta todas as miniaturas do grupo antigo,
+// levando refs a zero) e conta: criados, perdidos de proposito e RECUSADOS.
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const VOLTAS = Number(process.argv[3] || 8);
+// Um grupo webgl e um 2D: alternar entre eles desmonta as miniaturas do outro.
+// Orbit 3D e webgl e Runway e 2D: alternar entre eles troca de ENGINE, que e o
+// que destroi e recria o renderer do palco. Stickers, que estava aqui antes,
+// tambem e webgl — a alternancia nao trocava de engine e o palco nem era
+// recriado, entao o probe media so as miniaturas.
+const GRUPOS = ['Orbit 3D', 'Runway'];
+
+const INSTRUMENTAR = function () {
+  const w = window;
+  w.__ctx = { criados: 0, recusados: 0, perdidosDeProposito: 0, erros: [], porCanvas: {}, vivos: 0 };
+  // Cada contexto criado entra num registro fraco para se saber quantos ainda
+  // estao VIVOS (nao perdidos) — criados sozinho nao distingue vazamento de
+  // reuso.
+  w.__ctxRefs = [];
+  const orig = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function (tipo, opts) {
+    const r = orig.call(this, tipo, opts);
+    if (/webgl/.test(String(tipo))) {
+      if (r) {
+        w.__ctx.criados++;
+        // quem pediu: a classe do canvas separa palco de miniatura
+        const quem = (this.className || this.id || '(sem classe)') + '';
+        w.__ctx.porCanvas[quem] = (w.__ctx.porCanvas[quem] || 0) + 1;
+        w.__ctxRefs.push({ gl: r, canvas: this, quem });
+        const ext = r.getExtension('WEBGL_lose_context');
+        if (ext && !ext.__hooked) {
+          const lose = ext.loseContext.bind(ext);
+          ext.loseContext = function () { w.__ctx.perdidosDeProposito++; return lose(); };
+          ext.__hooked = true;
+        }
+      } else {
+        w.__ctx.recusados++;
+      }
+    }
+    return r;
+  };
+};
+
+const TROCAR = async function (grupo) {
+  document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+  const linha = Array.from(document.querySelectorAll('.tpl-item'))
+    .find((el) => (el.textContent || '').trim().startsWith(grupo));
+  if (!linha) return 'grupo ' + grupo + ' nao achado';
+  linha.click();
+  await new Promise((r) => setTimeout(r, 1400));
+  const card = document.querySelector('.tpl-grid-accordion .tpl-card');
+  if (card) {
+    (card.querySelector('.tpl-card-label') || card).click();
+    await new Promise((r) => setTimeout(r, 2200));
+  }
+  return 'ok';
+};
+
+(async () => {
+  const b = await puppeteer.launch({
+    executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+    args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+  });
+  const p = await b.newPage();
+  const erros = [];
+  p.on('console', (m) => {
+    const t = m.text();
+    if (/context could not be created|context loss|CONTEXT_LOST|blocked/i.test(t)) erros.push(t.slice(0, 160));
+  });
+  p.on('pageerror', (e) => erros.push('[pageerror] ' + String(e).slice(0, 160)));
+  await p.evaluateOnNewDocument(INSTRUMENTAR);
+  await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await p.evaluate(() => {
+    localStorage.setItem('motion-welcome-seen', '1');
+    localStorage.setItem('motion-tour-seen', '1');
+  });
+  await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+  await new Promise((r) => setTimeout(r, 4000));
+  console.log('inicio ', JSON.stringify(await p.evaluate(() => window.__ctx)));
+
+  for (let i = 0; i < VOLTAS; i++) {
+    const g = GRUPOS[i % GRUPOS.length];
+    const r = await p.evaluate(TROCAR, g);
+    const c = await p.evaluate(() => {
+      const o = window.__ctx;
+      const vivos = window.__ctxRefs.filter((e) => !e.gl.isContextLost());
+      o.vivos = vivos.length;
+      // Vivo mas fora do documento = vazado: ninguem mais pode usar aquele
+      // contexto e ele segue contando contra o limite da pagina.
+      o.vazados = vivos.filter((e) => !document.contains(e.canvas)).length;
+      return o;
+    });
+    console.log(
+      'volta ' + String(i + 1).padStart(2) + '  ' + g.padEnd(9) + ' ' + r.padEnd(4)
+      + '  criados=' + String(c.criados).padStart(3)
+      + '  perdidosDeProposito=' + String(c.perdidosDeProposito).padStart(3)
+      + '  recusados=' + String(c.recusados).padStart(3)
+      + '  vivos=' + String(c.vivos).padStart(3)
+      + '  vazados=' + String(c.vazados).padStart(3),
+    );
+    if (c.recusados > 0) { console.log('  >>> o Chrome comecou a RECUSAR contexto nesta volta'); break; }
+  }
+
+  console.log('');
+  console.log('por canvas:', JSON.stringify((await p.evaluate(() => window.__ctx)).porCanvas));
+  console.log('mensagens de contexto (' + erros.length + '):');
+  for (const e of erros.slice(0, 8)) console.log('  ' + e);
+  await b.close();
+})();

--- a/scripts/_probe_context_route.cjs
+++ b/scripts/_probe_context_route.cjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Sair e voltar da biblioteca derruba contexto a cada volta?
+//
+// Trocar de grupo no acordeao nem sempre zera a contagem de referencias das
+// miniaturas — alguma lista pode manter uma montada. Sair da ROTA zera com
+// certeza: nenhuma miniatura sobrevive a /projects. Este e, portanto, o teste
+// que mede o ciclo destruir/recriar de verdade.
+//
+// Sem carencia, cada ida e volta custa um `forceContextLoss()` (three) e um
+// `app.destroy(true)` (Pixi), e sao essas perdas que o Chrome soma contra a
+// pagina ate recusar criacao com "Web page caused context loss and was
+// blocked". Com carencia de 10s, uma ida e volta rapida nao pode derrubar nada.
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const VOLTAS = Number(process.argv[3] || 10);
+
+const INSTRUMENTAR = function () {
+  const w = window;
+  w.__ctx = { criados: 0, recusados: 0, perdidosDeProposito: 0, porCanvas: {} };
+  w.__ctxRefs = [];
+  const orig = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function (tipo, opts) {
+    const r = orig.call(this, tipo, opts);
+    if (/webgl/.test(String(tipo))) {
+      if (r) {
+        w.__ctx.criados++;
+        const quem = (this.className || this.id || '(sem classe)') + '';
+        w.__ctx.porCanvas[quem] = (w.__ctx.porCanvas[quem] || 0) + 1;
+        w.__ctxRefs.push({ gl: r, canvas: this, quem });
+        const ext = r.getExtension('WEBGL_lose_context');
+        if (ext && !ext.__hooked) {
+          const lose = ext.loseContext.bind(ext);
+          ext.loseContext = function () { w.__ctx.perdidosDeProposito++; return lose(); };
+          ext.__hooked = true;
+        }
+      } else {
+        w.__ctx.recusados++;
+      }
+    }
+    return r;
+  };
+};
+
+// Navegacao pelo trilho, nao por goto: um goto recarrega a pagina e zera a
+// instrumentacao junto com o modulo, medindo outra coisa.
+const IR = async function (rotulo) {
+  document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+  const item = Array.from(document.querySelectorAll('.rail-item, .rail-action, a'))
+    .find((el) => (el.textContent || '').trim() === rotulo);
+  if (!item) return 'sem item ' + rotulo;
+  item.click();
+  await new Promise((r) => setTimeout(r, 2200));
+  return location.pathname;
+};
+
+(async () => {
+  const b = await puppeteer.launch({
+    executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+    args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+  });
+  const p = await b.newPage();
+  const erros = [];
+  p.on('console', (m) => {
+    const t = m.text();
+    if (/context could not be created|blocked|CONTEXT_LOST/i.test(t)) erros.push(t.slice(0, 160));
+  });
+  p.on('pageerror', (e) => erros.push('[pageerror] ' + String(e).slice(0, 160)));
+  await p.evaluateOnNewDocument(INSTRUMENTAR);
+  await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await p.evaluate(() => {
+    localStorage.setItem('motion-welcome-seen', '1');
+    localStorage.setItem('motion-tour-seen', '1');
+  });
+  await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+  await new Promise((r) => setTimeout(r, 4000));
+  const ler = () => p.evaluate(() => {
+    const o = window.__ctx;
+    const vivos = window.__ctxRefs.filter((e) => !e.gl.isContextLost());
+    return { criados: o.criados, perdidos: o.perdidosDeProposito, recusados: o.recusados,
+      vivos: vivos.length, porCanvas: o.porCanvas };
+  });
+  console.log('inicio ', JSON.stringify(await ler()));
+
+  for (let i = 0; i < VOLTAS; i++) {
+    const fora = await p.evaluate(IR, 'Projects');
+    const volta = await p.evaluate(IR, 'Library');
+    const c = await ler();
+    console.log('volta ' + String(i + 1).padStart(2)
+      + '  ' + String(fora).padEnd(10) + ' -> ' + String(volta).padEnd(10)
+      + '  criados=' + String(c.criados).padStart(3)
+      + '  perdidos=' + String(c.perdidos).padStart(3)
+      + '  recusados=' + String(c.recusados).padStart(3)
+      + '  vivos=' + String(c.vivos).padStart(3));
+    if (c.recusados > 0) { console.log('  >>> o Chrome RECUSOU contexto nesta volta'); break; }
+  }
+  console.log('');
+  console.log('por canvas:', JSON.stringify((await ler()).porCanvas));
+  console.log('mensagens (' + erros.length + '):');
+  for (const e of erros.slice(0, 6)) console.log('  ' + e);
+  await b.close();
+})();

--- a/scripts/_probe_effects_ui.cjs
+++ b/scripts/_probe_effects_ui.cjs
@@ -1,4 +1,20 @@
 #!/usr/bin/env node
+// ATENCAO: ESTE PROBE E INSTAVEL (flaky). Rodado duas vezes sem alterar nada,
+// deu resultados diferentes — numa passada Vignette/Halftone/Posterize
+// mediram o efeito, na seguinte voltaram ao baseline. A causa e timing: depois
+// de recarregar, o palco leva um tempo variavel para reaplicar o efeito
+// adicionado, e nenhuma espera fixa cobriu isso de forma confiavel.
+//
+// Use-o como INDICADOR, nunca como prova. A prova determinista dos efeitos e
+// scripts/verify-effects-gl.cjs, que compila o shader real em GPU e mede — essa
+// repete. O que este probe mostra bem, quando pega a janela, e que a fiacao
+// painel -> store -> renderer funciona: ja vi aqui o Halftone zerar a cor
+// (maxRB 0, que e o modo mono), o Posterize saturar as bandas (maxRB 255) e o
+// Vignette apagar o centro.
+//
+// Para torna-lo confiavel seria preciso esperar a CONDICAO (o palco mudar em
+// relacao ao baseline) em vez de um tempo, com um limite de tentativas.
+//
 // Prova os efeitos NO APP: semeia uma cena com conteudo, aplica cada efeito pelo
 // painel (select + Add, o caminho do usuario) e mede o palco.
 //
@@ -13,7 +29,7 @@ const b=await puppeteer.launch({executablePath:CHROME,headless:'new',args:['--en
 const p=await b.newPage();
 p.on('pageerror',e=>console.log('  [pageerror]',String(e).slice(0,200)));
 await p.goto(U+'/library',{waitUntil:'domcontentloaded',timeout:180000});
-await p.evaluate(()=>{
+const semear = () => p.evaluate(()=>{
   localStorage.setItem('motion-welcome-seen','1'); localStorage.setItem('motion-tour-seen','1');
   const scene={activeTemplateId:'arc-01',tracks:[{id:'t0',templateId:'arc-01'}],
     width:810,height:1080,fps:30,duration:8,
@@ -22,6 +38,7 @@ await p.evaluate(()=>{
   localStorage.setItem('motion-project-fx',JSON.stringify(scene));
   localStorage.setItem('motion-projects-v1',JSON.stringify({activeId:'fx',projects:[{id:'fx',name:'Teste de efeitos',createdAt:1,updatedAt:2,mode:'2d'}]}));
 });
+await semear();
 await p.goto(U+'/library',{waitUntil:'networkidle2',timeout:180000});
 // espera CONTEUDO, nao tempo
 const pintou=await p.waitForFunction(()=>{
@@ -75,20 +92,36 @@ const aplicar=(nome)=>p.evaluate(async(nome)=>{
 const base=await medir();
 console.log('sem efeito        ', JSON.stringify(base));
 const linhas=[];
-for(const nome of ['Grain','Vignette','RGB Split','Pixelate']){
+for(const nome of ['Grain','Vignette','Halftone','Posterize','Scanlines','Pixelate','RGB Split','Wave']){
   const r=await aplicar(nome);
-  await new Promise(x=>setTimeout(x,2500));
+  await new Promise(x=>setTimeout(x,7000));
   const m=await medir();
   linhas.push({nome,r,m});
   console.log(nome.padEnd(18), r==='ok'?JSON.stringify(m):('FALHOU: '+r));
   const cv=await p.$('canvas.stage-canvas');
   if(cv) await cv.screenshot({path:path.join(OUT,nome.replace(/ /g,'-').toLowerCase()+'.png')});
-  await p.evaluate(async()=>{
-    for(const btn of [...document.querySelectorAll('.effect-card .icon-btn')]){
-      if(/remove/i.test(btn.getAttribute('aria-label')||'')){ btn.click(); await new Promise(r=>setTimeout(r,180)); btn.click(); await new Promise(r=>setTimeout(r,250)); }
-    }
-  });
-  await new Promise(x=>setTimeout(x,1500));
+  // ISOLAMENTO: RE-SEMEAR E RECARREGAR.
+  //
+  // Duas coisas descobertas medindo, nao supondo. Primeiro: remover por clique
+  // nao limpava, e os efeitos acumulavam — a luma caia monotonicamente e toda
+  // medida depois da primeira media o empilhamento. Segundo: recarregar TAMBEM
+  // nao limpa, porque o autosave ja persistiu o efeito no projeto e a recarga
+  // hidrata dali; diagnosticado vendo o painel voltar com ["Vignette",
+  // "Halftone"] na segunda volta. So re-escrever a cena semeada (com effects
+  // vazio) antes de recarregar isola de verdade.
+  await semear();
+  await p.goto(U+"/library",{waitUntil:"networkidle2",timeout:180000});
+  // Espera o PALCO pintar, nao um tempo fixo: com 3s o renderer ainda estava
+  // subindo e a medida saia igual a do baseline.
+  await p.waitForFunction(()=>{
+    const c=document.querySelector("canvas.stage-canvas"); if(!c||!c.width) return false;
+    const o=document.createElement("canvas");o.width=c.width;o.height=c.height;
+    const g=o.getContext("2d");g.drawImage(c,0,0);
+    const d=g.getImageData(0,0,c.width,c.height).data;
+    let m=0,n=0;for(let i=0;i<d.length;i+=4){m+=d[i];n++;}m/=n;
+    let v=0;for(let i=0;i<d.length;i+=4){const q=d[i]-m;v+=q*q;}
+    return Math.sqrt(v/n)>8;
+  },{timeout:60000,polling:500}).catch(()=>{});
 }
 console.log('\n--- veredito ---');
 const g=linhas.find(l=>l.nome==='Grain'), v=linhas.find(l=>l.nome==='Vignette'), s=linhas.find(l=>l.nome==='RGB Split');

--- a/scripts/_probe_posterize.cjs
+++ b/scripts/_probe_posterize.cjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// Prova o Posterize NO APP, nos DOIS engines, esperando a CONDICAO (nao tempo).
+//
+// A prova de GPU (verify-effects-gl) compila o shader isolado; ela nao ve a
+// fiacao painel -> store -> renderer nem o espaco de cor que cada engine
+// entrega. Este mede o palco: quantos NIVEIS distintos por canal existem nos
+// pixels do conteudo, e com que ESPACAMENTO. Posterize com n niveis tem de dar
+// no maximo n valores por canal, igualmente espacados entre 0 e 255.
+//
+// Espera por condicao com limite de tentativas, que e o que faltava no
+// _probe_effects_ui.cjs (marcado instavel por esperar tempo fixo).
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const LEVELS = Number(process.argv[3] || 4);
+const OUT = path.resolve(__dirname, '..', '..', '_fx-shots');
+fs.mkdirSync(OUT, { recursive: true });
+
+const CASOS = [
+  { nome: '2D (Pixi)', templateId: 'arc-01', rotulo: 'Arc Fan', grupo: 'Arc' },
+  // Semear o webgl pelo localStorage nao acorda o engine 3D: o palco fica
+  // vazio. O preset e escolhido pelo trilho, que e o caminho que troca o
+  // renderer de verdade.
+  { nome: 'webgl (three)', templateId: 'orbit-3d-01', rotulo: 'Ring Stream', grupo: 'Orbit 3D' },
+];
+
+// medicao: niveis distintos por canal nos pixels de CONTEUDO (fundo excluido)
+const MEDIR = function () {
+  const c = document.querySelector('canvas.stage-canvas');
+  if (!c || !c.width) return null;
+  const o = document.createElement('canvas');
+  o.width = c.width; o.height = c.height;
+  const g = o.getContext('2d');
+  g.drawImage(c, 0, 0);
+  const d = g.getImageData(0, 0, c.width, c.height).data;
+  // o fundo e chapado: a cor mais frequente e ele, e sai da conta
+  const hist = new Map();
+  for (let i = 0; i < d.length; i += 4) {
+    const k = d[i] + ',' + d[i + 1] + ',' + d[i + 2];
+    hist.set(k, (hist.get(k) || 0) + 1);
+  }
+  let fundo = [0, 0, 0], max = 0;
+  for (const [k, n] of hist) if (n > max) { max = n; fundo = k.split(',').map(Number); }
+  const setR = new Set(), setG = new Set(), setB = new Set();
+  let conteudo = 0;
+  for (let i = 0; i < d.length; i += 4) {
+    const dist = Math.abs(d[i] - fundo[0]) + Math.abs(d[i + 1] - fundo[1]) + Math.abs(d[i + 2] - fundo[2]);
+    if (dist < 24) continue;
+    conteudo++;
+    setR.add(d[i]); setG.add(d[i + 1]); setB.add(d[i + 2]);
+  }
+  const listaR = Array.from(setR).sort((a, b) => a - b);
+  const passos = [];
+  for (let i = 1; i < listaR.length; i++) passos.push(listaR[i] - listaR[i - 1]);
+  return {
+    conteudo, fundo,
+    niveisR: setR.size, niveisG: setG.size, niveisB: setB.size,
+    listaR: listaR.length <= 24 ? listaR : null,
+    passos: passos.length <= 23 ? passos : null,
+  };
+};
+
+const semear = function (tid) {
+  const scene = {
+    activeTemplateId: tid,
+    tracks: [{ id: 't0', templateId: tid }],
+    width: 810, height: 1080, fps: 30, duration: 8,
+    background: { source: 'color', color: '#1a1a1a', gradient: false, color2: '#1a1a1a', imageUrl: null, blur: 28 },
+    effects: [],
+  };
+  localStorage.setItem('motion-welcome-seen', '1');
+  localStorage.setItem('motion-tour-seen', '1');
+  localStorage.setItem('motion-scene-v1', JSON.stringify(scene));
+  localStorage.setItem('motion-project-fx', JSON.stringify(scene));
+  localStorage.setItem('motion-projects-v1', JSON.stringify({
+    activeId: 'fx',
+    projects: [{ id: 'fx', name: 'Teste posterize', createdAt: 1, updatedAt: 2, mode: '2d' }],
+  }));
+};
+
+const aplicarPosterize = async function (lv) {
+  const sel = Array.from(document.querySelectorAll('select'))
+    .find((s) => Array.from(s.options).some((o) => o.textContent.trim() === 'Posterize'));
+  if (!sel) return 'sem select de efeitos';
+  const opt = Array.from(sel.options).find((o) => o.textContent.trim() === 'Posterize');
+  sel.value = opt.value;
+  sel.dispatchEvent(new Event('change', { bubbles: true }));
+  await new Promise((r) => setTimeout(r, 150));
+  const add = Array.from(document.querySelectorAll('button')).find((b) => b.textContent.trim() === 'Add');
+  if (!add) return 'sem botao Add';
+  add.click();
+  await new Promise((r) => setTimeout(r, 500));
+  const card = Array.from(document.querySelectorAll('.effect-card'))
+    .find((c) => {
+      const t = c.querySelector('.effect-title');
+      return t && t.textContent.trim() === 'Posterize';
+    });
+  if (!card) return 'card do Posterize nao apareceu';
+  const range = card.querySelector('input[type=range]');
+  if (!range) return 'ok, sem slider Levels';
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+  setter.call(range, String(lv));
+  range.dispatchEvent(new Event('input', { bubbles: true }));
+  range.dispatchEvent(new Event('change', { bubbles: true }));
+  await new Promise((r) => setTimeout(r, 300));
+  return 'ok, levels=' + range.value;
+};
+
+const clipDoPalco = function () {
+  const r = document.querySelector('canvas.stage-canvas').getBoundingClientRect();
+  return { x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) };
+};
+
+(async () => {
+  if (!CHROME) { console.error('Chrome nao encontrado'); process.exit(2); }
+
+  const esperado = [];
+  for (let i = 0; i < LEVELS; i++) esperado.push(Math.round((i / (LEVELS - 1)) * 255));
+
+  for (const caso of CASOS) {
+    console.log('');
+    console.log('=== ' + caso.nome + '  (' + caso.templateId + ') ===');
+    // Um navegador POR CASO. Com um so, o segundo engine caia em
+    // "THREE.WebGLRenderer: Error creating WebGL context" — o contexto do
+    // primeiro engine nao volta a tempo dentro da mesma pagina.
+    const b = await puppeteer.launch({
+      executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+      // --use-angle=gl derrubava o contexto WebGL do palco 3D (VALIDATE_STATUS
+      // false e CONTEXT_LOST logo depois). Com o ANGLE padrao do Chrome pinta.
+      args: ['--enable-gpu'],
+      defaultViewport: { width: 1600, height: 1000 },
+    });
+    const p = await b.newPage();
+    p.on('pageerror', (e) => console.log('  [pageerror]', String(e).slice(0, 200)));
+    await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+    await p.evaluate(semear, caso.templateId);
+    await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+
+    // Escolhe o preset pelo trilho. Modal de boas-vindas escondido antes: um
+    // .click() passa por tras do backdrop sem reclamar.
+    const escolheu = await p.evaluate(async (rotulo, grupo) => {
+      document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => {
+        el.style.display = 'none';
+      });
+      // A lista e um acordeao de DOIS niveis: `.tpl-item` e a linha do GRUPO, e
+      // o preset so existe no DOM com o grupo aberto — ai ele e um `.tpl-card`
+      // com `.tpl-card-label`. Procurar o preset entre os `.tpl-item` acha
+      // sempre o grupo e nunca o preset.
+      const achar = () => Array.from(document.querySelectorAll('.tpl-card'))
+        .find((el) => {
+          const l = el.querySelector('.tpl-card-label');
+          return l && l.textContent.trim() === rotulo;
+        });
+      if (!achar()) {
+        const linha = Array.from(document.querySelectorAll('.tpl-item'))
+          .find((el) => (el.textContent || '').trim().startsWith(grupo));
+        if (!linha) {
+          const vistos = Array.from(document.querySelectorAll('.tpl-item'))
+            .map((el) => (el.textContent || '').trim().slice(0, 14));
+          return 'grupo ' + grupo + ' nao achado; grupos: ' + JSON.stringify(vistos.slice(0, 8));
+        }
+        linha.click();
+        await new Promise((r) => setTimeout(r, 900));
+      }
+      const card = achar();
+      if (!card) return 'preset ' + rotulo + ' nao apareceu com o grupo aberto';
+      card.scrollIntoView({ block: 'center' });
+      await new Promise((r) => setTimeout(r, 250));
+      // O rotulo, nao a miniatura: o canvas da miniatura fica por cima do card.
+      (card.querySelector('.tpl-card-label') || card).click();
+      await new Promise((r) => setTimeout(r, 3000));
+      return 'clicou em ' + rotulo;
+    }, caso.rotulo, caso.grupo);
+    console.log('  preset ', escolheu);
+
+    const pintou = await p.waitForFunction(
+      function (fn) {
+        // eslint-disable-next-line no-new-func
+        const m = new Function('return (' + fn + ')()')();
+        return !!m && m.conteudo > 20000 && m.niveisR > 40;
+      },
+      { timeout: 90000, polling: 700 }, MEDIR.toString(),
+    ).then(() => true).catch(() => false);
+
+    const base = await p.evaluate(MEDIR);
+    if (!pintou) {
+      console.log('  palco nao pintou conteudo suficiente:', JSON.stringify(base));
+      await b.close();
+      continue;
+    }
+    console.log('  antes  ', JSON.stringify({
+      conteudo: base.conteudo, niveisR: base.niveisR, niveisG: base.niveisG, niveisB: base.niveisB,
+    }));
+    await p.screenshot({ path: path.join(OUT, 'post-antes-' + caso.templateId + '.png'), clip: await p.evaluate(clipDoPalco) });
+
+    console.log('  aplicar', await p.evaluate(aplicarPosterize, LEVELS));
+
+    const alvo = Math.max(4, Math.floor(base.niveisR / 3));
+    const caiu = await p.waitForFunction(
+      function (fn, alvo) {
+        // eslint-disable-next-line no-new-func
+        const m = new Function('return (' + fn + ')()')();
+        return !!m && m.niveisR < alvo;
+      },
+      { timeout: 25000, polling: 500 }, MEDIR.toString(), alvo,
+    ).then(() => true).catch(() => false);
+
+    const dep = await p.evaluate(MEDIR);
+    console.log('  depois ', JSON.stringify(dep));
+    console.log('  niveis cairam abaixo de ' + alvo + '?', caiu ? 'SIM' : 'NAO');
+    console.log('  esperado com levels=' + LEVELS + ':', JSON.stringify(esperado));
+    await p.screenshot({ path: path.join(OUT, 'post-depois-' + caso.templateId + '.png'), clip: await p.evaluate(clipDoPalco) });
+    await b.close();
+  }
+
+  console.log('');
+  console.log('fotos em ' + OUT);
+})();

--- a/scripts/_probe_posterize_levels.cjs
+++ b/scripts/_probe_posterize_levels.cjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// O controle Levels do Posterize move o palco?
+//
+// O slider do app nao e <input type=range>: e um `.strack` proprio, que le
+// pointerdown/pointermove. So mouse de verdade prova que ele funciona — e a
+// prova e a CONTAGEM DE NIVEIS no palco, nao o numero escrito na tela.
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const ALVOS = [2, 3, 8, 16];
+
+const MEDIR = function () {
+  const c = document.querySelector('canvas.stage-canvas');
+  if (!c || !c.width) return null;
+  const o = document.createElement('canvas');
+  o.width = c.width; o.height = c.height;
+  const g = o.getContext('2d');
+  g.drawImage(c, 0, 0);
+  const d = g.getImageData(0, 0, c.width, c.height).data;
+  const hist = new Map();
+  for (let i = 0; i < d.length; i += 4) {
+    const k = d[i] + ',' + d[i + 1] + ',' + d[i + 2];
+    hist.set(k, (hist.get(k) || 0) + 1);
+  }
+  let fundo = [0, 0, 0], max = 0;
+  for (const [k, n] of hist) if (n > max) { max = n; fundo = k.split(',').map(Number); }
+  const setR = new Set();
+  let conteudo = 0;
+  for (let i = 0; i < d.length; i += 4) {
+    const dist = Math.abs(d[i] - fundo[0]) + Math.abs(d[i + 1] - fundo[1]) + Math.abs(d[i + 2] - fundo[2]);
+    if (dist < 24) continue;
+    conteudo++;
+    setR.add(d[i]);
+  }
+  const lista = Array.from(setR).sort((a, b) => a - b);
+  return { conteudo, fundo, niveis: lista.length, lista: lista.length <= 20 ? lista : null };
+};
+
+(async () => {
+  const b = await puppeteer.launch({
+    executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+    args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+  });
+  const p = await b.newPage();
+  p.on('pageerror', (e) => console.log('  [pageerror]', String(e).slice(0, 200)));
+  await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+  // Mesma semeadura do _probe_posterize.cjs: sem um projeto ativo o palco fica
+  // vazio e nao ha o que medir.
+  await p.evaluate(() => {
+    const scene = {
+      activeTemplateId: 'arc-01',
+      tracks: [{ id: 't0', templateId: 'arc-01' }],
+      width: 810, height: 1080, fps: 30, duration: 8,
+      background: { source: 'color', color: '#1a1a1a', gradient: false, color2: '#1a1a1a', imageUrl: null, blur: 28 },
+      effects: [],
+    };
+    localStorage.setItem('motion-welcome-seen', '1');
+    localStorage.setItem('motion-tour-seen', '1');
+    localStorage.setItem('motion-scene-v1', JSON.stringify(scene));
+    localStorage.setItem('motion-project-fx', JSON.stringify(scene));
+    localStorage.setItem('motion-projects-v1', JSON.stringify({
+      activeId: 'fx',
+      projects: [{ id: 'fx', name: 'Teste posterize', createdAt: 1, updatedAt: 2, mode: '2d' }],
+    }));
+  });
+  await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+  await p.evaluate(() => {
+    document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+  });
+  await p.waitForFunction(
+    function (fn) { const m = new Function('return (' + fn + ')()')(); return !!m && m.conteudo > 20000; },
+    { timeout: 60000, polling: 700 }, MEDIR.toString(),
+  );
+  console.log('baseline', JSON.stringify(await p.evaluate(MEDIR)));
+
+  console.log('add    ', await p.evaluate(async () => {
+    const sel = Array.from(document.querySelectorAll('select'))
+      .find((s) => Array.from(s.options).some((o) => o.textContent.trim() === 'Posterize'));
+    if (!sel) return 'sem select';
+    sel.value = Array.from(sel.options).find((o) => o.textContent.trim() === 'Posterize').value;
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 150));
+    const add = Array.from(document.querySelectorAll('button')).find((btn) => btn.textContent.trim() === 'Add');
+    add.click();
+    await new Promise((r) => setTimeout(r, 1200));
+    const card = Array.from(document.querySelectorAll('.effect-card'))
+      .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === 'Posterize'; });
+    if (!card) return 'sem card';
+    card.scrollIntoView({ block: 'center' });
+    return 'ok, controles: ' + card.querySelectorAll('.strack').length;
+  }));
+  await new Promise((r) => setTimeout(r, 800));
+  console.log('default', JSON.stringify(await p.evaluate(MEDIR)));
+
+  // o retangulo do slider Levels, em coordenadas de viewport
+  const caixa = await p.evaluate(() => {
+    const card = Array.from(document.querySelectorAll('.effect-card'))
+      .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === 'Posterize'; });
+    const st = card && card.querySelector('.strack');
+    if (!st) return null;
+    const r = st.getBoundingClientRect();
+    return { x: r.x, y: r.y, w: r.width, h: r.height, texto: st.textContent.trim().slice(0, 40) };
+  });
+  console.log('slider ', JSON.stringify(caixa));
+  if (!caixa) { await b.close(); return; }
+
+  const MIN = 2, MAX = 16;
+  for (const alvo of ALVOS) {
+    const t = (alvo - MIN) / (MAX - MIN);
+    // a borda do trilho nao aceita clique (clamp de 6px), entao vem de dentro
+    const x = caixa.x + 6 + t * (caixa.w - 12);
+    const y = caixa.y + caixa.h / 2;
+    await p.mouse.move(x, y);
+    await p.mouse.down();
+    await p.mouse.move(x, y);
+    await p.mouse.up();
+    await new Promise((r) => setTimeout(r, 900));
+    const lido = await p.evaluate(() => {
+      const card = Array.from(document.querySelectorAll('.effect-card'))
+        .find((c) => { const t2 = c.querySelector('.effect-title'); return t2 && t2.textContent.trim() === 'Posterize'; });
+      const st = card.querySelector('.strack');
+      return st.textContent.trim().replace(/\s+/g, ' ');
+    });
+    const m = await p.evaluate(MEDIR);
+    console.log('levels=' + String(alvo).padStart(2) + '  painel="' + lido + '"  palco=' + JSON.stringify(m));
+  }
+  await b.close();
+})();

--- a/scripts/_probe_posterize_mix.cjs
+++ b/scripts/_probe_posterize_mix.cjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// O controle Mix do Posterize devolve o fundo e a silhueta dos cards?
+//
+// A medida nao e "parece melhor": e a COR DO FUNDO (a mais frequente do quadro)
+// e a contagem de pixels ainda distinguiveis dela. Com Mix em 100 o fundo
+// #1a1a1a (26) cai para 0 e os pretos do card colapsam nele; conforme o Mix
+// desce, o fundo tem de voltar na direcao de 26 e a contagem de conteudo tem de
+// subir. Mix em 0 tem de ser identidade: fundo 26 e ~256 niveis.
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const PONTOS = [100, 75, 50, 25, 0];
+
+const MEDIR = function () {
+  const c = document.querySelector('canvas.stage-canvas');
+  if (!c || !c.width) return null;
+  const o = document.createElement('canvas');
+  o.width = c.width; o.height = c.height;
+  const g = o.getContext('2d'); g.drawImage(c, 0, 0);
+  const d = g.getImageData(0, 0, c.width, c.height).data;
+  const hist = new Map();
+  for (let i = 0; i < d.length; i += 4) {
+    const k = d[i] + ',' + d[i + 1] + ',' + d[i + 2];
+    hist.set(k, (hist.get(k) || 0) + 1);
+  }
+  let fundo = [0, 0, 0], max = 0;
+  for (const [k, n] of hist) if (n > max) { max = n; fundo = k.split(',').map(Number); }
+  const set = new Set();
+  let conteudo = 0;
+  for (let i = 0; i < d.length; i += 4) {
+    set.add(d[i]);
+    const dist = Math.abs(d[i] - fundo[0]) + Math.abs(d[i + 1] - fundo[1]) + Math.abs(d[i + 2] - fundo[2]);
+    if (dist >= 24) conteudo++;
+  }
+  return { fundo: fundo[0], conteudo, niveis: set.size };
+};
+
+const semear = function () {
+  const scene = {
+    activeTemplateId: 'arc-01',
+    tracks: [{ id: 't0', templateId: 'arc-01' }],
+    width: 810, height: 1080, fps: 30, duration: 8,
+    background: { source: 'color', color: '#1a1a1a', gradient: false, color2: '#1a1a1a', imageUrl: null, blur: 28 },
+    effects: [],
+  };
+  localStorage.setItem('motion-welcome-seen', '1');
+  localStorage.setItem('motion-tour-seen', '1');
+  localStorage.setItem('motion-scene-v1', JSON.stringify(scene));
+  localStorage.setItem('motion-project-fx', JSON.stringify(scene));
+  localStorage.setItem('motion-projects-v1', JSON.stringify({
+    activeId: 'fx', projects: [{ id: 'fx', name: 'Mix posterize', createdAt: 1, updatedAt: 2, mode: '2d' }],
+  }));
+};
+
+(async () => {
+  const b = await puppeteer.launch({
+    executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+    args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+  });
+  const p = await b.newPage();
+  p.on('pageerror', (e) => console.log('  [pageerror]', String(e).slice(0, 200)));
+  await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await p.evaluate(semear);
+  await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+  await p.evaluate(() => {
+    document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+  });
+  await p.waitForFunction(
+    function (fn) { const m = new Function('return (' + fn + ')()')(); return !!m && m.conteudo > 20000; },
+    { timeout: 60000, polling: 700 }, MEDIR.toString(),
+  );
+  console.log('sem efeito  ', JSON.stringify(await p.evaluate(MEDIR)));
+
+  const rotulos = await p.evaluate(async () => {
+    const sel = Array.from(document.querySelectorAll('select'))
+      .find((s) => Array.from(s.options).some((o) => o.textContent.trim() === 'Posterize'));
+    sel.value = Array.from(sel.options).find((o) => o.textContent.trim() === 'Posterize').value;
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 150));
+    Array.from(document.querySelectorAll('button')).find((btn) => btn.textContent.trim() === 'Add').click();
+    await new Promise((r) => setTimeout(r, 1400));
+    const card = Array.from(document.querySelectorAll('.effect-card'))
+      .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === 'Posterize'; });
+    if (!card) return null;
+    card.scrollIntoView({ block: 'center' });
+    return Array.from(card.querySelectorAll('.ctl-row, .control-row, label'))
+      .map((el) => el.textContent.trim().slice(0, 20));
+  });
+  console.log('controles   ', JSON.stringify(rotulos));
+
+  // pausa: as leituras tem de sair do mesmo frame
+  console.log('pausa       ', await p.evaluate(async () => {
+    const btn = document.querySelector('.play-btn');
+    if (btn && btn.getAttribute('title') === 'Pause') { btn.click(); await new Promise((r) => setTimeout(r, 600)); }
+    return document.querySelector('.play-btn').getAttribute('title');
+  }));
+
+  // o SEGUNDO .strack do card e o Mix (o primeiro e Levels)
+  const caixa = await p.evaluate(() => {
+    const card = Array.from(document.querySelectorAll('.effect-card'))
+      .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === 'Posterize'; });
+    const st = card.querySelectorAll('.strack');
+    if (st.length < 2) return { erro: 'o card tem ' + st.length + ' slider(s); Mix nao apareceu' };
+    const r = st[1].getBoundingClientRect();
+    return { x: r.x, y: r.y, w: r.width, h: r.height, texto: st[1].textContent.trim() };
+  });
+  console.log('slider Mix  ', JSON.stringify(caixa));
+  if (caixa.erro) { await b.close(); return; }
+
+  for (const alvo of PONTOS) {
+    const x = caixa.x + 6 + (alvo / 100) * (caixa.w - 12);
+    const y = caixa.y + caixa.h / 2;
+    await p.mouse.move(x, y); await p.mouse.down(); await p.mouse.move(x, y); await p.mouse.up();
+    await new Promise((r) => setTimeout(r, 800));
+    const painel = await p.evaluate(() => {
+      const card = Array.from(document.querySelectorAll('.effect-card'))
+        .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === 'Posterize'; });
+      return card.querySelectorAll('.strack')[1].textContent.trim().replace(/\s+/g, ' ');
+    });
+    console.log('mix=' + String(alvo).padStart(3) + '  painel="' + painel + '"  ' + JSON.stringify(await p.evaluate(MEDIR)));
+  }
+  await b.close();
+})();

--- a/scripts/_probe_thumb_lifecycle.cjs
+++ b/scripts/_probe_thumb_lifecycle.cjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// O contexto das miniaturas sobrevive, e as miniaturas voltam a pintar?
+//
+// Duas perguntas, porque a correcao troca destruir por limpar e as duas podem
+// quebrar em direcoes opostas:
+//
+//   1. a pagina NUNCA pode causar perda de contexto por conta propria — e a
+//      soma dessas perdas que faz o Chrome recusar criacao com "Web page caused
+//      context loss and was blocked"
+//   2. depois da carencia (que solta o canvas e joga fora o cache de geometria)
+//      as miniaturas tem de voltar a pintar, senao a correcao trocou um bug por
+//      outro
+//
+// A prova de (2) e CONTEUDO de imagem, nao presenca de <img>: um still vazio
+// tem src e nao mostra nada.
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const ESPERA_MS = Number(process.argv[3] || 13000); // > CARENCIA_MS
+
+const INSTRUMENTAR = function () {
+  const w = window;
+  w.__ctx = { criados: 0, recusados: 0, perdidosDeProposito: 0, porCanvas: {} };
+  w.__ctxRefs = [];
+  const orig = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function (tipo, opts) {
+    const r = orig.call(this, tipo, opts);
+    if (/webgl/.test(String(tipo))) {
+      if (r) {
+        w.__ctx.criados++;
+        const quem = (this.className || this.id || '(sem classe)') + '';
+        w.__ctx.porCanvas[quem] = (w.__ctx.porCanvas[quem] || 0) + 1;
+        w.__ctxRefs.push({ gl: r, canvas: this });
+        const ext = r.getExtension('WEBGL_lose_context');
+        if (ext && !ext.__hooked) {
+          const lose = ext.loseContext.bind(ext);
+          ext.loseContext = function () { w.__ctx.perdidosDeProposito++; return lose(); };
+          ext.__hooked = true;
+        }
+      } else { w.__ctx.recusados++; }
+    }
+    return r;
+  };
+};
+
+// Quantas miniaturas realmente PINTARAM: o still e lido num canvas 2D e so
+// conta se tiver variacao de pixel.
+const MINIATURAS = async function () {
+  const imgs = Array.from(document.querySelectorAll('.tpl-thumb img'))
+    .filter((im) => im.src && im.naturalWidth > 0);
+  let pintadas = 0;
+  for (const im of imgs.slice(0, 24)) {
+    const c = document.createElement('canvas');
+    c.width = Math.min(60, im.naturalWidth); c.height = Math.min(80, im.naturalHeight);
+    const g = c.getContext('2d');
+    try { g.drawImage(im, 0, 0, c.width, c.height); } catch { continue; }
+    const d = g.getImageData(0, 0, c.width, c.height).data;
+    let m = 0, n = 0;
+    for (let i = 0; i < d.length; i += 4) { m += d[i]; n++; }
+    m /= n;
+    let s = 0;
+    for (let i = 0; i < d.length; i += 4) { const v = d[i] - m; s += v * v; }
+    if (Math.sqrt(s / n) > 3) pintadas++;
+  }
+  return { comImg: imgs.length, pintadas, esqueletos: document.querySelectorAll('.tpl-thumb-skeleton').length };
+};
+
+const IR = async function (rotulo) {
+  document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+  const item = Array.from(document.querySelectorAll('.rail-item, .rail-action, a'))
+    .find((el) => (el.textContent || '').trim() === rotulo);
+  if (!item) return 'sem item ' + rotulo;
+  item.click();
+  await new Promise((r) => setTimeout(r, 2500));
+  return location.pathname;
+};
+
+(async () => {
+  const b = await puppeteer.launch({
+    executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+    args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+  });
+  const p = await b.newPage();
+  const erros = [];
+  p.on('console', (m) => {
+    const t = m.text();
+    if (/could not be created|blocked|CONTEXT_LOST/i.test(t)) erros.push(t.slice(0, 150));
+  });
+  p.on('pageerror', (e) => erros.push('[pageerror] ' + String(e).slice(0, 150)));
+  await p.evaluateOnNewDocument(INSTRUMENTAR);
+  await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await p.evaluate(() => {
+    localStorage.setItem('motion-welcome-seen', '1');
+    localStorage.setItem('motion-tour-seen', '1');
+  });
+  await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+  await new Promise((r) => setTimeout(r, 6000));
+
+  const ler = () => p.evaluate(() => {
+    const o = window.__ctx;
+    return { criados: o.criados, perdidos: o.perdidosDeProposito, recusados: o.recusados,
+      vivos: window.__ctxRefs.filter((e) => !e.gl.isContextLost()).length, porCanvas: o.porCanvas };
+  });
+
+  console.log('inicio      ', JSON.stringify(await ler()));
+  console.log('  miniaturas', JSON.stringify(await p.evaluate(MINIATURAS)));
+
+  // Sai da biblioteca, fica MAIS que a carencia, e volta. E o caso que a
+  // carencia existe para cobrir — e o unico em que a limpeza roda de verdade.
+  console.log('sai         ', await p.evaluate(IR, 'Projects'));
+  await new Promise((r) => setTimeout(r, ESPERA_MS));
+  console.log('  apos ' + ESPERA_MS + 'ms fora', JSON.stringify(await ler()));
+  console.log('volta       ', await p.evaluate(IR, 'Library'));
+  await new Promise((r) => setTimeout(r, 6000));
+  console.log('  ', JSON.stringify(await ler()));
+  console.log('  miniaturas', JSON.stringify(await p.evaluate(MINIATURAS)));
+
+  console.log('');
+  console.log('mensagens (' + erros.length + '):');
+  for (const e of erros.slice(0, 6)) console.log('  ' + e);
+  await b.close();
+})();

--- a/scripts/verify-contexts.cjs
+++ b/scripts/verify-contexts.cjs
@@ -166,6 +166,54 @@ const pending = CTX_BUILDERS.filter((rel) => {
   return src.includes('easedPhase') && !src.includes('cardAspect');
 });
 
+// ---------- ciclo de vida do contexto GL ----------
+//
+// Um contexto perdido POR ORDEM DA PAGINA e contado pelo Chrome, e passado o
+// limite dele a criacao seguinte volta "A WebGL context could not be created.
+// Reason: Web page caused context loss and was blocked". Quando isso acontece
+// nada mais consegue contexto: a miniatura 3D cai para 2D, o Pixi da miniatura
+// tambem falha, e o palco morre em `renderer3d.init` — leva o editor inteiro.
+//
+// Aconteceu por dois caminhos, e os dois eram um destroy num lugar que roda A
+// CADA TROCA: as miniaturas quando `refs` chega a zero (toda troca de grupo do
+// acordeao) e o palco quando o engine muda (2D <-> webgl). Medido antes da
+// correcao: 11 perdas em 10 alternancias, linear e sem teto.
+//
+// Verificado na FONTE porque nenhum teste de unidade ve isto.
+const DERRUBA_CONTEXTO = /forceContextLoss\s*\(|\.destroy\s*\(\s*true/;
+const semComentarios = (src) => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+
+for (const rel of ['three3d/thumbScene.ts', 'lib/thumbScene2d.ts']) {
+  const codigo = semComentarios(fs.readFileSync(path.join(root, rel), 'utf8'));
+  assertions++;
+  if (DERRUBA_CONTEXTO.test(codigo)) {
+    failures.push({
+      subject: rel,
+      message: 'derruba contexto GL (forceContextLoss ou destroy(true)) — o release da miniatura roda'
+        + ' a cada troca de grupo, e o Chrome bloqueia criacao depois de somar essas perdas',
+    });
+  }
+}
+{
+  const rel = 'components/PreviewStage.tsx';
+  const codigo = semComentarios(fs.readFileSync(path.join(root, rel), 'utf8'));
+  assertions++;
+  if (/\.destroy\s*\(/.test(codigo)) {
+    failures.push({
+      subject: rel,
+      message: 'destroi o renderer do palco — isso roda a cada troca de engine e cada destroy custa uma'
+        + ' perda de contexto contada contra a pagina; estacione o renderer em vez de destruir',
+    });
+  }
+  assertions++;
+  if (!/palcos\s*\.\s*set\s*\(/.test(codigo)) {
+    failures.push({
+      subject: rel,
+      message: 'nao guarda o renderer por engine — sem o cache, trocar de engine cria contexto novo toda vez',
+    });
+  }
+}
+
 if (failures.length) {
   console.error(`\nContext verification FAILED — ${failures.length} problem(s):\n`);
   const seen = new Set();

--- a/scripts/verify-effects-gl.cjs
+++ b/scripts/verify-effects-gl.cjs
@@ -15,6 +15,12 @@
 //    vignette   cinza uniforme -> o centro tem de ficar mais claro que a borda
 //    rgb-split  faixa branca   -> o canal R tem de se deslocar para um lado e o
 //               B para o outro, com o G parado
+//    halftone   degrade liso   -> a cobertura de tinta tem de crescer com o tom
+//    posterize  degrade liso   -> tem de virar exatamente N patamares, com 0 e 255
+//               alcancaveis (pega o erro de dividir por n em vez de n-1)
+//    scanlines  cinza uniforme -> tem de aparecer periodicidade em Y
+//    wave       quadro branco  -> tem de deslocar em x, e o deslocamento tem de
+//               VARIAR com y (senao e um shift, nao uma onda)
 //    pixelate   ruido fino     -> blocos de N px tem de zerar a variacao interna
 //
 //  Uso: node scripts/verify-effects-gl.cjs
@@ -51,6 +57,11 @@ for (const [id, fx] of Object.entries(effects)) {
     fragment: pixiFragment(fx),
     u0: fx.shader.uniforms(d, { width: 256, height: 256, time: 0 }),
     u1: fx.shader.uniforms(d, { width: 256, height: 256, time: 1 }),
+    // Os valores dos CONTROLES vao junto: o esperado de um teste tem de vir da
+    // intencao declarada, nao do uniform. Derivar o esperado do uniform e
+    // tautologia — muta-se o uniforms() e o esperado muda com ele, entao o teste
+    // sempre passa. Um teste de mutacao mostrou isso acontecendo aqui.
+    defaults: d,
   };
 }
 
@@ -105,6 +116,10 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
       // faixa branca de 8px no meio, para o split ter uma borda para deslocar
       faixa: makeTex((x) => (Math.abs(x - W / 2) < 4 ? [255, 255, 255] : [0, 0, 0])),
       ruido: makeTex((x, y) => { const i = y * W + x; return [(i*37)%256, (i*91)%256, (i*17)%256]; }),
+      // degrade horizontal liso: revela banding (posterize) e a trama (halftone)
+      degrade: makeTex((x) => { const v = Math.round((x / (W - 1)) * 255); return [v, v, v]; }),
+      // quadro branco centrado: revela deslocamento lateral (wave)
+      quadro: makeTex((x, y) => (Math.abs(x - W/2) < 40 && Math.abs(y - H/2) < 40 ? [255,255,255] : [0,0,0])),
     };
 
     const run = (fragment, uniforms, tex) => {
@@ -204,6 +219,61 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
     } catch (e) { r.falhas.push('rgb-split: ' + String(e.message).slice(0, 160)); }
 
     try {
+      // POSTERIZE: um degrade liso tem de virar N patamares — nem mais nem
+      // menos. Contar valores distintos e a medida direta disso, e ela tambem
+      // pega o erro classico de dividir por n em vez de n-1, que deixa o branco
+      // fora de alcance.
+      try {
+        // Pelos uniforms REAIS do efeito, nao um uSteps chumbado: passar o valor
+        // a mao pula a funcao uniforms() e o teste deixa de ver erro nela. Um
+        // teste de mutacao mostrou isso — trocar n-1 por n passava verde.
+        const q = run(fx.posterize.fragment, fx.posterize.u0, TEX.degrade);
+        const esperado = Math.round(fx.posterize.defaults.levels);
+        const vals = new Set();
+        for (let x = 0; x < W; x++) vals.add(q[((H >> 1) * W + x) * 4]);
+        const ordenados = [...vals].sort((a, b) => a - b);
+        r.medidas.posterize = { niveis: vals.size, esperado, min: ordenados[0], max: ordenados[ordenados.length - 1] };
+        if (vals.size !== esperado) r.falhas.push('posterize: o controle levels pediu ' + esperado + ' niveis e a tela mostrou ' + vals.size);
+        if (ordenados[ordenados.length - 1] < 250) r.falhas.push('posterize: o branco nao chega a 255 (max ' + ordenados[ordenados.length-1] + ') — sinal de dividir por n em vez de n-1');
+        if (ordenados[0] > 5) r.falhas.push('posterize: o preto nao chega a 0 (min ' + ordenados[0] + ')');
+      } catch (e) { r.falhas.push('posterize: ' + String(e.message).slice(0, 160)); }
+
+      // HALFTONE: sobre um degrade, a cobertura de tinta tem de CRESCER conforme
+      // o tom escurece. Mede a media na faixa escura contra a clara.
+      try {
+        const h = run(fx.halftone.fragment, { ...fx.halftone.u0, uCell: 8 }, TEX.degrade);
+        const media = (x0, x1) => { let s2 = 0, n = 0; for (let y = 0; y < H; y++) for (let x = x0; x < x1; x++) { s2 += h[(y*W+x)*4]; n++; } return s2/n; };
+        const escuro = media(8, 56), claro = media(W-56, W-8);
+        r.medidas.halftone = { ladoEscuro: +escuro.toFixed(1), ladoClaro: +claro.toFixed(1) };
+        if (claro <= escuro + 20) r.falhas.push('halftone: a trama nao segue o tom (escuro ' + escuro.toFixed(1) + ' vs claro ' + claro.toFixed(1) + ')');
+      } catch (e) { r.falhas.push('halftone: ' + String(e.message).slice(0, 160)); }
+
+      // SCANLINES: sobre cinza uniforme tem de aparecer periodicidade em Y, e a
+      // media tem de CAIR (as linhas escurecem). Compara linhas pares e impares
+      // no espacamento pedido.
+      try {
+        const base = run(fx.scanlines.fragment, { ...fx.scanlines.u0, uStrength: 0, uCurve: 0 }, TEX.cinza);
+        const sc = run(fx.scanlines.fragment, { ...fx.scanlines.u0, uSpacing: 4, uStrength: 0.6, uCurve: 0 }, TEX.cinza);
+        const linha = (px, y) => { let s2 = 0; for (let x = 0; x < W; x++) s2 += px[(y*W+x)*4]; return s2/W; };
+        const cresta = linha(sc, H>>1), vale = linha(sc, (H>>1) + 2);
+        const mediaBase = linha(base, H>>1), mediaSc = linha(sc, H>>1);
+        r.medidas.scanlines = { linhaA: +cresta.toFixed(1), linhaB: +vale.toFixed(1), semEfeito: +mediaBase.toFixed(1) };
+        if (Math.abs(cresta - vale) < 8) r.falhas.push('scanlines: sem periodicidade em Y (linhas a 2px: ' + cresta.toFixed(1) + ' vs ' + vale.toFixed(1) + ')');
+      } catch (e) { r.falhas.push('scanlines: ' + String(e.message).slice(0, 160)); }
+
+      // WAVE: com uSpeed 0 a fase e fixa; o quadro centrado tem de sair DESLOCADO
+      // em x conforme y, e nao apenas borrado. Mede o centroide em duas alturas.
+      try {
+        const w0 = run(fx.wave.fragment, { uAmount: 0, uFreq: 3, uSpeed: 0 }, TEX.quadro);
+        const w1 = run(fx.wave.fragment, { uAmount: 30, uFreq: 3, uSpeed: 0 }, TEX.quadro);
+        const centro = (px, y) => { let soma = 0, peso = 0; for (let x = 0; x < W; x++) { const v = px[(y*W+x)*4]; soma += v*x; peso += v; } return peso > 0 ? soma/peso : -1; };
+        const yA = (H>>1) - 30, yB = (H>>1) + 30;
+        const semA = centro(w0, yA), comA = centro(w1, yA), comB = centro(w1, yB);
+        r.medidas.wave = { semOnda: +semA.toFixed(2), comOnda_yA: +comA.toFixed(2), comOnda_yB: +comB.toFixed(2) };
+        if (Math.abs(comA - semA) < 3) r.falhas.push('wave: nao deslocou nada (' + semA.toFixed(2) + ' -> ' + comA.toFixed(2) + ')');
+        if (Math.abs(comA - comB) < 3) r.falhas.push('wave: o deslocamento nao varia com y — isso e um shift, nao uma onda');
+      } catch (e) { r.falhas.push('wave: ' + String(e.message).slice(0, 160)); }
+
       // PIXELATE: blocos de N px zeram a variacao interna.
       const N = 16;
       const p = run(fx.pixelate.fragment, { uSize: [N, N] }, TEX.ruido);

--- a/scripts/verify-effects-gl.cjs
+++ b/scripts/verify-effects-gl.cjs
@@ -79,6 +79,16 @@ for (const [id, fx] of Object.entries(effects)) {
   };
 }
 
+// Uniforms em OUTROS pontos de um controle, para as medidas que precisam de
+// mais de um. Passam pela mesma `uniforms()` do efeito — chumbar o valor aqui
+// pularia a funcao e o teste deixaria de ver erro nela.
+{
+  const CTX = { width: 256, height: 256, time: 0 };
+  const d = effectDefaults('posterize');
+  payload.posterize.uMix0 = effects.posterize.shader.uniforms({ ...d, mix: 0 }, CTX);
+  payload.posterize.uMix50 = effects.posterize.shader.uniforms({ ...d, mix: 50 }, CTX);
+}
+
 (async () => {
   if (!CHROME) { console.error('Chrome nao encontrado'); process.exit(2); }
   const browser = await puppeteer.launch({
@@ -261,6 +271,34 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
         if (ordenados[ordenados.length - 1] < 250) r.falhas.push('posterize: o branco nao chega a 255 (max ' + ordenados[ordenados.length-1] + ') — sinal de dividir por n em vez de n-1');
         if (ordenados[0] > 5) r.falhas.push('posterize: o preto nao chega a 0 (min ' + ordenados[0] + ')');
       } catch (e) { r.falhas.push('posterize: ' + String(e.message).slice(0, 160)); }
+
+      // POSTERIZE / MIX: o controle existe porque o efeito roda no quadro TODO,
+      // fundo incluido, e quantizar la embaixo apaga a silhueta dos cards. Duas
+      // perguntas, as duas medidas contra o que sai na tela:
+      //   mix=0   tem de ser IDENTIDADE — o degrade volta com os seus ~256
+      //           valores, nao com os 5 patamares
+      //   mix=50  tem de cair no MEIO entre a fonte e o quantizado, ponto a
+      //           ponto (o esperado vem das duas corridas medidas, nao de uma
+      //           formula reescrita aqui)
+      try {
+        const linha = (px) => { const v = []; for (let x = 0; x < W; x++) v.push(px[((H >> 1) * W + x) * 4]); return v; };
+        const fonte = linha(run(fx.posterize.fragment, fx.posterize.uMix0, TEX.degrade));
+        const quant = linha(run(fx.posterize.fragment, fx.posterize.u0, TEX.degrade));
+        const meio = linha(run(fx.posterize.fragment, fx.posterize.uMix50, TEX.degrade));
+        const niveisFonte = new Set(fonte).size;
+        let pior = 0;
+        for (let x = 0; x < W; x++) {
+          const esperado = (fonte[x] + quant[x]) / 2;
+          const dif = Math.abs(meio[x] - esperado);
+          if (dif > pior) pior = dif;
+        }
+        r.medidas['posterize:mix'] = {
+          niveis_mix0: niveisFonte, niveis_mix100: new Set(quant).size,
+          maiorDesvio_mix50: +pior.toFixed(1),
+        };
+        if (niveisFonte < 200) r.falhas.push('posterize: mix=0 nao e identidade — o degrade voltou com ' + niveisFonte + ' valores em vez de ~256');
+        if (pior > 3) r.falhas.push('posterize: mix=50 nao cai no meio entre fonte e quantizado (maior desvio ' + pior.toFixed(1) + ')');
+      } catch (e) { r.falhas.push('posterize:mix: ' + String(e.message).slice(0, 160)); }
 
       // HALFTONE: sobre um degrade, a cobertura de tinta tem de CRESCER conforme
       // o tom escurece. Mede a media na faixa escura contra a clara.

--- a/scripts/verify-effects-gl.cjs
+++ b/scripts/verify-effects-gl.cjs
@@ -41,7 +41,7 @@ Module._resolveFilename = function (request, parent, isMain, options) {
 };
 
 const { effects, effectDefaults } = require('../effects');
-const { pixiFragment } = require('../effects/adapters/glsl');
+const { pixiFragment, threeFragment } = require('../effects/adapters/glsl');
 
 const CHROME = [
   'C:/Program Files/Google/Chrome/Application/chrome.exe',
@@ -55,6 +55,20 @@ for (const [id, fx] of Object.entries(effects)) {
   const d = effectDefaults(id);
   payload[id] = {
     fragment: pixiFragment(fx),
+    // O fragment do three tambem, para o teste de PARIDADE. O #include do three
+    // nao compila cru, e a conversao final para sRGB e justamente o que se quer
+    // comparar — entao ele e trocado pela transformada explicita.
+    fragmentThree: threeFragment(fx)
+      .replace('#include <colorspace_fragment>', 'gl_FragColor = vec4(fx_toSrgb(gl_FragColor.rgb), gl_FragColor.a);')
+      // O vertex compartilhado deste teste emite vTextureCoord; renomeia para
+      // linkar, em vez de manter dois vertex shaders.
+      .replace(/vUv/g, 'vTextureCoord')
+      .replace('varying vec2 vTextureCoord;', 'in vec2 vTextureCoord;')
+      .replace(/gl_FragColor/g, 'fx_out')
+      .replace(/texture2D[(]/g, 'texture(')
+      // Cabecalho de ES 3.00 na frente: o vertex compartilhado deste teste e
+      // 300 es, e misturar versoes nao linka.
+      .replace(/^/, ["#version 300 es", "precision highp float;", "out vec4 fx_out;", ""].join(String.fromCharCode(10))),
     u0: fx.shader.uniforms(d, { width: 256, height: 256, time: 0 }),
     u1: fx.shader.uniforms(d, { width: 256, height: 256, time: 1 }),
     // Os valores dos CONTROLES vao junto: o esperado de um teste tem de vir da
@@ -118,6 +132,16 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
       ruido: makeTex((x, y) => { const i = y * W + x; return [(i*37)%256, (i*91)%256, (i*17)%256]; }),
       // degrade horizontal liso: revela banding (posterize) e a trama (halftone)
       degrade: makeTex((x) => { const v = Math.round((x / (W - 1)) * 255); return [v, v, v]; }),
+      // O MESMO degrade, mas em espaco LINEAR — que e o que o three recebe de
+      // verdade (ele trabalha linear e converte na saida). Alimentar o lado
+      // three com a textura sRGB era erro do teste: dava 136/255 de divergencia
+      // ate em pixelate e wave, que so deslocam coordenada e nao podem divergir.
+      degradeLin: makeTex((x) => {
+        const srgb = x / (W - 1);
+        const lin = srgb <= 0.04045 ? srgb / 12.92 : Math.pow((srgb + 0.055) / 1.055, 2.4);
+        const v = Math.round(lin * 255);
+        return [v, v, v];
+      }),
       // quadro branco centrado: revela deslocamento lateral (wave)
       quadro: makeTex((x, y) => (Math.abs(x - W/2) < 40 && Math.abs(y - H/2) < 40 ? [255,255,255] : [0,0,0])),
     };
@@ -289,6 +313,38 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
       r.medidas.pixelate = { desvio_intra_bloco: +dv.toFixed(3), desvio_original: +desvio(run(fx.pixelate.fragment, { uSize: [1, 1] }, TEX.ruido)).toFixed(3) };
       if (dv > 0.5) r.falhas.push(`pixelate: os blocos de ${N}px nao ficaram uniformes (desvio ${dv.toFixed(2)})`);
     } catch (e) { r.falhas.push('pixelate: ' + String(e.message).slice(0, 160)); }
+
+    // ---- PARIDADE ENTRE ENGINES ----
+    //
+    // O teste que faltava, e que teria pegado a divergencia de espaco de cor: o
+    // contrato promete que UM shader vale nos dois engines, e ninguem estava
+    // comparando as duas saidas. O three trabalha em linear e converte na saida;
+    // o Pixi entrega sRGB. Sem tratar isso, o posterize caia em niveis
+    // completamente diferentes (0,64,128,191,255 contra 0,137,188,225,255).
+    //
+    // Compara sobre o degrade, que e onde a diferenca de espaco aparece mais.
+    for (const id of Object.keys(fx)) {
+      try {
+        const a = run(fx[id].fragment, fx[id].u0, TEX.degrade);
+        const b = run(fx[id].fragmentThree, fx[id].u0, TEX.degradeLin);
+        let maior = 0, soma = 0, n = 0;
+        for (let i = 0; i < a.length; i += 4) {
+          const d = Math.abs(a[i] - b[i]);
+          if (d > maior) maior = d;
+          soma += d; n++;
+        }
+        const media = soma / n;
+        r.medidas['paridade:' + id] = { maiorDif: maior, mediaDif: +media.toFixed(2) };
+        // 6 de 255 cobre arredondamento e a ida-e-volta da transformada; acima
+        // disso os dois engines estao desenhando coisas diferentes.
+        // A tolerancia e pela MEDIA, nao pelo pico: a ida-e-volta
+        // sRGB->linear->sRGB passa por um byte de 8 bits, e nos escuros — onde a
+        // curva sRGB e mais inclinada — um unico passo de quantizacao vira
+        // varios niveis de volta. O pico e um artefato disso; a media diz se os
+        // dois engines estao desenhando a mesma coisa.
+        if (media > 4) r.falhas.push('paridade ' + id + ': pixi e three divergem, media ' + media.toFixed(2) + '/255 (pico ' + maior + ')');
+      } catch (e) { r.falhas.push('paridade ' + id + ': ' + String(e.message).slice(0, 200)); }
+    }
 
     return r;
   }, payload);

--- a/store/use3DStore.ts
+++ b/store/use3DStore.ts
@@ -116,6 +116,7 @@ export interface FillSpec {
   c1: string;
   c2: string;
   gradient?: GradientSpec;
+  alpha?: number;
 }
 
 // Artwork on a device's screen. `url` is live-session only — a blob: string is

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,9 +1,9 @@
 /* ============================================================
    MOTION STUDIO — DESIGN TOKENS
    Light UI from the Figma reference (file 7NtsGHDBicdNLMt48Y6BOX,
-   node 0:2702): flat white panels separated by 1px #e5e7eb borders
-   on a #e5e7eb canvas area, Tailwind-gray palette, Inter, and
-   fully square corners. Dark theme kept under [data-theme="dark"].
+   node 0:2702): white tool surfaces on a #e5e7eb canvas area,
+   Tailwind-gray palette, Inter, and square inner controls. The workspace
+   shell uses separated panel islands; dark theme lives under [data-theme="dark"].
    ============================================================ */
 :root {
   /* ---- Surfaces ---- */

--- a/three3d/thumbScene.ts
+++ b/three3d/thumbScene.ts
@@ -337,41 +337,72 @@ export function detachCanvas() {
 
 // ---- ciclo de vida do contexto ----
 //
-// Mesmo motivo do lado Pixi: este modulo tomava um contexto GL e nunca o
-// devolvia, e com os dois somados o PALCO ficava sem. Medido: o canvas do palco
-// existia com zero contexto e `app.renderer` vinha null, derrubando o editor em
-// makePlaceholderTexture.
+// UM contexto, criado na primeira miniatura e mantido pela vida da pagina. Ele
+// NAO e destruido quando a ultima miniatura sai, e essa e a correcao de um bug
+// que o desenho anterior causava.
 //
-// Contagem de referencias, nao ordem de inicializacao: cada miniatura montada
-// retem, cada desmontada solta, e a ultima a sair devolve o contexto.
+// Antes, `refs` chegando a zero destruia o renderer e chamava
+// `forceContextLoss()`. Mas `refs` passa por zero em toda troca de grupo no
+// acordeao — o React desmonta as miniaturas do grupo antigo antes de montar as
+// do novo — entao cada troca custava uma perda de contexto CAUSADA PELA PAGINA.
+// O Chrome soma essas perdas por pagina e, passado o limite dele, recusa criar
+// o proximo:
+//
+//   THREE.WebGLRenderer: A WebGL context could not be created.
+//   Reason: "Web page caused context loss and was blocked"
+//
+// que e o erro relatado ao trocar de preset com efeito ativo, estourando aqui
+// em `getShared`, chamado pela fila de miniaturas. Medido no app antes desta
+// mudanca: 4 perdas de proposito nas 3 primeiras trocas de grupo. Adiar a
+// destruicao so diminuiria a frequencia; nao destruir torna o erro impossivel,
+// porque `shared` nunca volta a ser null e um segundo contexto nunca e pedido.
+//
+// O medo original era o oposto — este modulo e o do Pixi tomando contexto e
+// deixando o PALCO sem (medido na epoca: canvas do palco com zero contexto e
+// `app.renderer` null, derrubando o editor em makePlaceholderTexture). Mas isso
+// vinha de MUITOS contextos; com um singleton por engine o total da pagina fica
+// em tres (palco, miniatura 2D, miniatura 3D), medido, contra o limite de ~16
+// do navegador. Segurar dois nao chega perto de apertar.
+//
+// A contagem de referencias continua, porque a ultima miniatura a sair ainda
+// tem trabalho util: soltar o canvas de onde ele estava e jogar fora o cache de
+// geometria, que e a unica coisa aqui que cresce com o uso. Adiada, para nao
+// refazer geometria a cada troca de grupo.
+const CARENCIA_MS = 10_000;
 let refs = 0;
+let agendado: ReturnType<typeof setTimeout> | null = null;
+
+function cancelarLimpeza() {
+  if (agendado === null) return;
+  clearTimeout(agendado);
+  agendado = null;
+}
 
 export function retainThumb3d(): () => void {
   refs++;
+  cancelarLimpeza();
   let solto = false;
   return () => {
     if (solto) return;
     solto = true;
     refs = Math.max(0, refs - 1);
-    if (refs === 0) disposeShared3d();
+    if (refs > 0) return;
+    cancelarLimpeza();
+    agendado = setTimeout(() => {
+      agendado = null;
+      if (refs === 0) limparShared3d();
+    }, CARENCIA_MS);
   };
 }
 
-function disposeShared3d() {
+// Limpeza, nao destruicao: o renderer, o contexto, o plano, os tons e os
+// materiais dos slots ficam. So sai o que se refaz sozinho sob demanda.
+function limparShared3d() {
   const ctx = shared;
-  shared = null;
   if (!ctx) return;
   try {
     detachCanvas();
     ctx.geomCache.forEach((g) => g.dispose());
     ctx.geomCache.clear();
-    ctx.plane.dispose();
-    ctx.tones.forEach((t) => t.dispose());
-    ctx.slots.forEach((s) => { s.front.material.dispose(); s.back.material.dispose(); });
-    ctx.slots.length = 0;
-    ctx.renderer.dispose();
-    // dispose() solta os recursos mas NAO o contexto; sem isto o navegador
-    // segue contando este canvas contra o limite.
-    ctx.renderer.forceContextLoss();
-  } catch { /* um contexto que já foi não precisa ir de novo */ }
+  } catch { /* nada aqui e essencial: falhar em limpar nao pode quebrar a pagina */ }
 }


### PR DESCRIPTION
Recreated from #63 to resolve merge conflicts: this branch already has `appariciojunior/main` merged in cleanly (verified locally with no conflicts before pushing). Same content as #63 — Halftone, Posterize, Scanlines, Wave effects closing Phase 2, plus the cross-engine color-space fix, Posterize Mix control, and the WebGL context-loss fix.

Closes #63 (superseded — that PR's head branch is shared with a different open PR in another repo, so a fresh branch was used here instead of updating it in place).