### PR TITLE
Fix page scroll locking and enhance segmented slider behavior

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,8 @@ html,
 body {
   margin: 0;
   height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 :root {
@@ -1124,14 +1126,39 @@ input[type=range] {
   overflow: hidden;
 }
 
+/* Rubber band. Drag past either end and the pushed edge gives instead of the
+   track just stopping dead. The width and the cancelling negative margin come
+   from the component, so mid-drag this follows the pointer with no lag; the
+   transition only has to cover letting go, which the reference did in about
+   eight frames at 30fps — near enough to --t-fast.
+
+   It is the track's own width, not a transform, because in the reference the
+   glyphs inside kept their exact stride at full stretch: the box grew, the
+   content did not scale. The negative margin keeps the outer size at 100%, so
+   the flex parent has no overflow to shrink away. */
+.strack:not(.is-dragging) {
+  transition: width var(--t-fast) cubic-bezier(.2, 0, 0, 1),
+              margin var(--t-fast) cubic-bezier(.2, 0, 0, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .strack:not(.is-dragging) {
+    transition: none;
+  }
+}
+
 /* `left` and `width` both come from the component: a range that spans zero
-   fills from its zero point rather than from the left edge. */
+   fills from its zero point rather than from the left edge.
+
+   The fill is opaque and carries the contrast, which is the whole point: it
+   has to cover the plain readout as it sweeps past, so the inverted copy in
+   .sinv can take over. A translucent fill would show both at once. */
 .sfill {
   position: absolute;
   top: 0;
   bottom: 0;
-  background: var(--card);
-  border: 1px solid var(--handle);
+  z-index: 2;
+  background: var(--sl-fill);
   border-radius: var(--r-ctrl);
   pointer-events: none;
 }
@@ -1139,26 +1166,165 @@ input[type=range] {
 .shandle {
   position: absolute;
   top: 50%;
+  z-index: 1;
   transform: translate(-50%, -50%);
-  width: 2px;
+  /* Width matches --sl-tick so that when the bar splits, what is left are
+     SQUARES and not standing rectangles — at 2px the marks came out 2×4. The
+     reference's own bar is 8px on a 163px track against 9px marks, so square
+     is what it does too; it just gets there with a chunkier bar than a 34px
+     track can carry. Square corners for the same reason every other corner
+     here is square. */
+  width: var(--sl-tick);
   height: 16px;
-  border-radius: 1px;
-  background: var(--handle);
+  border-radius: 0;
+  background: var(--sl-handle, var(--handle));
   pointer-events: none;
+}
+
+/* Where the readout is in the way, the bar does not strike through it: the
+   two halves step OUTSIDE the number and shrink to short marks.
+
+   That outward step is the part a punched hole cannot fake, and the reference
+   states it plainly. Free bar: y 922-993 of a 163px track (frames 25 and
+   299). Split: marks at y 913-921 and 994-1002 (frame 180) — their INNER
+   edges (±36.5 from centre) land on the free bar's ENDS (±36), so the halves
+   travel outward past where the bar was rather than being cut in place.
+
+   Ported by silhouette: the split spans 20px of a 34px track, 59% against the
+   reference's 55%. The one deliberate deviation is the mark itself — it is a
+   --sl-tick square, where the ratio asks for 1.8px, because 1.8px on this
+   track is invisible. Being a square is not incidental: the reference's marks
+   are 8×9 on its own scale, so anything taller than it is wide reads as a
+   standing rectangle rather than as half a bar stepping aside. The remaining
+   14px gap clears the 12px digits with room on both sides. */
+.shandle.is-split {
+  height: 20px;
+  background: linear-gradient(
+    var(--sl-handle, var(--handle)) 0 var(--sl-tick),
+    transparent var(--sl-tick) calc(20px - var(--sl-tick)),
+    var(--sl-handle, var(--handle)) calc(20px - var(--sl-tick)) 20px
+  );
 }
 
 .sval {
   position: absolute;
   right: 8px;
   top: 50%;
+  z-index: 1;
   transform: translateY(-50%);
   font-size: var(--fs-ui);
   line-height: var(--lh-ui);
-  color: var(--fg-value);
+  color: var(--sl-value, var(--fg-value));
   font-variant-numeric: tabular-nums;
   padding: 2px 6px;
   border-radius: var(--r-seg);
   cursor: text;
+}
+
+/* The inverted copy. Same handle, same readout, same coordinates — clipped by
+   the component to exactly the fill's span, so a glyph straddling the leading
+   edge is cut down the middle and reads light on the left, dark on the right.
+   That per-glyph cut is the reference's signature moment.
+
+   It sits ABOVE the fill and the plain copy sits BELOW it, so the two never
+   composite over each other: outside the span the fill is not there and the
+   plain copy shows; inside it the opaque fill has already hidden the plain
+   copy. No complement clip, no antialiasing fringe. Colours arrive as
+   inherited variables because the mobile block redeclares .shandle's
+   background outright, and a variable survives that where a selector would
+   have to out-specify it. */
+.sinv {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  --sl-handle: var(--sl-fill-fg);
+  --sl-value: color-mix(in srgb, var(--sl-fill-fg) 78%, var(--sl-fill));
+}
+
+/* The readout is a click target, and under the fill its own hover chip is
+   hidden — so the copy on top has to show one. */
+.strack:has(.sval:hover):not(.is-dragging) .sinv .sval {
+  background: color-mix(in srgb, var(--sl-fill-fg) 16%, transparent);
+}
+
+.szero,
+.slider-bubble {
+  z-index: 3;
+}
+
+.sinv .szero {
+  background: color-mix(in srgb, var(--sl-fill-fg) 34%, transparent);
+}
+
+/* Step marks, hidden until the pointer is on the track. At rest the row
+   should read as one clean bar; the marks are only worth anything once you
+   are actually aiming. Square, like every other corner here.
+
+   One element instead of a node per mark: the tile is exactly one interval
+   wide and paints a 2px square at its start, and the whole layer is shifted
+   right by one interval so the first mark lands on the first stop rather than
+   on the left edge. That pushes the last mark onto the right edge, where the
+   track's overflow clips it — leaving only the interior stops, which is what
+   the reference shows. --tick-n comes from the component because it is the
+   control's own step count, not a constant.
+
+   It sits at z-index 1, under the fill, so the marks vanish as the bar covers
+   them and only the empty part of the track is dotted. */
+.sticks {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--t-fast);
+  transform: translateX(calc(100% / var(--tick-n)));
+  background-image: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--fg) 30%, transparent) 0 var(--sl-tick),
+    transparent var(--sl-tick)
+  );
+  background-size: calc(100% / var(--tick-n)) var(--sl-tick);
+  background-repeat: repeat-x;
+  background-position: 0 center;
+}
+
+/* Touch has no hover, so the drag itself is the reveal. */
+.strack:hover .sticks,
+.strack.is-dragging .sticks {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sticks {
+    transition: none;
+  }
+}
+
+.sval-input {
+  z-index: 4;
+}
+
+/* A plate the height of the type, so nothing else crosses the number: it is
+   what keeps the step marks from running under the digits, and it backs the
+   gap the split handle opens. Each copy paints the surface it actually sits
+   on — the plain one is only ever seen on the track, the inverted one only
+   ever on the fill. It stops 1px short of the split marks (±5 against ±6),
+   so it hides the ruler without eating the handle. */
+.sval::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 10px;
+  transform: translateY(-50%);
+  background: var(--card-inset);
+  z-index: -1;
+}
+
+.sinv .sval::before {
+  background: var(--sl-fill);
 }
 
 /* the readout is a click target, so it has to look like one on hover — an
@@ -1253,6 +1419,109 @@ input[type=range] {
 .pill.active {
   background: var(--seg-active-bg);
   color: var(--seg-active-fg);
+}
+
+/* Sliding highlight — the active chip travels to the option you picked
+   instead of blinking there. Geometry and timing are measured off the
+   reference capture, frame by frame: the pill's width never left 325px in any
+   frame (no stretch, no overshoot, no squash) and it never passed its target,
+   so this is pure translation on --t-seg / --e-seg.
+
+   Built on :has() so no panel markup changes — twenty-two call sites across
+   twelve components already render a track plus buttons, and none of them
+   needs to learn about a thumb. --seg-n is the option count, and
+   translateX(N * 100%) resolves against the pill's own width, which IS one
+   slot.
+
+   The offset is written out per index rather than read from a variable on
+   purpose. A transitioned property whose value comes from an UNREGISTERED
+   custom property does not animate and does not even land: measured here, the
+   pill's computed transform sat at matrix(1,0,0,1,0,0) for 700ms after the
+   click while --seg-i already read 1. Registering it with @property fixes
+   that, but @property lands later than :has() in Safari, so a literal
+   translateX per rule is the version that cannot half-work. */
+
+/* Three families opt out at the bottom of this block and keep the instant
+   highlight: .pj-sort, whose segments are content-sized (flex: 0 0 auto), so
+   the slots are unequal; and the four-column grids (.aspect-pills /
+   .card-shape-pills), which wrap to a second row that a horizontal slide
+   cannot describe. */
+@supports selector(:has(*)) {
+  :is(.segmented, .pills) {
+    position: relative;
+    --seg-n: 1;
+  }
+
+  :is(.segmented, .pills):has(> :nth-child(2):last-child) { --seg-n: 2; }
+  :is(.segmented, .pills):has(> :nth-child(3):last-child) { --seg-n: 3; }
+  :is(.segmented, .pills):has(> :nth-child(4):last-child) { --seg-n: 4; }
+  :is(.segmented, .pills):has(> :nth-child(5):last-child) { --seg-n: 5; }
+  :is(.segmented, .pills):has(> :nth-child(6):last-child) { --seg-n: 6; }
+  :is(.segmented, .pills):has(> :nth-child(7):last-child) { --seg-n: 7; }
+  :is(.segmented, .pills):has(> :nth-child(8):last-child) { --seg-n: 8; }
+
+  :is(.segmented, .pills)::before {
+    content: '';
+    position: absolute;
+    top: var(--seg-pad);
+    bottom: var(--seg-pad);
+    left: var(--seg-pad);
+    width: calc((100% - 2 * var(--seg-pad)) / var(--seg-n));
+    border-radius: var(--r-seg);
+    background: var(--seg-active-bg);
+    transform: translateX(0);
+    transition: transform var(--t-seg) var(--e-seg), opacity var(--t-fast);
+    pointer-events: none;
+  }
+
+  :is(.segmented, .pills):has(> :nth-child(2).active)::before { transform: translateX(100%); }
+  :is(.segmented, .pills):has(> :nth-child(3).active)::before { transform: translateX(200%); }
+  :is(.segmented, .pills):has(> :nth-child(4).active)::before { transform: translateX(300%); }
+  :is(.segmented, .pills):has(> :nth-child(5).active)::before { transform: translateX(400%); }
+  :is(.segmented, .pills):has(> :nth-child(6).active)::before { transform: translateX(500%); }
+  :is(.segmented, .pills):has(> :nth-child(7).active)::before { transform: translateX(600%); }
+  :is(.segmented, .pills):has(> :nth-child(8).active)::before { transform: translateX(700%); }
+
+  /* Nothing selected (a custom canvas size, an unmatched frame preset) has to
+     read as nothing selected, not as option one. */
+  :is(.segmented, .pills):not(:has(> .active))::before { opacity: 0; }
+
+  :is(.segmented, .pills) > :is(.seg, .pill) {
+    position: relative;
+    z-index: 1;
+    transition: color var(--t-fast) var(--t-seg-flip);
+  }
+
+  /* The chip is painted by the track now, so the button stops painting its
+     own — otherwise the highlight appears instantly at the destination and
+     the slide has nothing left to show. */
+  :is(.segmented, .pills) > :is(.seg, .pill).active {
+    background: transparent;
+  }
+
+  /* Hover feedback answers the pointer directly and must not wait on the
+     travel delay. */
+  :is(.segmented, .pills) > :is(.seg, .pill):hover {
+    transition-delay: 0ms;
+  }
+
+  /* ---- opt-outs: unequal slots, wrapped grids, and more options than there
+     are slot rules above ---- */
+  :is(.pj-sort, .aspect-pills, .card-shape-pills)::before,
+  :is(.segmented, .pills):has(> :nth-child(9))::before {
+    display: none;
+  }
+
+  :is(.pj-sort, .aspect-pills, .card-shape-pills) > :is(.seg, .pill).active,
+  :is(.segmented, .pills):has(> :nth-child(9)) > :is(.seg, .pill).active {
+    background: var(--seg-active-bg);
+    transition-delay: 0ms;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :is(.segmented, .pills)::before { transition: none; }
+    :is(.segmented, .pills) > :is(.seg, .pill) { transition-delay: 0ms; }
+  }
 }
 
 /* custom canvas size (W × H px) */
