### PR TITLE
Unify editor icons and animate theme toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -444,6 +444,73 @@ input[type=range] {
 }
 
 /* ============================================================
+   THEME GLYPH — the sun/moon toggle, one shape that morphs
+   (components/EditorIcons.tsx → ThemeGlyph)
+
+   The MOON is the base state, because the button offers the theme
+   you are going TO: on light it shows the moon, on dark the sun.
+
+   Everything moves on `transform`, so it composites. Two details
+   that are load-bearing rather than decorative:
+
+   · `stroke-width` animates alongside the disc's scale. Without it
+     scale(1.55) would drag the 1.5 stroke up to 2.33 and the glyph
+     would fatten away from the rest of the icon set.
+   · The rays retract to the centre, which means they cross the disc's
+     ring on the way in (they live between radius 6.2 and 8.5; the
+     disc grows to 6.2). That is deliberate here — it is the original
+     gesture — and it is why they also fade over the full duration
+     rather than lingering.
+   ============================================================ */
+.theme-glyph {
+  --dur: 420ms;
+  --grow: 1.55;
+  --sw: 0.968;    /* 1.5 / --grow, so the stroke reads 1.5 at both ends */
+  --park: 3.61px; /* clears the disc's stroke by 1.35 in the sun state */
+}
+
+.theme-glyph .disc {
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform    var(--dur) cubic-bezier(.4, 0, .2, 1),
+              stroke-width var(--dur) cubic-bezier(.4, 0, .2, 1);
+}
+
+.theme-glyph .bite {
+  transition: transform var(--dur) cubic-bezier(.4, 0, .2, 1);
+}
+
+.theme-glyph .rays {
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform var(--dur) cubic-bezier(.4, 0, .2, 1),
+              opacity   var(--dur) linear;
+}
+
+/* light theme → the MOON: disc grown, bite carved in, rays gone */
+.theme-glyph .disc { transform: scale(var(--grow)); stroke-width: var(--sw); }
+.theme-glyph .bite { transform: translate(0, 0); }
+.theme-glyph .rays { transform: scale(0); opacity: 0; transition-delay: 0ms; }
+
+/* dark theme → the SUN: bite parked off the disc, rays out */
+:root[data-theme="dark"] .theme-glyph .disc { transform: none; stroke-width: 1.5; }
+:root[data-theme="dark"] .theme-glyph .bite {
+  transform: translate(var(--park), calc(-1 * var(--park)));
+}
+:root[data-theme="dark"] .theme-glyph .rays {
+  transform: none;
+  opacity: .5;
+  transition-delay: calc(var(--dur) * .2);
+}
+
+/* 1ms rather than 0s: the end state still has to be applied */
+@media (prefers-reduced-motion: reduce) {
+  .theme-glyph .disc,
+  .theme-glyph .bite,
+  .theme-glyph .rays { transition-duration: 1ms; transition-delay: 0ms; }
+}
+
+/* ============================================================
    TEMPLATES CARD — header pad 14/12/10, tabs + search h34
    ============================================================ */
 .templates {

--- a/components/AssetsPanel.tsx
+++ b/components/AssetsPanel.tsx
@@ -11,6 +11,7 @@ import { isVideoSource } from '@/lib/videoTexture';
 import MobileSheet from './MobileSheet';
 import { useMobileInteractions } from './MobileInteractions';
 import { DimInput } from './CanvasPanel';
+import { AddIcon, ChevronDownIcon, ChevronUpIcon, CloseIcon, CropIcon, EyeIcon as Eye, EyeOffIcon, GripIcon } from './EditorIcons';
 
 const SHAPE_OPTIONS = ['auto', ...Object.keys(CARD_SHAPES)];
 // The pair the W×H fields open on. It is seeded from whatever ratio the scene
@@ -25,21 +26,7 @@ const pixelPairFor = (ratio: number): [number, number] => (ratio >= 1
   ? [PIXEL_SEED_LONG_EDGE, Math.round(PIXEL_SEED_LONG_EDGE / ratio)]
   : [Math.round(PIXEL_SEED_LONG_EDGE * ratio), PIXEL_SEED_LONG_EDGE]);
 
-const EyeIcon = ({ off }: { off?: boolean }) => (
-  <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-    <path d="M1.5 8s2.5-4.5 6.5-4.5S14.5 8 14.5 8 12 12.5 8 12.5 1.5 8 1.5 8z" stroke="currentColor" strokeWidth="1.3"/>
-    <circle cx="8" cy="8" r="2" stroke="currentColor" strokeWidth="1.3"/>
-    {off && <path d="M2.5 13.5l11-11" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>}
-  </svg>
-);
-
-const XIcon = () => (
-  <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
-);
-
-const CropIcon = () => (
-  <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M4 1.5v10.5h10.5M1.5 4H12v10.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/></svg>
-);
+const AssetEyeIcon = ({ off }: { off?: boolean }) => (off ? <EyeOffIcon size={12}/> : <Eye size={12}/>);
 
 // 3×3 focal-point picker: images cover-fill their card without stretching;
 // the focus chooses which part survives the crop.
@@ -92,12 +79,6 @@ function MobileCropSheet({ asset, onClose }: { asset: AssetItem; onClose: () => 
     </MobileSheet>
   );
 }
-
-const GripIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
-    {[5, 9, 13].flatMap((y) => [7, 11].map((x) => <circle key={`${x}-${y}`} cx={x} cy={y} r="1" />))}
-  </svg>
-);
 
 function MobileAssetRow({
   asset,
@@ -153,9 +134,9 @@ function MobileAssetRow({
       style={{ transform: CSS.Transform.toString(transform), transition }}
     >
       <div className="mobile-asset-actions" aria-hidden={!open}>
-        <button onClick={() => { onCrop(); onOpen(false); }}><CropIcon /><span>Crop</span></button>
-        <button onClick={() => { onToggle(); onOpen(false); }}><EyeIcon off={!asset.visible} /><span>{asset.visible ? 'Hide' : 'Show'}</span></button>
-        <button className="danger" onClick={() => { onRemove(); onOpen(false); }}><XIcon /><span>Remove</span></button>
+        <button onClick={() => { onCrop(); onOpen(false); }}><CropIcon size={12}/><span>Crop</span></button>
+        <button onClick={() => { onToggle(); onOpen(false); }}><AssetEyeIcon off={!asset.visible} /><span>{asset.visible ? 'Hide' : 'Show'}</span></button>
+        <button className="danger" onClick={() => { onRemove(); onOpen(false); }}><CloseIcon size={12}/><span>Remove</span></button>
       </div>
       <div
         className="mobile-asset-face"
@@ -182,7 +163,7 @@ function MobileAssetRow({
           {...attributes}
           {...listeners}
         >
-          <GripIcon />
+          <GripIcon size={18}/>
         </button>
       </div>
     </li>
@@ -486,7 +467,7 @@ export default function AssetsPanel() {
             <DragOverlay>
               {activeDragId && (() => {
                 const asset = sortableEntries.find((entry) => entry.asset.id === activeDragId)?.asset;
-                return asset ? <div className="mobile-asset-overlay"><span className="asset-thumb asset-thumb-empty" /><span>{asset.name}</span><GripIcon /></div> : null;
+                return asset ? <div className="mobile-asset-overlay"><span className="asset-thumb asset-thumb-empty" /><span>{asset.name}</span><GripIcon size={18}/></div> : null;
               })()}
             </DragOverlay>
             {cropOpenId && (() => {
@@ -512,7 +493,7 @@ export default function AssetsPanel() {
                   // persisted upload still resolving from IndexedDB (or its bytes
                   // are gone) — show a clickable placeholder, never src="".
                   <span className="asset-thumb asset-thumb-empty" onClick={() => openSlotPicker(i)} title="Re-add file">
-                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/></svg>
+                    <AddIcon size={12}/>
                   </span>
                 ) : isVideoSource(a.url, a.kind) ? (
                   // play only on hover — a still poster frame otherwise, so N video
@@ -543,7 +524,7 @@ export default function AssetsPanel() {
                     disabled={i === 0}
                     onClick={() => i > 0 && reorderAssets(i, i - 1)}
                   >
-                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M4 10l4-4 4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                    <ChevronUpIcon size={14}/>
                   </button>
                   <button
                     className="icon-btn"
@@ -552,7 +533,7 @@ export default function AssetsPanel() {
                     disabled={i >= filled - 1}
                     onClick={() => i < filled - 1 && reorderAssets(i, i + 1)}
                   >
-                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                    <ChevronDownIcon size={14}/>
                   </button>
                 </span>
                 <button
@@ -560,13 +541,13 @@ export default function AssetsPanel() {
                   title="Crop focus"
                   onClick={() => setCropOpenId(cropOpenId === a.id ? null : a.id)}
                 >
-                  <CropIcon />
+                  <CropIcon size={12}/>
                 </button>
                 <button className={`icon-btn ${a.visible ? '' : 'off'}`} title={a.visible ? 'Hide' : 'Show'} onClick={() => toggleAsset(a.id)}>
-                  <EyeIcon off={!a.visible} />
+                  <AssetEyeIcon off={!a.visible} />
                 </button>
                 <button className="icon-btn" title="Remove" onClick={() => removeAsset(a.id)}>
-                  <XIcon />
+                  <CloseIcon size={12}/>
                 </button>
                 {cropOpenId === a.id && <CropPopover asset={a} onClose={() => setCropOpenId(null)} />}
               </li>
@@ -579,7 +560,7 @@ export default function AssetsPanel() {
               >
                 <span className="asset-idx">{i + 1}</span>
                 <span className="asset-thumb asset-thumb-empty">
-                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/></svg>
+                  <AddIcon size={12}/>
                 </span>
                 <span className="mobile-slot-copy"><strong>Slot {i + 1}</strong><small>Drop or click to add</small></span>
               </li>

--- a/components/BoardExportBar.tsx
+++ b/components/BoardExportBar.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { downloadSceneZip } from '@/lib/exportScene';
+import { AlertIcon, ExportIcon } from './EditorIcons';
 
 // Board mode — the export control for the timeline bar, mirroring WebSourceBar.
 // Packs the live scene (runtime + config + preview + README) into a zip.
@@ -25,10 +26,7 @@ export default function BoardExportBar() {
     <div className="web-source-bar">
       {err && (
         <span className="web-source-err" title={err}>
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-            <circle cx="8" cy="8" r="6.25" stroke="currentColor" strokeWidth="1.4"/>
-            <path d="M8 5v3.5M8 10.8v.2" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
-          </svg>
+          <AlertIcon size={12}/>
           {err}
         </span>
       )}
@@ -38,7 +36,7 @@ export default function BoardExportBar() {
         disabled={busy}
         title="Download the scene bundle (runtime + config + preview) as a zip"
       >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M8 2v8m0 0L5 7m3 3l3-3M3 13h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+        <ExportIcon size={14}/>
         {busy ? 'Packing…' : 'Export zip'}
       </button>
     </div>

--- a/components/DesktopEditor.tsx
+++ b/components/DesktopEditor.tsx
@@ -29,6 +29,7 @@ import WebSourceBar from '@/components/WebSourceBar';
 import { use3DStore } from '@/store/use3DStore';
 import { useUIStore } from '@/store/useUIStore';
 import { useWebStore } from '@/store/useWebStore';
+import { ChevronRightIcon, FullscreenIcon } from '@/components/EditorIcons';
 
 const PreviewStage = dynamic(() => import('@/components/PreviewStage'), { ssr: false });
 const ThreeStage3D = dynamic(() => import('@/components/ThreeStage3D'), { ssr: false });
@@ -99,7 +100,7 @@ export default function DesktopEditor() {
           <>
             <PreviewStage />
             <button className="stage-fs" title="Fullscreen">
-              <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><path d="M2 6V2h4M14 6V2h-4M2 10v4h4M14 10v4h-4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" /></svg>
+              <FullscreenIcon size={15}/>
             </button>
           </>
         )}
@@ -108,10 +109,10 @@ export default function DesktopEditor() {
         {!isProjects && <ProjectDock />}
         <HistoryControls />
         <button className="panel-toggle panel-toggle-left" onClick={toggleLeftPanel} aria-expanded={!leftCollapsed} aria-label={leftCollapsed ? 'Expand left sidebar' : 'Collapse left sidebar'} title={leftCollapsed ? 'Expand left sidebar' : 'Collapse left sidebar'}>
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 3.5L10.5 8 6 12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
+          <ChevronRightIcon size={16}/>
         </button>
         <button className="panel-toggle panel-toggle-right" onClick={toggleRightPanel} aria-expanded={!rightCollapsed} aria-label={rightCollapsed ? 'Expand right sidebar' : 'Collapse right sidebar'} title={rightCollapsed ? 'Expand right sidebar' : 'Collapse right sidebar'}>
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 3.5L10.5 8 6 12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
+          <ChevronRightIcon size={16}/>
         </button>
       </main>
 

--- a/components/EasingPanel.tsx
+++ b/components/EasingPanel.tsx
@@ -10,6 +10,7 @@ import {
   sampleEasing,
   type EasingSpec,
 } from '@/lib/easing';
+import { ResetIcon } from './EditorIcons';
 
 // A small preset preview curve (own tiny viewBox with padding).
 function MiniCurve({ spec }: { spec: EasingSpec }) {
@@ -76,9 +77,7 @@ export default function EasingPanel() {
 
         {/* ---- reset ---- */}
         <button className="ez-reset" onClick={resetValues}>
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-            <path d="M3 8a5 5 0 1 1 1.5 3.5M3 8V4.5M3 8h3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
+          <ResetIcon size={12}/>
           Reset all values
         </button>
       </div>

--- a/components/EditorIcons.tsx
+++ b/components/EditorIcons.tsx
@@ -1,4 +1,29 @@
-import type { SVGProps } from 'react';
+import { useId, type SVGProps } from 'react';
+
+// ============================================================
+//  ONE SPEC for every icon in the editor — rail, panels, transport,
+//  and everything that used to live inline in other components:
+//
+//   1. Optical box 14×14, inside a 20×20 grid (x3–17 · y3–17),
+//      touching at least two opposite edges — no more Mockup at 8
+//      wide next to Boards at 15.
+//   2. A single viewBox: 0 0 20 20. `size` still controls the
+//      rendered pixels (Export/Undo/Redo/Play/Pause stay smaller by
+//      default), but every icon is now drawn on the same 20-unit grid.
+//   3. stroke / stroke-width / fill / join / cap live ONCE here, on
+//      the <svg>, and are inherited — a path only carries geometry
+//      and, when secondary, opacity .5.
+//   4. No corner radius anywhere: rx doesn't exist. Matches
+//      --r-card / --r-nav / --r-seg / --r-chip, all 0px.
+//   5. Two opacity levels only: 1 and .5.
+//   6. Geometry on the 0.5 grid; a 2-unit minimum gutter between
+//      neighbouring strokes so nothing merges at 20px.
+//   7. Exceptions are named, not accidental: a curve only where the
+//      curve IS the shape (Sun, Moon, Bell, the Undo/Redo loop, the
+//      easing curve) — never as corner rounding. Perspective only on
+//      the 3D icon. Fill only on the transport marks (Play/Pause),
+//      which need mass at 14px.
+// ============================================================
 
 export type EditorIconProps = Omit<SVGProps<SVGSVGElement>, 'width' | 'height'> & {
   size?: number;
@@ -10,101 +35,390 @@ function iconProps({ size = 20, ...props }: EditorIconProps) {
     height: size,
     viewBox: '0 0 20 20',
     fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 1.5,
+    strokeLinejoin: 'miter',
+    strokeLinecap: 'butt',
     'aria-hidden': true,
     focusable: false,
     ...props,
   } as const;
 }
 
+// Play/Pause are the rule-07 fill exception: transport marks need mass at 14px.
+function iconPropsFilled({ size = 20, ...props }: EditorIconProps) {
+  return {
+    width: size,
+    height: size,
+    viewBox: '0 0 20 20',
+    fill: 'currentColor',
+    stroke: 'none',
+    'aria-hidden': true,
+    focusable: false,
+    ...props,
+  } as const;
+}
+
+// ---------------------------------------------------------------
+//  Rail — navigation
+// ---------------------------------------------------------------
+
+export function AddIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M10 3v14M3 10h14"/></svg>;
+}
+
 export function ProjectsIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M2.75 6.25A1.5 1.5 0 014.25 4.75h3l1.5 1.75h6a1.5 1.5 0 011.5 1.5v6.25a1.5 1.5 0 01-1.5 1.5h-10.5a1.5 1.5 0 01-1.5-1.5V6.25z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>;
+  return <svg {...iconProps(props)}><path d="M3 17V4h5.5l2 2H17v11Z"/></svg>;
 }
 
+// A featured card with two more receding behind it — which is literally what
+// the Runway and Coverflow families do, so the icon states the section's
+// content and its motion at once. A 2x2 grid, which this was, is the shape
+// every dashboard uses for "library" and says nothing about this app.
+// Gutters are 2 and 2.5, over the 2-unit minimum, so the thin cards stay
+// separate at 20px instead of merging into a block.
 export function LibraryIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><rect x="3" y="3" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="11" y="3" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="3" y="11" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><rect x="11" y="11" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5"/></svg>;
+  return <svg {...iconProps(props)}>
+    <path d="M10 3h7v14h-7Z"/>
+    <path d="M6.5 4.5h1.5v11H6.5ZM3 6h1.5v8H3Z" opacity=".5"/>
+  </svg>;
 }
 
-export function ThreeDIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M10 2.5l6.5 3.75v7.5L10 17.5l-6.5-3.75v-7.5L10 2.5z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/><path d="M3.7 6.4L10 10l6.3-3.6M10 10v7.4" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>;
-}
-
-export function WebIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M7.5 6.5L4 10l3.5 3.5M12.5 6.5L16 10l-3.5 3.5M11 4.5l-2 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
-}
-
-export function BoardIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><rect x="2.5" y="4.5" width="4.5" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5"/><rect x="8" y="4.5" width="4" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5" opacity="0.65"/><rect x="13" y="4.5" width="4.5" height="11" rx="1.2" stroke="currentColor" strokeWidth="1.5" opacity="0.4"/></svg>;
+// A screen on a stand: covers all four device slots (phone, laptop,
+// tablet, display) instead of asserting "phone".
+export function MockupIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M3 3h14v10H3Z"/>
+    <path d="M10 13v4M6 17h8" opacity=".5"/>
+  </svg>;
 }
 
 export function ExperimentalsIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M7.5 2.75h5M8.5 2.75v4.5l-4.25 7.1A1.9 1.9 0 005.9 17.25h8.2a1.9 1.9 0 001.65-2.9l-4.25-7.1v-4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/><path d="M6.5 13h7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" opacity=".55"/></svg>;
+  return <svg {...iconProps(props)}>
+    <path d="M7 3h6M8.5 3v5L3.5 17h13L11.5 8V3"/>
+    <path d="M6 13h8" opacity=".5"/>
+  </svg>;
 }
 
-export function MockupIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><rect x="6" y="2" width="8" height="16" rx="1.8" stroke="currentColor" strokeWidth="1.5"/><path d="M8.5 15.5h3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>;
+// Rule 07's perspective exception — the only isometric glyph, because
+// this is the only section whose subject is perspective.
+export function ThreeDIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M10 3l7 3.5v7L10 17l-7-3.5v-7Z"/>
+    <path d="M3 6.5L10 10l7-3.5M10 10v7" opacity=".5"/>
+  </svg>;
 }
 
-export function AddIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M10 4v12M4 10h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>;
+export function WebIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M7 6l-4 4 4 4M13 6l4 4-4 4"/>
+    <path d="M11.5 3l-3 14" opacity=".5"/>
+  </svg>;
 }
 
+// A board of ARRANGED cards, not a kanban of columns — three sizes in
+// two directions, so it never reads as a row of columns next to Library.
+export function BoardIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M3 3h8v7H3Z"/>
+    <path d="M13 3h4v14h-4ZM3 12h8v5H3Z" opacity=".5"/>
+  </svg>;
+}
+
+// ---------------------------------------------------------------
+//  Rail — footer
+// ---------------------------------------------------------------
+
+export function BellIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M5 14.5V9a5 5 0 0 1 10 0v5.5M3 14.5h14"/>
+    <path d="M8.5 17h3" opacity=".5"/>
+  </svg>;
+}
+
+// Bigger disc (r 3.5 -> 4) and rays that vary in length — cardinals reach
+// further than diagonals, so it reads as a burst instead of eight identical
+// ticks. The gap off the disc is 2.2 all the way round, and the tips are
+// allowed past the 14x14 optical box other icons keep to — a sunburst is the
+// one shape that reads better breaking its own frame. Widening the gap means
+// pushing the tips out too, or the rays shorten into stubs.
 export function SunIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><circle cx="10" cy="10" r="3.25" stroke="currentColor" strokeWidth="1.5"/><path d="M10 2.5v2M10 15.5v2M2.5 10h2M15.5 10h2M4.7 4.7l1.4 1.4M13.9 13.9l1.4 1.4M15.3 4.7l-1.4 1.4M6.1 13.9l-1.4 1.4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>;
+  return <svg {...iconProps(props)}>
+    <path d="M14 10A4 4 0 0 1 6 10A4 4 0 0 1 14 10Z"/>
+    <path d="M10 3.8V1.5M10 16.2V18.5M3.8 10H1.5M16.2 10H18.5M14.4 5.6l1.1-1.1M14.4 14.4l1.1 1.1M5.6 14.4l-1.1 1.1M5.6 5.6l-1.1-1.1" opacity=".5"/>
+  </svg>;
 }
 
 export function MoonIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M15.7 12.6A6 6 0 017.4 4.3 6.1 6.1 0 1015.7 12.6z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/></svg>;
+  return <svg {...iconProps(props)}><path d="M16.1 12.8A8 8 0 0 1 7.2 3.9A6.55 6.55 0 1 0 16.1 12.8Z"/></svg>;
 }
 
-export function BellIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M5.25 8.4a4.75 4.75 0 019.5 0v3.1l1.35 2.1H3.9l1.35-2.1V8.4z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/><path d="M8.15 15.2a2 2 0 003.7 0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>;
+// ---------------------------------------------------------------
+//  The theme toggle, as ONE morphing glyph instead of two icons
+//  swapped by a ternary — a swap has nothing to animate.
+//
+//  The disc grows, a bite slides over it and carves the crescent,
+//  and the rays retract. Two stroked rings mask each other: the disc
+//  shows only OUTSIDE the bite (the crescent's outer arc) and the
+//  bite shows only INSIDE the disc (its inner arc), so together they
+//  close the shape. Three things that geometry forced, all measured:
+//
+//   · The bite sits 7.5 from the disc centre, not closer. That is the
+//     angle the two arcs cross at (108°); at 4.67 they cross at 137°,
+//     a graze that leaves a long forked tip instead of a cusp.
+//   · The bite parks 12.6 away in the sun state. Under 11.25 it
+//     notches the disc's stroke; much farther and it only reaches the
+//     disc in the last quarter, so the moon snaps in instead of forming.
+//   · The masks sit on the STATIC <g> with the transform on the child.
+//     A mask is resolved in its own element's space, so putting it on
+//     the moving ring makes the mask travel along and leaves a sliver
+//     of ring showing in the sun.
+//
+//  Keyed off :root[data-theme="dark"] in app/globals.css. The moon is
+//  the BASE state because the button shows the theme you are going to:
+//  light theme offers the moon, dark theme offers the sun.
+// ---------------------------------------------------------------
+
+export function ThemeGlyph(props: EditorIconProps) {
+  const uid = useId();
+  const cut = `theme-cut-${uid}`;
+  const inside = `theme-in-${uid}`;
+  return (
+    <svg {...iconProps(props)} className="theme-glyph">
+      <defs>
+        {/* hide the disc where the bite covers it */}
+        <mask id={cut} maskUnits="userSpaceOnUse" x="-14" y="-14" width="48" height="48">
+          <rect x="-14" y="-14" width="48" height="48" fill="#fff"/>
+          <circle className="bite" cx="15.3" cy="4.7" r="6.5" fill="#000"/>
+        </mask>
+        {/* show the bite's ring only where it falls inside the disc */}
+        <mask id={inside} maskUnits="userSpaceOnUse" x="-14" y="-14" width="48" height="48">
+          <circle className="disc" cx="10" cy="10" r="4" fill="#fff"/>
+        </mask>
+      </defs>
+      <g mask={`url(#${cut})`}><circle className="disc" cx="10" cy="10" r="4"/></g>
+      <g mask={`url(#${inside})`}><circle className="bite" cx="15.3" cy="4.7" r="6.5"/></g>
+      <g className="rays" opacity=".5">
+        <path d="M10 3.8V1.5M10 16.2V18.5M3.8 10H1.5M16.2 10H18.5M14.4 5.6l1.1-1.1M14.4 14.4l1.1 1.1M5.6 14.4l-1.1 1.1M5.6 5.6l-1.1-1.1"/>
+      </g>
+    </svg>
+  );
 }
 
+// ---------------------------------------------------------------
+//  Panels
+// ---------------------------------------------------------------
+
+// Frame plus the mountain silhouette, and no sun. The 1.5-unit square that
+// used to stand in for one did not read as a sun — a sun needs a ray or a
+// curve to identify it, and at 20px that square was just a speck in the
+// corner.
 export function MediaIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><rect x="2.75" y="3.5" width="14.5" height="13" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><circle cx="7" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.5"/><path d="M4.5 14l3.2-3 2.4 2 2.1-2.1 3.3 3.1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+  return <svg {...iconProps(props)}>
+    <path d="M3 3h14v14H3Z"/>
+    <path d="M3 13.5l4-4 3.5 3.5L14 9.5l3 3" opacity=".5"/>
+  </svg>;
 }
 
 export function AdjustIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M3 5h4M11 5h6M3 10h8M15 10h2M3 15h3M10 15h7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/><circle cx="9" cy="5" r="2" stroke="currentColor" strokeWidth="1.5"/><circle cx="13" cy="10" r="2" stroke="currentColor" strokeWidth="1.5"/><circle cx="8" cy="15" r="2" stroke="currentColor" strokeWidth="1.5"/></svg>;
+  return <svg {...iconProps(props)}>
+    <path d="M7 3.5h2v3H7ZM12 8.5h2v3h-2ZM5.5 13.5h2v3h-2Z"/>
+    <path d="M3 5h4M9 5h8M3 10h9M14 10h3M3 15h2.5M7.5 15H17" opacity=".5"/>
+  </svg>;
 }
 
 export function CanvasIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><rect x="3" y="3" width="14" height="14" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><path d="M7 3v14M13 3v14M3 7h14M3 13h14" stroke="currentColor" strokeWidth="1.5" opacity="0.45"/></svg>;
+  return <svg {...iconProps(props)}>
+    <path d="M3 3h14v14H3Z"/>
+    <path d="M7.5 3v14M12.5 3v14M3 7.5h14M3 12.5h14" opacity=".5"/>
+  </svg>;
 }
 
-export function ExportIcon(props: EditorIconProps) {
-  const { size = 14, ...rest } = props;
-  return <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden focusable="false" {...rest}><path d="M8 2v8m0 0L5 7m3 3l3-3M3 13h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
-}
-
-export function UndoIcon(props: EditorIconProps) {
-  const { size = 15, ...rest } = props;
-  return <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden focusable="false" {...rest}><path d="M3 7h6.5a3.5 3.5 0 010 7H6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/><path d="M5.5 4.5L3 7l2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>;
-}
-
-export function RedoIcon(props: EditorIconProps) {
-  const { size = 15, ...rest } = props;
-  return <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden focusable="false" {...rest}><path d="M13 7H6.5a3.5 3.5 0 000 7H10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/><path d="M10.5 4.5L13 7l-2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>;
-}
-
-export function PlayIcon(props: EditorIconProps) {
-  const { size = 14, ...rest } = props;
-  return <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden focusable="false" {...rest}><path d="M4 2.8v8.4c0 .8.9 1.3 1.6.9l6.6-4.2c.6-.4.6-1.4 0-1.8L5.6 1.9c-.7-.4-1.6.1-1.6.9z" fill="currentColor"/></svg>;
-}
-
-export function PauseIcon(props: EditorIconProps) {
-  const { size = 14, ...rest } = props;
-  return <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden focusable="false" {...rest}><rect x="3" y="2.5" width="3" height="9" rx="1" fill="currentColor"/><rect x="8" y="2.5" width="3" height="9" rx="1" fill="currentColor"/></svg>;
+// Stem on top, dot on bottom — inverted from the standard lowercase-i
+// A literal lowercase "i": dot on top, stem below — and the EXACT vertical
+// mirror of AlertIcon about y=10, same dot (1.2) and same stem (5) in the
+// opposite arrangement. Telling them apart by proportion, which is what this
+// used to do, fails at 18px: both were stem-over-dot and read as the same
+// glyph. Mirroring is the only difference that survives the size.
+// The dot is filled rather than stroked — a stroke-only square that small
+// would leave its centre hollow.
+export function InfoIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M17 10A7 7 0 1 1 3 10A7 7 0 1 1 17 10Z"/>
+    <path d="M9.4 6.2h1.2v1.2h-1.2Z" fill="currentColor" stroke="none" opacity=".5"/>
+    <path d="M10 9V14" opacity=".5"/>
+  </svg>;
 }
 
 export function ChevronDownIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M5 7.5l5 5 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+  return <svg {...iconProps(props)}><path d="M3 7l7 6 7-6"/></svg>;
 }
 
 export function BackIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M13 4l-6 6 6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+  return <svg {...iconProps(props)}><path d="M13 3l-6 7 6 7"/></svg>;
 }
 
-export function InfoIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><circle cx="10" cy="10" r="7" stroke="currentColor" strokeWidth="1.5"/><path d="M10 9v4M10 6.5v.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>;
+// ---------------------------------------------------------------
+//  Transport & history — same 20x20 grid as everything else now;
+//  `size` keeps them rendering smaller by default, for tight toolbars.
+// ---------------------------------------------------------------
+
+export function ExportIcon(props: EditorIconProps) {
+  return <svg {...iconProps({ size: 14, ...props })}>
+    <path d="M10 3v9M6.5 8.5L10 12l3.5-3.5"/>
+    <path d="M3 17h14" opacity=".5"/>
+  </svg>;
+}
+
+// Rule 07's curve exception — the loop is the shape, not corner rounding.
+export function UndoIcon(props: EditorIconProps) {
+  return <svg {...iconProps({ size: 15, ...props })}>
+    <path d="M6.5 3.5L3 7l3.5 3.5"/>
+    <path d="M3 7h9a4.5 4.5 0 0 1 0 9H7" opacity=".5"/>
+  </svg>;
+}
+
+export function RedoIcon(props: EditorIconProps) {
+  return <svg {...iconProps({ size: 15, ...props })}>
+    <path d="M13.5 3.5L17 7l-3.5 3.5"/>
+    <path d="M17 7H8a4.5 4.5 0 0 0 0 9h5" opacity=".5"/>
+  </svg>;
+}
+
+// Rule 07's fill exception — transport marks need mass at 14px.
+export function PlayIcon(props: EditorIconProps) {
+  return <svg {...iconPropsFilled({ size: 14, ...props })}><path d="M5 3.5L17 10L5 16.5Z"/></svg>;
+}
+
+export function PauseIcon(props: EditorIconProps) {
+  return <svg {...iconPropsFilled({ size: 14, ...props })}><path d="M3.5 3.5h5v13h-5ZM11.5 3.5h5v13h-5Z"/></svg>;
+}
+
+// ---------------------------------------------------------------
+//  Actions — previously copy-pasted inline in 2-3 components each,
+//  each copy drifting a little. Now one definition, imported.
+// ---------------------------------------------------------------
+
+export function PencilIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M12.5 3.5l4 4L7 17H3v-4L12.5 3.5Z"/>
+    <path d="M10.5 5.5l4 4" opacity=".5"/>
+  </svg>;
+}
+
+export function DuplicateIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M7 7h10v10H7Z"/>
+    <path d="M3 3h10v10H3Z" opacity=".5"/>
+  </svg>;
+}
+
+export function TrashIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M3 6h14M5 6l1 11h8l1-11"/>
+    <path d="M8 6V3.5h4V6" opacity=".5"/>
+  </svg>;
+}
+
+export function CloseIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M3 3l14 14M17 3L3 17"/></svg>;
+}
+
+export function SearchIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M13.5 8.5A5 5 0 1 1 3.5 8.5A5 5 0 1 1 13.5 8.5Z"/>
+    <path d="M12.5 12.5L17 17" opacity=".5"/>
+  </svg>;
+}
+
+export function HeartIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M10 16.5C10 16.5 3 12 3 7.5A3.5 3.5 0 0 1 10 6A3.5 3.5 0 0 1 17 7.5C17 12 10 16.5 10 16.5Z"/>
+  </svg>;
+}
+
+export function CropIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M6.5 3v10.5H17"/>
+    <path d="M3 6.5h10.5V17" opacity=".5"/>
+  </svg>;
+}
+
+// The drag-reorder handle: two columns of dots, filled (not stroked — a
+// grip is a texture, not a contour, so it stays outside rule 03's stroke-only
+// default the same way Play/Pause do).
+export function GripIcon(props: EditorIconProps) {
+  return <svg {...iconPropsFilled(props)}>
+    <circle cx="7" cy="5" r="1.1"/><circle cx="13" cy="5" r="1.1"/>
+    <circle cx="7" cy="10" r="1.1"/><circle cx="13" cy="10" r="1.1"/>
+    <circle cx="7" cy="15" r="1.1"/><circle cx="13" cy="15" r="1.1"/>
+  </svg>;
+}
+
+// ---------------------------------------------------------------
+//  State & visibility
+// ---------------------------------------------------------------
+
+export function EyeIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M3 10A8 8 0 0 1 17 10A8 8 0 0 1 3 10Z"/>
+    <path d="M12 10A2 2 0 0 1 8 10A2 2 0 0 1 12 10Z" opacity=".5"/>
+  </svg>;
+}
+
+export function EyeOffIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M3.5 16.5L16.5 3.5"/>
+    <path d="M3 10A8 8 0 0 1 17 10A8 8 0 0 1 3 10ZM12 10A2 2 0 0 1 8 10A2 2 0 0 1 12 10Z" opacity=".5"/>
+  </svg>;
+}
+
+// Filled dot, same reasoning as InfoIcon: a stroke-only square that small
+// reads as a hollow ring instead of a point.
+export function AlertIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M17 10A7 7 0 1 1 3 10A7 7 0 1 1 17 10Z"/>
+    <path d="M10 6v5" opacity=".5"/>
+    <path d="M9.4 12.6h1.2v1.2h-1.2Z" fill="currentColor" stroke="none" opacity=".5"/>
+  </svg>;
+}
+
+export function FullscreenIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M3 7V3h4M17 7V3h-4M3 13v4h4M17 13v4h-4"/></svg>;
+}
+
+// Two plates of the SAME size on a true 2:1 isometric (half-width 7, half-
+// height 3.5), the lower one drawn as just the V that the upper plate does
+// not cover — that is what makes it read as a stack. Two different sizes
+// with a gap, which is what this was, reads as an arrow instead.
+// Isometric here is a second named perspective exception to rule 07: a
+// stack of planes is a depth concept the same way the 3D shelf is.
+export function LayersIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M10 4.5L17 8L10 11.5L3 8Z"/>
+    <path d="M3 12L10 15.5L17 12"/>
+  </svg>;
+}
+
+// ---------------------------------------------------------------
+//  Navigation & editor
+// ---------------------------------------------------------------
+
+export function ChevronUpIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M3 13l7-6 7 6"/></svg>;
+}
+
+export function ChevronRightIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}><path d="M7 3l6 7-6 7"/></svg>;
+}
+
+// Rule 07's curve exception — the loop is the shape, not corner rounding.
+// Both arc endpoints sit exactly on the r=7 circle centred at (10,10): with
+// endpoints off the radius, SVG silently scales the radius up to reach them,
+// which is what pushed this glyph outside the 14x14 box (y 2 -> 17.58).
+export function ResetIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M3 10A7 7 0 1 1 5.05 14.95"/>
+    <path d="M3 10V6.5M3 10H6.5" opacity=".5"/>
+  </svg>;
 }