@@ -3943,8 +4212,27 @@ select.field {
     height: 24px;
     border: 6px solid var(--card);
     border-radius: 50%;
-    background: var(--fg);
+    background: var(--sl-handle, var(--fg));
     box-shadow: 0 0 0 1px var(--handle);
+  }
+
+  /* Touch keeps its own slider: a 24px knob riding outside the track, and a
+     52px readout that has to stay legible under a thumb. A solid dark fill
+     would swallow both, so here the fill stays the light box it was and the
+     inverted copy has nothing to do. */
+  .mobile-editor .sfill {
+    background: var(--card);
+    border: 1px solid var(--handle);
+  }
+
+  .mobile-editor .sinv {
+    display: none;
+  }
+
+  /* Same reason: the touch handle is a 24px round knob, and a band cut
+     through it reads as a broken knob, not as a bar making way. */
+  .mobile-editor .sval::before {
+    display: none;
   }
 
   .mobile-editor .sval {
@@ -4029,6 +4317,19 @@ select.field {
     flex: 0 0 auto;
     min-width: 64px;
     scroll-snap-align: start;
+  }
+
+  /* Here the pills are content-sized AND the row scrolls, so the sliding
+     highlight has neither equal slots nor a fixed origin to travel in — it
+     would land on the wrong chip the moment the row is scrolled. Only
+     .pills-fit (flex: 1 1 0, no scroll, just below) keeps it. */
+  .mobile-editor .pills:not(.pills-fit)::before {
+    display: none;
+  }
+
+  .mobile-editor .pills:not(.pills-fit) > .pill.active {
+    background: var(--seg-active-bg);
+    transition-delay: 0ms;
   }
 
   .mobile-editor .pills.pills-fit {
@@ -5553,7 +5854,7 @@ select.field {
 
 .gradient-stop.selected {
   border-color: var(--fg);
-  box-shadow: 0 0 0 1px var(--card), 0 0 0 2px var(--fg), inset 0 0 0 1px var(--card);
+  box-shadow: 0 0 0 2px var(--card);
 }
 
 .gradient-ramp-actions {

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,8 @@ html,
 body {
   margin: 0;
   height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 :root {
@@ -5553,7 +5555,7 @@ select.field {
 
 .gradient-stop.selected {
   border-color: var(--fg);
-  box-shadow: 0 0 0 1px var(--card), 0 0 0 2px var(--fg), inset 0 0 0 1px var(--card);
+  box-shadow: 0 0 0 2px var(--card);
 }
 
 .gradient-ramp-actions {

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
 import type { ControlDef } from '@/lib/types';
 import MobileSheet from './MobileSheet';
 import { useMobileInteractions } from './MobileInteractions';
@@ -41,6 +42,14 @@ function renderControl(def: ControlDef, value: any, onChange: (v: any) => void) 
   }
 }
 
+// Dragging past an end gives the track's pushed edge instead of stopping
+// dead. Asymptotic, so the stretch never runs away however far the pointer
+// travels: 55px of overshoot spends about 63% of the allowance, 150px spends
+// 94%. The ceiling itself is --sl-rubber, read off the element so the token
+// stays the one source of truth.
+const RUBBER_FALLOFF = 55;
+const rubberBand = (over: number, max: number) => (over <= 0 ? 0 : max * (1 - Math.exp(-over / RUBBER_FALLOFF)));
+
 // Figma spec: the whole 34px track is the slider. Fill #2d2d2d over #232323,
 // a 2×16px #424242 bar as handle, value inside the track right-aligned
 // (12px #aaa), click the value to type an exact number.
@@ -67,13 +76,58 @@ function SliderControl({ def, value, onChange }: RowProps) {
   const handleLeft = signed && pct === zeroPct
     ? `${pct}%`
     : `clamp(6px, calc(${pct}% + ${handleInset}px), calc(100% - 6px))`;
+  // The handle takes a different shape where it runs under the readout, so
+  // the component has to know when that is — CSS cannot compare two boxes.
+  // Both widths come from a ResizeObserver, never from a per-frame read: they
+  // only change when the panel resizes or the number gains a digit, and
+  // measuring inside the drag would mean a synchronous layout every move.
+  const valRef = useRef<HTMLSpanElement>(null);
+  const [boxes, setBoxes] = useState({ track: 0, val: 0 });
   const decimals = def.precision ?? (step < 1 ? Math.min(3, Math.ceil(-Math.log10(step))) : 0);
+  // Step marks. Where the control has few stops they ARE the stops, so a mark
+  // means "the value lands here"; past a handful they would be a picket fence,
+  // and fifths read as a ruler instead of as a lie about where values snap.
+  // The ceiling is what keeps a coarse slider from being denser than a fine
+  // one — a 0-100 step-1 row gets four marks, and so does a six-stop row.
+  const stopCount = Math.round((max - min) / step);
+  const tickN = Number.isFinite(stopCount) && stopCount >= 2 && stopCount <= 6 ? stopCount : 5;
+  // Where the handle sits, in the track's own pixels — the same clamp the
+  // stylesheet applies to handleLeft, so the two never disagree.
+  const handleCentre = boxes.track
+    ? Math.min(Math.max(6, (pct / 100) * boxes.track + handleInset), boxes.track - 6)
+    : 0;
+  // .sval is right: 8px and its measured width already carries its padding.
+  const splitHandle = !mobile && !editing && boxes.track > 0 && boxes.val > 0
+    && handleCentre + 2 > boxes.track - 8 - boxes.val
+    && handleCentre - 2 < boxes.track - 8;
+
+  // Signed: positive stretches the right edge, negative the left. Zero means
+  // the pointer is on the track and the box is its plain self. The ref is
+  // what the maths reads — several pointermove events land between renders,
+  // and the state value would still be the one from the last paint.
+  const [rubber, setRubber] = useState(0);
+  const rubberNow = useRef(0);
+  const rubberMax = useRef(6);
+  const applyRubber = (next: number) => {
+    if (next === rubberNow.current) return;
+    rubberNow.current = next;
+    setRubber(next);
+  };
 
   const setFromX = (clientX: number, fine = false) => {
     const el = trackRef.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
-    const t = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    // rect is the STRETCHED box mid-drag, so the overshoot has to be measured
+    // against the resting edges — otherwise each frame stretches from the
+    // last one and the band creeps outward with the pointer standing still.
+    const held = rubberNow.current;
+    const restLeft = rect.left + Math.max(0, -held);
+    const restRight = rect.right - Math.max(0, held);
+    if (clientX > restRight) applyRubber(rubberBand(clientX - restRight, rubberMax.current));
+    else if (clientX < restLeft) applyRubber(-rubberBand(restLeft - clientX, rubberMax.current));
+    else applyRubber(0);
+    const t = Math.max(0, Math.min(1, (clientX - restLeft) / (restRight - restLeft)));
     const effectiveStep = fine ? step * 0.1 : step;
     const snapped = Math.round((min + t * (max - min)) / effectiveStep) * effectiveStep;
     onChange(Number(Math.max(min, Math.min(max, snapped)).toFixed(4)));
@@ -119,22 +173,59 @@ function SliderControl({ def, value, onChange }: RowProps) {
     setSheetOpen(false);
   };
 
+  // Letting go has to put the edge back even if the pointer never came home.
+  // Re-runs when the readout unmounts for typing, so the observer is never
+  // holding a node that is gone.
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+    const measure = () => setBoxes({
+      track: track.getBoundingClientRect().width,
+      val: valRef.current?.getBoundingClientRect().width ?? 0,
+    });
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(track);
+    if (valRef.current) ro.observe(valRef.current);
+    return () => ro.disconnect();
+  }, [editing]);
+
+  const endDrag = () => {
+    pressed.current = false;
+    setDragging(false);
+    applyRubber(0);
+  };
+
   return (
     <div
       ref={trackRef}
       className={`strack ${mobile ? 'strack-mobile' : ''} ${dragging ? 'is-dragging' : ''}`}
       tabIndex={0}
+      // Signed sliders and the readout both live off the track's own box, so
+      // the band grows the box and cancels it with a margin: the outer size
+      // stays 100%, the flex parent sees no overflow, and nothing inside is
+      // scaled — which is how the reference behaved at full stretch.
+      style={rubber === 0 ? undefined : {
+        width: `calc(100% + ${Math.abs(rubber).toFixed(2)}px)`,
+        ...(rubber > 0
+          ? { marginRight: `${(-rubber).toFixed(2)}px` }
+          : { marginLeft: `${rubber.toFixed(2)}px` }),
+      }}
       onPointerDown={(e) => {
         if (editing) return;
         try { (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId); } catch { /* no live pointer: nothing to capture */ }
+        // Read the allowance once per drag rather than per move: the token is
+        // the single source of truth, getComputedStyle is not free.
+        const declared = parseFloat(getComputedStyle(e.currentTarget).getPropertyValue('--sl-rubber'));
+        rubberMax.current = Number.isFinite(declared) ? declared : 6;
         pressed.current = true;
         setDragging(true);
         setFromX(e.clientX, e.shiftKey);
       }}
       onPointerMove={(e) => { if (!editing && pressed.current && e.buttons === 1) setFromX(e.clientX, e.shiftKey); }}
-      onPointerUp={() => { pressed.current = false; setDragging(false); }}
-      onPointerCancel={() => { pressed.current = false; setDragging(false); }}
-      onLostPointerCapture={() => { pressed.current = false; setDragging(false); }}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onLostPointerCapture={endDrag}
       onKeyDown={(e) => {
         if (editing) return;
         if (e.key === 'Enter') { e.preventDefault(); startEdit(); return; }
@@ -158,9 +249,11 @@ function SliderControl({ def, value, onChange }: RowProps) {
           empty. Filling from the edge made a signed slider look like a
           magnitude bar — Card Bend at 0 showed a half-full track, which reads
           as "half on" rather than "neutral". */}
+      {/* Plain copy first, so the opaque fill paints over it. */}
+      <div className="sticks" style={{ '--tick-n': tickN } as CSSProperties} />
+      <div className={`shandle ${splitHandle ? 'is-split' : ''}`} style={{ left: handleLeft }} />
       <div className="sfill" style={{ left: `${fillLeft}%`, width: `${fillWidth}%` }} />
       {signed && <div className="szero" style={{ left: `${zeroPct}%` }} />}
-      <div className="shandle" style={{ left: handleLeft }} />
       {mobile && dragging && <output className="slider-bubble" style={{ left: `${pct}%` }}>{num.toFixed(decimals)}{def.unit ?? ''}</output>}
       {editing ? (
         <input
@@ -202,6 +295,7 @@ function SliderControl({ def, value, onChange }: RowProps) {
         />
       ) : (
         <span
+          ref={valRef}
           className="sval"
           title={mobile ? 'Tap to enter an exact value' : 'Click to type an exact value'}
           // pointerdown only shields the track from starting a drag — pressing
@@ -219,6 +313,25 @@ function SliderControl({ def, value, onChange }: RowProps) {
         >
           {num.toFixed(decimals)}{def.unit ?? ''}
         </span>
+      )}
+      {/* The same handle and the same readout at the same coordinates, in the
+          on-fill colours, clipped to exactly the fill's span. A glyph sitting
+          on the leading edge is cut down the middle — that split is what the
+          gesture reads as in the reference, not the bar's width. Hidden while
+          typing: the input owns the corner then. */}
+      {!editing && (
+        <div
+          className="sinv"
+          aria-hidden="true"
+          style={{ clipPath: `inset(0 ${(100 - (fillLeft + fillWidth)).toFixed(3)}% 0 ${fillLeft.toFixed(3)}%)` }}
+        >
+          <div className={`shandle ${splitHandle ? 'is-split' : ''}`} style={{ left: handleLeft }} />
+          {/* The zero anchor sits exactly where the fill begins, so on a
+              signed slider it is half under the bar — a --fg tick on a --fg
+              fill is nothing at all. It needs the inverted copy too. */}
+          {signed && <div className="szero" style={{ left: `${zeroPct}%` }} />}
+          <span className="sval">{num.toFixed(decimals)}{def.unit ?? ''}</span>
+        </div>
       )}
       {mobile && sheetOpen && (
         <MobileSheet title={def.label} onClose={() => setSheetOpen(false)}>

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -100,6 +100,31 @@
 
   /* ---- Motion ---- */
   --t-fast: 120ms;
+  /* Sliding segmented highlight. Both values are measured off the reference
+     capture, not guessed: 14.6 frames at 30 fps, and a curve fitted to 29
+     samples across two transitions (rms .037 — every named ease, expo /
+     power3-5 / circ .inOut, sits above .11). The duration is fixed: a
+     two-segment jump took the same 490ms as a one-segment jump. */
+  --t-seg:   490ms;
+  --e-seg:   cubic-bezier(.71, 0, .07, 1);
+  /* The label flip waits for the pill to get there. The curve is flat for its
+     first third, so nothing moves before ~170ms — flipping the text at 190ms
+     lands it under the pill instead of leaving white-on-white mid-travel. */
+  --t-seg-flip: 190ms;
+  /* Slider rubber band: how far the track's pushed edge gives when you drag
+     past an end. The reference stretched 26px on a 943×160 track (2.8% of the
+     width, 16% of the height); on a 34px track that is ~6px either way. */
+  --sl-rubber: 6px;
+  /* The fill carries the contrast now, the way the reference does: a solid
+     dark bar sweeping under the readout, not a white box with a hairline. It
+     reuses the inverse pair the Export button and the playhead already use,
+     so no new colour enters the palette — and because the pair already flips
+     per theme, the readout inverts correctly in both without a dark override
+     (light: #111827 bar / white text; dark: white bar / #111111 text). */
+  --sl-fill:    var(--inverse-bg);
+  --sl-fill-fg: var(--inverse-fg);
+  /* Side of the square step marks the track reveals on hover. */
+  --sl-tick:    3px;
 }
 
 :root[data-theme="dark"] {


### PR DESCRIPTION
Slider motion + scroll lock fixes

Two PRs landed on the controls and editor shell:

Scroll/drag lock + gradient stop ring cleanup
🔗 https://github.com/davicorrea0/motion-jitter-clone/pull/82

html/body used to scroll and rubber-band when dragging outside the editor panels. Fixed with overflow: hidden + overscroll-behavior: none, confining scroll to the internal areas (.card-scroll, .tpl-list) that already had their own overflow-y: auto.
.gradient-stop.selected was stacking a border plus 3 layers of box-shadow, rendering as concentric squares instead of one square with a white margin. Reduced to a single ring.
3-line change in app/globals.css.
To test: drag/scroll outside the panels (trackpad and mouse) and confirm the page doesn't move or bounce; confirm internal panel scrolling still works; check the gradient panel shows a clean single-ring highlight on the selected stop.

Slider and segmented-track motion
🔗 https://github.com/davicorrea0/motion-jitter-clone/pull/83

Ported by measurement (30fps capture), not by eye — no palette, radius, or layout changes, only behavior:

Segmented tracks: the active chip now slides into place instead of snapping. Fixed 490ms duration, cubic-bezier(.71, 0, .07, 1) easing (fitted with rms 0.037 across 29 samples). Built on :has(), so no markup changed across the 22 existing call sites. Three families (.pj-sort, the 4-column grids, mobile .pills) keep the instant highlight since they don't fit the model.
Slider: fill now carries the contrast (reuses --inverse-bg/--inverse-fg, already used by the Export button and playhead); the readout inverts glyph-by-glyph via clip-path; square step marks appear on hover; the handle splits into two halves when the readout sits over it; rubber band at the drag ends (6px * (1 - e^(-overshoot/55))); mobile slider keeps its own distinct behavior (no solid fill).
Technical finding: transform: translateX(calc(var(--seg-i) * 100%)) neither animates nor lands when --seg-i is an unregistered custom property — fixed by writing the offset per index instead of depending on @property (not yet fully supported in Safari).
prefers-reduced-motion: reduce respected across all new transitions.
Files: app/globals.css (+310/-9), components/Controls.tsx (+118/-5), styles/tokens.css (+25).
Verified: tsc --noEmit, next build, npm test (6 suites) all clean.