--- a/components/EffectsPanel.tsx
+++ b/components/EffectsPanel.tsx
@@ -8,6 +8,7 @@ import { useSceneStore, type ActiveEffect } from '@/store/useSceneStore';
 import { effectList, getEffect, effectDefaults } from '@/effects';
 import { ControlRow } from './Controls';
 import { useMobileInteractions } from './MobileInteractions';
+import { CloseIcon, EyeIcon, EyeOffIcon } from './EditorIcons';
 
 function MobileEffectCard({
   effect,
@@ -30,7 +31,7 @@ function MobileEffectCard({
         <button className="mobile-effect-grip" aria-label={`Reorder ${def.meta.name}`} {...attributes} {...listeners}>⠿</button>
         <span className="effect-title">{def.meta.name}</span>
         <button className="icon-btn" aria-label={effect.enabled ? `Disable ${def.meta.name}` : `Enable ${def.meta.name}`} onClick={onToggle}>
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M1.5 8s2.5-4.5 6.5-4.5S14.5 8 14.5 8 12 12.5 8 12.5 1.5 8 1.5 8z" stroke="currentColor" strokeWidth="1.3" /><circle cx="8" cy="8" r="2" stroke="currentColor" strokeWidth="1.3" /></svg>
+          {effect.enabled ? <EyeIcon size={16}/> : <EyeOffIcon size={16}/>}
         </button>
         <button className={`icon-btn ${confirming ? 'danger' : ''}`} aria-label={confirming ? `Confirm remove ${def.meta.name}` : `Remove ${def.meta.name}`} onClick={() => confirming ? onRemove() : setConfirming(true)} onBlur={() => setConfirming(false)}>
           {confirming ? <span className="mobile-remove-confirm">Remove?</span> : <span aria-hidden="true">×</span>}
@@ -115,14 +116,10 @@ export default function EffectsPanel() {
                 >⣿</span>
                 <span className="effect-title">{def.meta.name}</span>
                 <button className="icon-btn" onClick={() => toggleEffect(e.instanceId)}>
-                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-                    <path d="M1.5 8s2.5-4.5 6.5-4.5S14.5 8 14.5 8 12 12.5 8 12.5 1.5 8 1.5 8z" stroke="currentColor" strokeWidth="1.3" />
-                    <circle cx="8" cy="8" r="2" stroke="currentColor" strokeWidth="1.3" />
-                    {!e.enabled && <path d="M2.5 13.5l11-11" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />}
-                  </svg>
+                  {e.enabled ? <EyeIcon size={12}/> : <EyeOffIcon size={12}/>}
                 </button>
                 <button className="icon-btn" onClick={() => removeEffect(e.instanceId)}>
-                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" /></svg>
+                  <CloseIcon size={12}/>
                 </button>
               </div>
               <div className="effect-card-body">

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -12,7 +12,7 @@ import { preloadMockupProject } from '@/lib/mockupPreload';
 import { IS_HOSTED_DEPLOYMENT } from '@/lib/deployment';
 import NewsNotifier from './NewsNotifier';
 import UpdateNotifier from './UpdateNotifier';
-import { AddIcon, BoardIcon, ChevronDownIcon, ExperimentalsIcon, LibraryIcon, MockupIcon, MoonIcon, ProjectsIcon, SunIcon, ThreeDIcon, WebIcon } from './EditorIcons';
+import { AddIcon, BoardIcon, ChevronDownIcon, ExperimentalsIcon, LibraryIcon, MockupIcon, ProjectsIcon, ThemeGlyph, ThreeDIcon, WebIcon } from './EditorIcons';
 
 const ICONS: Record<NavSectionId, React.ReactNode> = {
   projects: <ProjectsIcon />,
@@ -147,11 +147,9 @@ export default function IconRail() {
           title={theme === 'dark' ? 'Light theme' : 'Dark theme'}
         >
           <span className="rail-ico">
-            {theme === 'dark' ? (
-              <SunIcon />
-            ) : (
-              <MoonIcon />
-            )}
+            {/* One glyph that morphs — a ternary swap has nothing to animate.
+                Which face shows is decided in CSS, off :root[data-theme]. */}
+            <ThemeGlyph />
           </span>
           <span className="rail-label">{theme === 'dark' ? 'Light' : 'Dark'}</span>
         </button>

--- a/components/MobileEditor.tsx
+++ b/components/MobileEditor.tsx
@@ -14,7 +14,7 @@ import ExportDialog from './ExportDialog';
 import { useUIStore } from '@/store/useUIStore';
 import { useProjectStore } from '@/store/useProjectStore';
 import { useSceneStore } from '@/store/useSceneStore';
-import { AdjustIcon, BackIcon, CanvasIcon, ChevronDownIcon, ExportIcon, InfoIcon, LibraryIcon, MediaIcon, MoonIcon, ProjectsIcon, SunIcon } from './EditorIcons';
+import { AdjustIcon, BackIcon, CanvasIcon, ChevronDownIcon, ExportIcon, InfoIcon, LibraryIcon, MediaIcon, ProjectsIcon, ThemeGlyph } from './EditorIcons';
 import { MobileInteractionProvider } from './MobileInteractions';
 
 const PreviewStage = dynamic(() => import('./PreviewStage'), { ssr: false });
@@ -74,7 +74,7 @@ export default function MobileEditor() {
             aria-label={theme === 'dark' ? 'Use light theme' : 'Use dark theme'}
             title={theme === 'dark' ? 'Light theme' : 'Dark theme'}
           >
-            {theme === 'dark' ? <SunIcon size={18} /> : <MoonIcon size={18} />}
+            <ThemeGlyph size={18} />
           </button>
           <button className="mobile-icon-button" onClick={() => setDesktopNotice(true)} aria-label="Desktop tools information">
             <InfoIcon size={18} />

--- a/components/MockupPanel.tsx
+++ b/components/MockupPanel.tsx
@@ -5,12 +5,9 @@ import { use3DStore, defaultModelFor } from '@/store/use3DStore';
 import { DEVICES, findDevice, selectDevice } from '@/three3d/devices';
 import { MOCKUP_ANIMATIONS } from '@/three3d/animations';
 import { MockupAnimThumb } from './MockupThumb';
+import { ChevronRightIcon } from './EditorIcons';
 
-const Chevron = () => (
-  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-    <path d="M4.5 2.5L8 6l-3.5 3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
+const Chevron = () => <ChevronRightIcon size={12}/>;
 
 // Left column in Mockup mode — accordion list of devices. Clicking a device
 // selects it and expands its panel showing the real 3D thumb, finish swatches,

--- a/components/ProjectsBrowser.tsx
+++ b/components/ProjectsBrowser.tsx
@@ -10,6 +10,7 @@ import { readProjectThreeD } from '@/lib/three3dPersist';
 import { templates } from '@/templates';
 import { useProjectStore } from '@/store/useProjectStore';
 import { useUIStore } from '@/store/useUIStore';
+import { AddIcon, DuplicateIcon, PencilIcon, TrashIcon } from './EditorIcons';
 
 // ============================================================
 //  PROJECTS TAB — the section's own full-width view
@@ -124,19 +125,6 @@ function frameStyle(sketch: Sketch, poster: string | null): React.CSSProperties 
   const axis = sketch.ratio < 4 / 3 ? { height: '76%' } : { width: '82%' };
   return { aspectRatio: String(sketch.ratio), ...axis, ...(poster ? null : { background: sketch.bg }) };
 }
-
-const RenameIcon = () => (
-  <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M10.5 2.5l3 3-8 8H2.5v-3l8-8z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/></svg>
-);
-const DuplicateIcon = () => (
-  <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><rect x="2.5" y="2.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.3"/><path d="M5.5 13.5h6a2 2 0 002-2v-6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
-);
-const BinIcon = () => (
-  <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 5h10M6.5 5V3.5h3V5M5 5l.6 8h4.8L11 5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/></svg>
-);
-const PlusIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 20 20" fill="none"><path d="M10 4.5v11M4.5 10h11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
-);
 
 export default function ProjectsBrowser() {
   const projects = useProjectStore((s) => s.projects);
@@ -268,7 +256,7 @@ export default function ProjectsBrowser() {
               read as a result. */}
           {!query.trim() && (
             <button className="pj-new" onClick={newProject}>
-              <span className="pj-new-mark"><PlusIcon /></span>
+              <span className="pj-new-mark"><AddIcon size={18}/></span>
               <span className="pj-new-label">New project</span>
               <span className="pj-new-hint">Starts empty · pick a template</span>
             </button>
@@ -344,9 +332,9 @@ function ProjectCard({
       {/* Over the thumbnail, revealed on hover/focus — see the layout note at
           the top of the file. */}
       <div className="pj-actions">
-        <button className="pj-act" title="Rename" onClick={onStartRename}><RenameIcon /></button>
-        <button className="pj-act" title="Duplicate" onClick={onDuplicate}><DuplicateIcon /></button>
-        <button className={`pj-act ${isConfirming ? 'danger' : ''}`} title={isConfirming ? 'Click again to delete' : 'Delete'} onClick={onDelete}><BinIcon /></button>
+        <button className="pj-act" title="Rename" onClick={onStartRename}><PencilIcon size={13}/></button>
+        <button className="pj-act" title="Duplicate" onClick={onDuplicate}><DuplicateIcon size={13}/></button>
+        <button className={`pj-act ${isConfirming ? 'danger' : ''}`} title={isConfirming ? 'Click again to delete' : 'Delete'} onClick={onDelete}><TrashIcon size={13}/></button>
       </div>
 
       <div className="pj-foot">

--- a/components/ProjectsPanel.tsx
+++ b/components/ProjectsPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { ago } from '@/lib/relativeTime';
 import { useProjectStore } from '@/store/useProjectStore';
+import { DuplicateIcon, PencilIcon, TrashIcon } from './EditorIcons';
 
 // The mobile projects sheet. On desktop the section is the full-width Projects
 // tab instead (components/ProjectsBrowser).
@@ -87,10 +88,10 @@ export default function ProjectsPanel({ onProjectOpen }: { onProjectOpen?: () =>
                     title="Rename"
                     onClick={() => { setEditingId(p.id); setEditName(p.name); setConfirmId(null); }}
                   >
-                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M10.5 2.5l3 3-8 8H2.5v-3l8-8z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/></svg>
+                    <PencilIcon size={12}/>
                   </button>
                   <button className="icon-btn" title="Duplicate" onClick={() => duplicate(p.id)}>
-                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><rect x="2.5" y="2.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.3"/><path d="M5.5 13.5h6a2 2 0 002-2v-6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
+                    <DuplicateIcon size={12}/>
                   </button>
                   <button
                     className={`icon-btn ${isConfirming ? 'danger' : ''}`}
@@ -98,7 +99,7 @@ export default function ProjectsPanel({ onProjectOpen }: { onProjectOpen?: () =>
                     onClick={() => (isConfirming ? (remove(p.id), setConfirmId(null)) : setConfirmId(p.id))}
                     onBlur={() => setConfirmId((c) => (c === p.id ? null : c))}
                   >
-                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M3 5h10M6.5 5V3.5h3V5M5 5l.6 8h4.8L11 5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                    <TrashIcon size={12}/>
                   </button>
                 </div>
               )}

--- a/components/TemplatesCard.tsx
+++ b/components/TemplatesCard.tsx
@@ -7,20 +7,14 @@ import type { Template } from '@/lib/types';
 import TemplateThumb from './TemplateThumb';
 import { ControlRow } from './Controls';
 import { useMobileInteractions } from './MobileInteractions';
+import { ChevronRightIcon, CloseIcon, HeartIcon, SearchIcon } from './EditorIcons';
 
 const Chevron = ({ dir = 'right' }: { dir?: 'right' | 'left' }) => (
-  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" style={dir === 'left' ? { transform: 'rotate(180deg)' } : undefined}>
-    <path d="M4.5 2.5L8 6l-3.5 3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
+  <ChevronRightIcon size={12} style={dir === 'left' ? { transform: 'rotate(180deg)' } : undefined}/>
 );
 
 const Heart = ({ filled, size = 12 }: { filled: boolean; size?: number }) => (
-  <svg width={size} height={size} viewBox="-1 -1 18 18" fill={filled ? 'currentColor' : 'none'} aria-hidden="true">
-    <path
-      d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314z"
-      stroke="currentColor" strokeWidth={filled ? 0 : 1.6} strokeLinejoin="round"
-    />
-  </svg>
+  <HeartIcon size={size} fill={filled ? 'currentColor' : undefined} stroke={filled ? 'none' : undefined}/>
 );
 
 // Favourites resolve through the CATALOGUE, not the full registry: a template
@@ -178,7 +172,7 @@ export default function TemplatesCard({
 
         <div className="searchbox">
           <span className="ico">
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.4"/><path d="M11 11l3 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/></svg>
+            <SearchIcon size={13}/>
           </span>
           <input placeholder={`Search ${catalogTemplateList.length} templates`} value={query} onChange={(e) => setQuery(e.target.value)} />
         </div>
@@ -213,7 +207,7 @@ export default function TemplatesCard({
                       title="Delete preset"
                       onClick={(e) => { e.stopPropagation(); deleteCustomPreset(p.id); }}
                     >
-                      <svg width="10" height="10" viewBox="0 0 16 16" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+                      <CloseIcon size={10}/>
                     </button>
                   </div>
                 );

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useSceneStore } from '@/store/useSceneStore';
 import ExportDialog from './ExportDialog';
 import TrackLane from './TrackLane';
-import { ExportIcon, PauseIcon, PlayIcon } from './EditorIcons';
+import { AddIcon, ExportIcon, LayersIcon, PauseIcon, PlayIcon } from './EditorIcons';
 
 function fmt(sec: number) {
   const s = Math.max(0, sec);
@@ -205,7 +205,7 @@ export default function Timeline({
           aria-expanded={lanesOpen}
           title="Motion layers"
         >
-          <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M8 1.8l6 3-6 3-6-3 6-3z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/><path d="M2 8.2l6 3 6-3" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/></svg>
+          <LayersIcon size={13}/>
           Layers
           <span className="tl-lanes-count">{tracks.length}</span>
         </button>
@@ -242,7 +242,7 @@ export default function Timeline({
 
         <div className="tl-lanes-foot">
           <button className="tl-add-track" onClick={() => addTrack()}>
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M8 3.5v9M3.5 8h9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+            <AddIcon size={12}/>
             Add layer
           </button>
           <span className="tl-lanes-hint">

--- a/components/TplCollapse.tsx
+++ b/components/TplCollapse.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useUIStore } from '@/store/useUIStore';
+import { BackIcon, ChevronRightIcon } from './EditorIcons';
 
 // The left column (templates / 3D effects) folds to a strip so the stage can
 // have the width on a small display. Two halves: the chevron that lives in the
@@ -10,9 +11,7 @@ export function CollapseButton() {
   const toggle = useUIStore((s) => s.toggleTplCollapsed);
   return (
     <button className="tpl-collapse" onClick={toggle} title="Collapse panel" aria-label="Collapse panel">
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-        <path d="M10 3.5L5.5 8l4.5 4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-      </svg>
+      <BackIcon size={14}/>
     </button>
   );
 }
@@ -22,9 +21,7 @@ export function CollapsedStrip() {
   return (
     <aside className="card templates tpl-strip">
       <button className="tpl-expand" onClick={toggle} title="Expand panel" aria-label="Expand panel">
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-          <path d="M6 3.5L10.5 8L6 12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-        </svg>
+        <ChevronRightIcon size={14}/>
       </button>
     </aside>
   );

--- a/components/TrackLane.tsx
+++ b/components/TrackLane.tsx
@@ -4,6 +4,7 @@ import { useMemo, useRef } from 'react';
 import { useSceneStore } from '@/store/useSceneStore';
 import { templateList } from '@/templates';
 import { trackWindow, type MotionTrack } from '@/lib/tracks';
+import { ChevronDownIcon, ChevronUpIcon, DuplicateIcon, EyeIcon, EyeOffIcon, TrashIcon } from './EditorIcons';
 
 type DragMode = 'move' | 'in' | 'out';
 
@@ -96,11 +97,7 @@ export default function TrackLane({
           title={track.visible ? 'Hide layer' : 'Show layer'}
           onClick={(e) => { e.stopPropagation(); toggleTrackVisible(track.id); }}
         >
-          {track.visible ? (
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M1.5 8S4 3.5 8 3.5 14.5 8 14.5 8S12 12.5 8 12.5 1.5 8 1.5 8z" stroke="currentColor" strokeWidth="1.3"/><circle cx="8" cy="8" r="1.8" fill="currentColor"/></svg>
-          ) : (
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M1.5 8S4 3.5 8 3.5 14.5 8 14.5 8S12 12.5 8 12.5 1.5 8 1.5 8z" stroke="currentColor" strokeWidth="1.3"/><path d="M3 13L13 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
-          )}
+          {track.visible ? <EyeIcon size={13}/> : <EyeOffIcon size={13}/>}
         </button>
 
         {/* stacking order: up = drawn nearer the viewer (later in the array) */}
@@ -111,7 +108,7 @@ export default function TrackLane({
             disabled={index === trackCount - 1}
             onClick={(e) => { e.stopPropagation(); onReorder(index, index + 1); }}
           >
-            <svg width="9" height="9" viewBox="0 0 12 12" fill="none"><path d="M2.5 7.5L6 4l3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+            <ChevronUpIcon size={9}/>
           </button>
           <button
             className="tl-lane-arrow"
@@ -119,7 +116,7 @@ export default function TrackLane({
             disabled={index === 0}
             onClick={(e) => { e.stopPropagation(); onReorder(index, index - 1); }}
           >
-            <svg width="9" height="9" viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/></svg>
+            <ChevronDownIcon size={9}/>
           </button>
         </div>
 
@@ -128,7 +125,7 @@ export default function TrackLane({
           title="Duplicate layer (offset)"
           onClick={(e) => { e.stopPropagation(); duplicateTrack(track.id); }}
         >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><rect x="2.5" y="2.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.3"/><path d="M5.5 13.5h6a2 2 0 002-2v-6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
+          <DuplicateIcon size={12}/>
         </button>
 
         <button
@@ -137,7 +134,7 @@ export default function TrackLane({
           disabled={trackCount <= 1}
           onClick={(e) => { e.stopPropagation(); removeTrack(track.id); }}
         >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M3 5h10M6.5 5V3.5h3V5M5 5l.6 8h4.8L11 5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/></svg>
+          <TrashIcon size={12}/>
         </button>
       </div>
 

--- a/components/WebSourceBar.tsx
+++ b/components/WebSourceBar.tsx
@@ -6,6 +6,7 @@ import { useSceneStore } from '@/store/useSceneStore';
 import { getTemplate } from '@/templates';
 import { resolveEasing } from '@/lib/easing';
 import { buildZip } from '@/lib/webExport';
+import { AlertIcon, ExportIcon, WebIcon } from './EditorIcons';
 
 // Web mode (SPIKE) — the source controls and the zip, laid out for the
 // timeline bar. Opening the editor is one button and a compile status; as a
@@ -68,18 +69,13 @@ export default function WebSourceBar() {
     <div className="web-source-bar">
       {problem && (
         <span className="web-source-err" title={problem}>
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-            <circle cx="8" cy="8" r="6.25" stroke="currentColor" strokeWidth="1.4"/>
-            <path d="M8 5v3.5M8 10.8v.2" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
-          </svg>
+          <AlertIcon size={12}/>
           {problem}
         </span>
       )}
 
       <button className="tl-ghost-btn" onClick={() => setCodeOpen(true)}>
-        <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
-          <path d="M7.5 6.5L4 10l3.5 3.5M12.5 6.5L16 10l-3.5 3.5M11 4.5l-2 11" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-        </svg>
+        <WebIcon size={14}/>
         Edit code
       </button>
 
@@ -89,7 +85,7 @@ export default function WebSourceBar() {
         disabled={!canExport || busy}
         title={canExport ? 'Download the component + motion as a zip' : 'Mark at least one element first'}
       >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M8 2v8m0 0L5 7m3 3l3-3M3 13h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+        <ExportIcon size={14}/>
         {busy ? 'Packing…' : 'Export zip'}
       </button>
     </div>


### PR DESCRIPTION
## Summary

The icon set had drifted, and the reason was not carelessness in drawing — most
of it was never in `EditorIcons.tsx` to begin with. **44 of the 66 inline
`<svg>` in the app were copy-pasted into other components**, and those 44 were
only **16 distinct shapes**. Each copy had moved a little:

| Icon | Copies | Drift between them |
| --- | --- | --- |
| Chevron → | 5 | two viewBoxes: 16 and 12 |
| Add | 4 | two viewBoxes: 16 and 20 |
| Eye | 3 | pupil `r=2` hollow vs `r=1.8` filled |
| Eye-off | 3 | slash at `M2.5 13.5` vs `M3 13` |
| Duplicate | 3 | `rx=1.5`, in an app whose every radius token is `0px` |
| Delete / Close / Rename / Alert | 2–3 each | identical, but copied instead of imported |

Everything now comes from `EditorIcons.tsx` and is imported, which is what stops
the drift from returning. **38 glyphs, one spec:**

1. optical box 14×14 inside a 20×20 viewBox, touching two opposite edges
2. a single viewBox — `size` still controls the rendered pixels
3. `stroke`, width, `fill`, join and cap declared **once** on the `<svg>` and
   inherited; a path carries geometry, plus `opacity .5` when secondary
4. no corner radius anywhere, matching `--r-card` / `--r-nav` / `--r-seg` / `--r-chip`
5. two opacity levels, `1` and `.5`
6. geometry on the 0.5 grid, 2-unit minimum gutter between neighbouring strokes
7. exceptions are **named**, not accidental: a curve only where the curve *is*
   the shape (Sun, Moon, Bell, the Undo/Redo loop); perspective only on 3D and
   Layers; fill only on the transport marks and the drag grip

## Shapes that changed for a reason

- **Library** is a featured card with two receding behind it — what the Runway
  and Coverflow families actually do. A 2×2 grid is the shape every dashboard
  uses for "library" and said nothing about this app.
- **Boards** moved off three vertical columns: beside Library they read as twins
  at 20px. It is a board of *arranged* cards, so it became a 2D composition —
  the change of axis is what separates them.
- **Info** is now the exact vertical mirror of **Alert**. Both were
  stem-over-dot, separated only by proportion, and at 18px that made them the
  same glyph. Mirroring is the only difference that survives the size.
- **Layers** is two plates of the same size, the lower one drawn as just the V
  the upper does not cover. Two different sizes with a gap reads as an arrow.
- **Boards'** columns left a 1-unit gutter, so at 20px the 1.5 strokes of
  neighbouring columns overlapped. Opened to 2.5.
- **Media** drops the 1.5-unit square that stood in for a sun — a sun needs a
  ray or a curve to identify it, and at 20px that square was a speck.
- **Sun** has a bigger disc and rays of two lengths, so it reads as a burst
  rather than eight identical ticks.
- **Reset** was a genuine bug: the old path drew a circle with a stray chord.

## The theme toggle now animates

It was `{theme === 'dark' ? <SunIcon /> : <MoonIcon />}` — a swap has nothing to
animate. It is now one morphing glyph (`ThemeGlyph`): the disc grows, a bite
slides over it and carves the crescent, the rays retract. Plain CSS in
`globals.css`, keyed off `:root[data-theme="dark"]`.

Three things the geometry forced, measured rather than guessed:

- the bite sits **7.5** from the disc centre, so the two arcs cross at **108°**.
  At 4.67 they cross at 137° — a graze that leaves a forked tip instead of a cusp.
- it parks **12.6** away in the sun state. Under 11.25 it notches the disc's
  stroke; much farther and it only reaches the disc in the last quarter, so the
  moon snaps in instead of forming.
- the masks sit on the **static `<g>`** with the transform on the child. A mask
  is resolved in its own element's space, so on the moving ring the mask travels
  along and leaves a sliver of ring showing in the sun.

`stroke-width` animates alongside the disc's scale, or `scale(1.55)` would drag
the 1.5 stroke up to 2.33 and fatten the glyph away from the rest of the set.
`prefers-reduced-motion` falls to `1ms` rather than `0s`, so the end state is
still applied.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` — all six suites pass
- [x] No unused imports left behind in the 13 components that stopped inlining SVG
- [x] Verified live in the running app, not only in isolation: both toggle end
      states (dark → disc `none` / stroke 1.5 / bite parked 3.61 / rays `.5`;
      light → disc 1.55 / stroke 0.968 / bite 0 / rays 0) and mid-transition
      (8 active transitions interpolating: disc 1.12, stroke 1.38, bite 2.80,
      rays 0.15)
- [x] Every redrawn glyph checked at its real render size (13/18/20px), on both
      the light and the dark rail — the sizes where proportion differences
      disappear and only arrangement survives

## Note on the branch base

Branched from `origin/main` **after** the colour-picker work landed, and applied
as a patch rather than by copying files — three of these files
(`globals.css`, `AssetsPanel.tsx`, `Timeline.tsx`) were also touched by that
work, and copying whole files would have reverted it.
