### PR TITLE
Integrate documentation into editor with rail entry

### DIFF
--- a/app/docs/_components/ControlGallery.tsx
+++ b/app/docs/_components/ControlGallery.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+import { ControlRow } from '@/components/Controls';
+import type { ControlDef } from '@/lib/types';
+
+/**
+ * Every control type, rendered by the editor's OWN control renderer.
+ *
+ * `ControlRow` is fully presentational — `{ def, value, onChange }`, no store —
+ * so the docs can mount the real thing instead of drawing a picture of it. What
+ * you see here is what the Adjust panel shows, down to the 34px track and the
+ * click-the-value-to-type behaviour, because it IS that component. A screenshot
+ * would go stale the first time a control is restyled; this cannot.
+ *
+ * The definitions below are examples in the same shape templates use, not
+ * copies of any particular template's controls.
+ */
+
+interface Demo {
+  def: ControlDef;
+  what: string;
+  how: string;
+}
+
+const DEMOS: Demo[] = [
+  {
+    def: {
+      key: 'tilt', label: 'Tilt', type: 'slider',
+      min: 0, max: 45, step: 1, default: 12, unit: '°', section: 'Motion',
+      description: 'How far each card leans out of the plane.',
+    },
+    what: 'A number in a range.',
+    how: 'The whole track is the control — press anywhere on it and drag. Hold Shift while dragging for a grid ten times finer than the declared step. Click the value to type an exact one; double-click the track to snap back to the declared default. Focus it and the arrow keys nudge by a step, or by a tenth of one with Shift held.',
+  },
+  {
+    def: {
+      key: 'bend', label: 'Card bend', type: 'slider',
+      min: -100, max: 100, step: 1, default: 0, unit: '%', section: 'Depth',
+      description: 'Negative bows the card away from you, positive bows it toward you.',
+    },
+    what: 'A range that spans zero.',
+    how: 'The same type, declared with a negative minimum, and it reads differently for it: the fill starts at ZERO and runs out to the value, so right of centre is positive, left is negative, and zero is empty. Filling from the left edge instead made a neutral control look half-on — a bend of 0 showed a half-full track.',
+  },
+  {
+    def: {
+      key: 'direction', label: 'Direction', type: 'toggle',
+      options: ['Forward', 'Reverse'], default: 'Forward', section: 'Motion',
+    },
+    what: 'Two states, both visible.',
+    how: 'Use it when the two options are opposites and the reader should see both at once. It is a segmented pair rather than a checkbox because "Forward / Reverse" has no natural off state.',
+  },
+  {
+    def: {
+      key: 'mode', label: 'Mode', type: 'pills',
+      options: ['Static', 'Rotate', 'Drift'], default: 'Rotate', section: 'Motion',
+    },
+    what: 'One of a few, all visible.',
+    how: 'The same shape as the toggle, extended. Good up to about four options — past that the row gets cramped and a select reads better. A mode pill is usually what visibleWhen keys off, so the panel can hide settings the current mode does not use.',
+  },
+  {
+    def: {
+      key: 'blend', label: 'Blend', type: 'select',
+      options: ['Normal', 'Multiply', 'Screen', 'Overlay', 'Soft light', 'Hard light', 'Difference'],
+      default: 'Normal', section: 'Finish',
+    },
+    what: 'One of many, folded away.',
+    how: 'A dropdown, for lists too long to lay out. Same data as pills — an options array and a string default — so switching between the two is a one-word edit if a list grows.',
+  },
+  {
+    def: {
+      key: 'from', label: 'From edge', type: 'direction',
+      default: 'left', section: 'Layout',
+    },
+    what: 'A direction, picked spatially.',
+    how: 'A 3×3 pad of edges and corners. It exists because "left / top-right / bottom" as a text list makes the reader translate words into geometry — here the control has the same shape as the thing it describes. Families that push content in from an edge use this.',
+  },
+  {
+    def: {
+      key: 'tint', label: 'Card tint', type: 'color',
+      default: '#111827', section: 'Finish',
+    },
+    what: 'A colour, as a hex string.',
+    how: 'The swatch opens the platform picker and the value is stored as a hex string. Worth noting: this is for colour a MOTION owns. The interface’s own colours never come from a control — they live in the token sheet.',
+  },
+  {
+    def: {
+      key: 'offset', label: 'Offset', type: 'xypad',
+      default: { x: 0, y: 0 }, section: 'Layout',
+    },
+    what: 'Two numbers that belong together.',
+    how: 'Drag the dot; the value is { x, y }. Reach for it when the two numbers are one gesture — a position, a nudge — rather than two independent settings. Two sliders would be more precise and much worse to aim.',
+  },
+  {
+    def: {
+      key: 'logo', label: 'Logo', type: 'upload',
+      default: '', section: 'Finish',
+    },
+    what: 'A file or a URL.',
+    how: 'Gives the motion its own image slot, separate from the card list — a watermark, a badge, a mask. The value is a reference, so it survives a reload with the rest of the project.',
+  },
+  {
+    def: {
+      key: 'caption', label: 'Caption', type: 'text',
+      default: 'Motion Studio', section: 'Finish',
+    },
+    what: 'A string.',
+    how: 'For motions that draw type. Plain and deliberately unstyled: the template decides how the string is rendered, the control only collects it.',
+  },
+];
+
+// How a value reads back, so the panel side and the transform side line up.
+function show(value: unknown): string {
+  if (typeof value === 'string') return value === '' ? "''" : `'${value}'`;
+  if (value && typeof value === 'object' && 'x' in (value as any)) {
+    const v = value as { x: number; y: number };
+    return `{ x: ${Math.round(v.x)}, y: ${Math.round(v.y)} }`;
+  }
+  return String(value);
+}
+
+// The number of distinct types shown, so the prose can never claim a count the
+// gallery does not actually render — the vocabulary has gained a type before.
+export const CONTROL_TYPE_COUNT = new Set(DEMOS.map((d) => d.def.type)).size;
+
+export default function ControlGallery() {
+  const [values, setValues] = useState<Record<string, any>>(() =>
+    Object.fromEntries(DEMOS.map((d) => [d.def.key, d.def.default])),
+  );
+
+  const set = (key: string) => (val: any) => setValues((v) => ({ ...v, [key]: val }));
+
+  return (
+    <div className="docs-ctl-list">
+      {DEMOS.map(({ def, what, how }) => (
+        <section key={def.key} className="docs-ctl">
+          <div className="docs-ctl-head">
+            <code>{def.type}</code>
+            <span>{what}</span>
+          </div>
+
+          <div className="docs-ctl-body">
+            {/* The same surface the Adjust panel gives a control: panel
+                background, one hairline, the panel's own side padding. */}
+            <div className="docs-ctl-demo">
+              <ControlRow def={def} value={values[def.key]} onChange={set(def.key)} />
+            </div>
+
+            <div className="docs-ctl-side">
+              <p>{how}</p>
+              <div className="docs-ctl-readout">
+                <span>the transform reads</span>
+                <code>values.{def.key} = {show(values[def.key])}</code>
+              </div>
+            </div>
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/app/docs/_components/DocsChrome.tsx
+++ b/app/docs/_components/DocsChrome.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import DocsHeader from './DocsHeader';
+import DocsPalette from './DocsPalette';
+import DocsSearchButton from './DocsSearchButton';
+import DocsSidebar from './DocsSidebar';
+import PageFeedback from './PageFeedback';
+import DocsIdeaDialog from './DocsIdeaDialog';
+import { CloseIcon, MenuIcon } from './DocsIcons';
+
+/**
+ * The docs chrome, and the one client component that has to exist: the menu
+ * button and the panel it opens are two different elements, so something above
+ * both has to hold that one piece of state.
+ *
+ * Below the breakpoint a second bar sits under the navbar carrying the menu
+ * button and the search, and the page list drops out from under IT. Above the
+ * breakpoint that bar is gone and both live where they already did — the sidebar
+ * is a column and it holds its own search.
+ *
+ * `children` is the page, still server-rendered — passing it through here costs
+ * nothing and keeps the pages themselves free of client code.
+ */
+export default function DocsChrome({ children }: { children: React.ReactNode }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [ideaOpen, setIdeaOpen] = useState(false);
+  const pathname = usePathname();
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const wasMenuOpen = useRef(false);
+
+  // Navigating closes it. Without this, tapping a link on a phone leaves the
+  // panel sitting over the page you just asked for.
+  useEffect(() => { setMenuOpen(false); setSearchOpen(false); setIdeaOpen(false); }, [pathname]);
+
+  // Opening the palette closes the page list: two overlays at once is one too
+  // many, and the palette can reach every page the list can.
+  const openSearch = () => { setMenuOpen(false); setSearchOpen(true); };
+
+  useEffect(() => {
+    if (wasMenuOpen.current && !menuOpen && !searchOpen) {
+      menuButtonRef.current?.focus();
+    }
+    wasMenuOpen.current = menuOpen;
+  }, [menuOpen, searchOpen]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      // Ctrl+K on Windows and Linux, Cmd+K on a Mac. Both are claimed by the
+      // browser in some builds, so preventDefault is not optional.
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setSearchOpen((o) => !o);
+        setMenuOpen(false);
+        return;
+      }
+      // A bare slash, the way most docs sites do it — but never while the
+      // caller is typing somewhere, or it eats the character.
+      if (e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const t = e.target as HTMLElement | null;
+        if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+        e.preventDefault();
+        openSearch();
+        return;
+      }
+      if (e.key === 'Escape' && menuOpen) setMenuOpen(false);
+      if (e.key === 'Escape' && ideaOpen) setIdeaOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [menuOpen, ideaOpen]);
+
+  return (
+    <div className={`docs-shell ${menuOpen ? 'menu-open' : ''}`}>
+      <DocsHeader onSuggest={() => { setMenuOpen(false); setIdeaOpen(true); }} />
+
+      {/* The bar under the navbar. Only drawn under the breakpoint — see docs.css. */}
+      <div className="docs-subbar">
+        <button
+          ref={menuButtonRef}
+          type="button"
+          className="docs-menu-btn"
+          onClick={() => setMenuOpen((o) => !o)}
+          aria-label={menuOpen ? 'Close the menu' : 'Open the menu'}
+          aria-expanded={menuOpen}
+          aria-controls="docs-navigation"
+        >
+          {menuOpen ? <CloseIcon /> : <MenuIcon />}
+          <span>Menu</span>
+        </button>
+        <DocsSearchButton onOpen={openSearch} />
+      </div>
+
+      <div className="docs-body">
+        <DocsSidebar open={menuOpen} onOpenSearch={openSearch} onSuggest={() => { setMenuOpen(false); setIdeaOpen(true); }} />
+        {/* A real button, not a div: the panel has to be dismissable by
+            something the keyboard and a screen reader can reach too. */}
+        {menuOpen && (
+          <button
+            type="button"
+            className="docs-scrim"
+            aria-label="Close the menu"
+            onClick={() => setMenuOpen(false)}
+          />
+        )}
+        {searchOpen && <DocsPalette onClose={() => setSearchOpen(false)} />}
+        {ideaOpen && <DocsIdeaDialog onClose={() => setIdeaOpen(false)} />}
+        <main className="docs-main">
+          <article className="docs-article">
+            {children}
+            <PageFeedback />
+          </article>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/app/docs/_components/DocsHeader.tsx
+++ b/app/docs/_components/DocsHeader.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { MoonIcon, SunIcon } from '@/components/EditorIcons';
+import LogoMark from '@/components/LogoMark';
+import { LinkOutIcon, RepoIcon } from './DocsIcons';
+import { REPO_URL, socials } from '../_lib/docsLinks';
+import { useUIStore } from '@/store/useUIStore';
+
+/**
+ * The docs header. Reuses the editor's own theme action and icons rather than
+ * keeping a second notion of the theme: the root layout sets `data-theme` from
+ * the stored preference before first paint, and this writes to the same store
+ * and the same storage key, so switching here follows you into the editor.
+ */
+export default function DocsHeader({ onSuggest }: { onSuggest: () => void }) {
+  const theme = useUIStore((s) => s.theme);
+  const toggleTheme = useUIStore((s) => s.toggleTheme);
+  const hydratePreferences = useUIStore((s) => s.hydratePreferences);
+
+  // The store's default is 'light'; the stored preference lives in
+  // localStorage, so it can only be read after mount.
+  useEffect(() => { hydratePreferences(); }, [hydratePreferences]);
+
+  const social = socials();
+
+  return (
+    <header className="docs-header">
+      <Link href="/docs" className="docs-brand">
+        <LogoMark height={17} />
+        {/* Wrapped so the narrow layout can drop the wordmark and keep the mark:
+            measured, the header's content needed 455px in a 375px viewport. */}
+        <span className="docs-brand-name">Motion Studio</span>
+        <span className="docs-brand-tag">docs</span>
+      </Link>
+
+      <nav className="docs-header-nav">
+        <Link href="/docs/library">Library</Link>
+        <Link href="/docs/mockup">Mockup</Link>
+        <Link href="/docs/controls/library">Controls</Link>
+        <button type="button" className="docs-suggest-btn" onClick={onSuggest}>
+          <span aria-hidden="true">+</span>
+          Suggest an idea
+        </button>
+      </nav>
+
+
+      <div className="docs-header-end">
+        <a
+          className="docs-icon-btn docs-repo-link"
+          href={REPO_URL}
+          target="_blank"
+          rel="noreferrer noopener"
+          aria-label="Source repository on GitHub"
+          title="Source on GitHub"
+        >
+          <RepoIcon />
+        </a>
+
+        {social.map((s) => (
+          <a
+            key={s.network}
+            className="docs-icon-btn"
+            href={s.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-label={s.label}
+            title={s.label}
+          >
+            <LinkOutIcon />
+          </a>
+        ))}
+
+        <button
+          className="docs-icon-btn"
+          onClick={toggleTheme}
+          aria-label={theme === 'dark' ? 'Use light theme' : 'Use dark theme'}
+          title={theme === 'dark' ? 'Light theme' : 'Dark theme'}
+        >
+          {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+        </button>
+
+        {/* In the landing this pointed at another origin and opened a tab. Here
+            the editor IS this app, so it is an in-app route: Link, no target. */}
+        <Link href="/library" className="docs-header-cta">
+          Open the editor
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/app/docs/_components/DocsIcons.tsx
+++ b/app/docs/_components/DocsIcons.tsx
@@ -1,0 +1,85 @@
+// House style, matching the editor's EditorIcons.tsx: 16x16, stroke line-art on
+// currentColor, no fill. The one exception is RepoIcon, which is the real GitHub
+// mark — see the note on it.
+
+const base = {
+  width: 16, height: 16, viewBox: '0 0 16 16', fill: 'none',
+  'aria-hidden': true, focusable: 'false' as const,
+};
+const stroke = {
+  stroke: 'currentColor', strokeWidth: 1.4,
+  strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const,
+};
+
+/**
+ * The GitHub mark. This one IS the brand logotype, unlike everything else in
+ * this file: a branch-and-node glyph was here first and read as "some repo",
+ * not as GitHub. The path is `mark-github-16.svg` from primer/octicons (MIT),
+ * downloaded verbatim rather than transcribed — a logo is exactly where one
+ * wrong character produces something subtly wrong that nobody catches.
+ *
+ * It is a filled silhouette, so it does not take the `stroke` treatment; it
+ * still follows the theme through `currentColor`.
+ */
+export function RepoIcon() {
+  return (
+    <svg {...base} fill="currentColor">
+      <path d="M6.766 11.328c-2.063-.25-3.516-1.734-3.516-3.656 0-.781.281-1.625.75-2.188-.203-.515-.172-1.609.063-2.062.625-.078 1.468.25 1.968.703.594-.187 1.219-.281 1.985-.281.765 0 1.39.094 1.953.265.484-.437 1.344-.765 1.969-.687.218.422.25 1.515.046 2.047.5.593.766 1.39.766 2.203 0 1.922-1.453 3.375-3.547 3.64.531.344.89 1.094.89 1.954v1.625c0 .468.391.734.86.547C13.781 14.359 16 11.53 16 8.03 16 3.61 12.406 0 7.984 0 3.563 0 0 3.61 0 8.031a7.88 7.88 0 0 0 5.172 7.422c.422.156.828-.125.828-.547v-1.25c-.219.094-.5.156-.75.156-1.031 0-1.64-.562-2.078-1.609-.172-.422-.36-.672-.719-.719-.187-.015-.25-.093-.25-.187 0-.188.313-.328.625-.328.453 0 .844.281 1.25.86.313.452.64.655 1.031.655s.641-.14 1-.5c.266-.265.47-.5.657-.656" />
+    </svg>
+  );
+}
+
+export function SearchIcon() {
+  return (
+    <svg {...base}>
+      <circle cx="7" cy="7" r="4.2" {...stroke} />
+      <path d="M10.2 10.2L13.5 13.5" {...stroke} />
+    </svg>
+  );
+}
+
+/** Generic outbound glyph, used for any social link that is filled in. */
+export function LinkOutIcon() {
+  return (
+    <svg {...base}>
+      <path d="M9.5 3.5h3v3M12.5 3.5L7.5 8.5" {...stroke} />
+      <path d="M11 9.5v2.2a1.3 1.3 0 01-1.3 1.3H4.3A1.3 1.3 0 013 11.7V6.3A1.3 1.3 0 014.3 5h2.2" {...stroke} />
+    </svg>
+  );
+}
+
+/** Thumbs up / down, for the page-feedback footer. */
+export function ThumbUpIcon() {
+  return (
+    <svg {...base}>
+      <path d="M5.5 14V7.2l3-4.7c.8.1 1.3.7 1.3 1.5V6.6h2.4c.9 0 1.5.8 1.3 1.6l-.9 4.6c-.1.7-.7 1.2-1.4 1.2H5.5z" {...stroke} />
+      <path d="M5.5 7.2H3.4c-.5 0-.9.4-.9.9v5c0 .5.4.9.9.9h2.1" {...stroke} />
+    </svg>
+  );
+}
+
+export function ThumbDownIcon() {
+  return (
+    <svg {...base}>
+      <path d="M5.5 2v6.8l3 4.7c.8-.1 1.3-.7 1.3-1.5V9.4h2.4c.9 0 1.5-.8 1.3-1.6l-.9-4.6C12.5 2.5 11.9 2 11.2 2H5.5z" {...stroke} />
+      <path d="M5.5 8.8H3.4c-.5 0-.9-.4-.9-.9v-5c0-.5.4-.9.9-.9h2.1" {...stroke} />
+    </svg>
+  );
+}
+
+/** Hamburger and close, for the mobile nav drawer. */
+export function MenuIcon() {
+  return (
+    <svg {...base}>
+      <path d="M2.5 4.5h11M2.5 8h11M2.5 11.5h11" {...stroke} />
+    </svg>
+  );
+}
+
+export function CloseIcon() {
+  return (
+    <svg {...base}>
+      <path d="M4 4l8 8M12 4l-8 8" {...stroke} />
+    </svg>
+  );
+}

--- a/app/docs/_components/DocsIdeaDialog.tsx
+++ b/app/docs/_components/DocsIdeaDialog.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useMemo, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { REPO_URL } from '../_lib/docsLinks';
+
+export default function DocsIdeaDialog({ onClose }: { onClose: () => void }) {
+  const pathname = usePathname();
+  const [idea, setIdea] = useState('');
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const href = useMemo(() => {
+    const title = 'Docs idea: ' + (idea.trim().slice(0, 72) || 'Improvement suggestion');
+    const body = ['## Idea', idea.trim() || 'Describe the idea here.', '', 'Docs page: ' + pathname].join('\n');
+    return REPO_URL + '/issues/new?' + new URLSearchParams({ title, body }).toString();
+  }, [idea, pathname]);
+
+  return (
+    <div className="docs-palette-layer">
+      <button type="button" className="docs-palette-scrim" aria-label="Close idea form" onClick={onClose} />
+      <div className="docs-idea-dialog" role="dialog" aria-modal="true" aria-labelledby="docs-idea-title">
+        <div className="docs-idea-dialog-head">
+          <div>
+            <span className="docs-eyebrow">GitHub issue</span>
+            <h2 id="docs-idea-title">Suggest an idea</h2>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close idea form">Esc</button>
+        </div>
+        <label htmlFor="docs-idea-dialog-field">What should be added or improved?</label>
+        <textarea
+          ref={inputRef}
+          id="docs-idea-dialog-field"
+          value={idea}
+          onChange={(event) => setIdea(event.target.value)}
+          maxLength={1000}
+          rows={5}
+          autoFocus
+          placeholder="Describe your idea"
+          onKeyDown={(event) => { if (event.key === 'Escape') onClose(); }}
+        />
+        <div className="docs-idea-dialog-foot">
+          <p>You will review and submit it on GitHub.</p>
+          <a
+            className={idea.trim() ? '' : 'disabled'}
+            href={idea.trim() ? href : undefined}
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-disabled={!idea.trim()}
+          >
+            Open GitHub issue
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/docs/_components/DocsPalette.tsx
+++ b/app/docs/_components/DocsPalette.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { DOCS_SEARCH, type DocsSearchEntry } from '../_lib/docsNav';
+import { SearchIcon } from './DocsIcons';
+
+/**
+ * The command palette. Hand-rolled on purpose: cmdk would bring four Radix
+ * packages into a codebase that carries no component library at all, to add
+ * fuzzy matching over sixteen pages — and fuzzy matching on sixteen items
+ * mostly produces confident nonsense. The ranking below is deliberate instead:
+ * a title match outranks a section match, which outranks a keyword match.
+ *
+ * Opened with Ctrl/Cmd+K or `/` from anywhere, and by the search button.
+ */
+
+interface Hit {
+  entry: DocsSearchEntry;
+  score: number;
+  /** The keyword that matched, when that is why it matched. */
+  hit?: string;
+}
+
+function rank(query: string): Hit[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  return DOCS_SEARCH
+    .map((entry) => {
+      const title = entry.title.toLowerCase();
+      let score = 0;
+      if (title.startsWith(q)) score = 4;
+      else if (title.includes(q)) score = 3;
+      else if (entry.section.toLowerCase().includes(q)) score = 2;
+      else if (entry.terms.some((t) => t.toLowerCase().includes(q))) score = 1;
+      return { entry, score, hit: entry.terms.find((t) => t.toLowerCase().includes(q)) };
+    })
+    .filter((h) => h.score > 0)
+    .sort((a, b) => b.score - a.score || a.entry.title.localeCompare(b.entry.title))
+    .slice(0, 8);
+}
+
+/** With no query the palette is a table of contents, not an empty box. */
+function browse(): Hit[] {
+  return DOCS_SEARCH.map((entry) => ({ entry, score: 0 }));
+}
+
+export default function DocsPalette({ onClose }: { onClose: () => void }) {
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+  const [cursor, setCursor] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // Where focus was before the dialog opened, so closing puts it back rather
+  // than dropping the caller at the top of the document.
+  const returnTo = useRef<HTMLElement | null>(null);
+
+  const hits = useMemo(() => (query.trim() ? rank(query) : browse()), [query]);
+
+  useEffect(() => {
+    returnTo.current = document.activeElement as HTMLElement | null;
+    inputRef.current?.focus();
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const keepFocusInside = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
+      );
+      if (!focusable?.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener('keydown', keepFocusInside);
+    return () => {
+      window.removeEventListener('keydown', keepFocusInside);
+      document.body.style.overflow = previousOverflow;
+      returnTo.current?.focus?.();
+    };
+  }, []);
+
+  useEffect(() => { setCursor(0); }, [query]);
+
+  // Keep the highlighted row in view when arrowing past the fold.
+  useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>('.docs-palette-hit.active');
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [cursor]);
+
+  const go = (href: string) => {
+    onClose();
+    router.push(href);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') { e.preventDefault(); onClose(); return; }
+    if (!hits.length) return;
+    if (e.key === 'ArrowDown') { e.preventDefault(); setCursor((c) => (c + 1) % hits.length); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setCursor((c) => (c - 1 + hits.length) % hits.length); }
+    else if (e.key === 'Home') { e.preventDefault(); setCursor(0); }
+    else if (e.key === 'End') { e.preventDefault(); setCursor(hits.length - 1); }
+    else if (e.key === 'Enter') { e.preventDefault(); go(hits[cursor].entry.href); }
+  };
+
+  // Section headings, but only while browsing: once a query is ranked, grouping
+  // by section would fight the ranking that put the best answer first.
+  const grouped = !query.trim();
+  let lastSection = '';
+
+  return (
+    <div className="docs-palette-layer" role="presentation">
+      <button
+        type="button"
+        className="docs-palette-scrim"
+        aria-label="Close the search"
+        onClick={onClose}
+      />
+      <div
+        ref={dialogRef}
+        className="docs-palette"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search the docs"
+      >
+        <div className="docs-palette-field">
+          <span className="docs-palette-ico"><SearchIcon /></span>
+          <input
+            ref={inputRef}
+            type="text"
+            className="docs-palette-input"
+            placeholder="Search the docs"
+            aria-label="Search the docs"
+            role="combobox"
+            aria-expanded={hits.length > 0}
+            aria-controls="docs-palette-list"
+            aria-activedescendant={hits.length ? `docs-palette-option-${cursor}` : undefined}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+          />
+          <kbd className="docs-palette-esc">esc</kbd>
+        </div>
+
+        <div className="docs-palette-list" id="docs-palette-list" role="listbox" ref={listRef}>
+          {hits.length === 0 && (
+            <p className="docs-palette-empty">No page matches “{query}”.</p>
+          )}
+          {hits.map((h, i) => {
+            const head = grouped && h.entry.section !== lastSection ? h.entry.section : null;
+            if (head) lastSection = h.entry.section;
+            return (
+              <div key={h.entry.href}>
+                {head && <div className="docs-palette-group">{head}</div>}
+                <button
+                  id={`docs-palette-option-${i}`}
+                  type="button"
+                  role="option"
+                  aria-selected={i === cursor}
+                  className={`docs-palette-hit ${i === cursor ? 'active' : ''}`}
+                  onMouseMove={() => setCursor(i)}
+                  onClick={() => go(h.entry.href)}
+                >
+                  <span className="docs-palette-hit-title">{h.entry.title}</span>
+                  <span className="docs-palette-hit-meta">
+                    {h.score === 1 && h.hit ? h.hit : h.entry.section}
+                  </span>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="docs-palette-foot">
+          <span><kbd>↑</kbd><kbd>↓</kbd> to move</span>
+          <span><kbd>↵</kbd> to open</span>
+          <span><kbd>esc</kbd> to close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/docs/_components/DocsSearchButton.tsx
+++ b/app/docs/_components/DocsSearchButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { SearchIcon } from './DocsIcons';
+
+/**
+ * Looks like a field, behaves like a button: it opens the palette. One search
+ * implementation instead of an inline dropdown plus a dialog, and the results
+ * are no longer at the mercy of whatever container is clipping them.
+ *
+ * The shortcut hint is platform-dependent, so it can only be decided after
+ * mount — rendering a guess on the server and correcting it on the client is a
+ * hydration mismatch, which is a broken tree rather than a cosmetic slip.
+ */
+export default function DocsSearchButton({ onOpen }: { onOpen: () => void }) {
+  const [hint, setHint] = useState<string | null>(null);
+
+  useEffect(() => {
+    const mac = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+    setHint(mac ? '⌘K' : 'Ctrl K');
+  }, []);
+
+  return (
+    <button type="button" className="docs-searchbtn" onClick={onOpen}>
+      <span className="docs-searchbtn-ico"><SearchIcon /></span>
+      <span className="docs-searchbtn-label">Search the docs</span>
+      {/* Reserved either way, so the row does not reflow when the hint lands. */}
+      <kbd className="docs-searchbtn-kbd">{hint ?? ' '}</kbd>
+    </button>
+  );
+}

--- a/app/docs/_components/DocsSidebar.tsx
+++ b/app/docs/_components/DocsSidebar.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import DocsSearchButton from './DocsSearchButton';
+import { LinkOutIcon, RepoIcon } from './DocsIcons';
+import { REPO_URL, socials } from '../_lib/docsLinks';
+import { DOCS_SECTIONS } from '../_lib/docsNav';
+
+// The sidebar is the only part of the docs that has to know where it is, so it
+// and the header are the only client components in the shell.
+export default function DocsSidebar({ open, onOpenSearch, onSuggest }: { open: boolean; onOpenSearch: () => void; onSuggest: () => void }) {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      id="docs-navigation"
+      className={`docs-nav ${open ? 'is-open' : ''}`}
+      aria-label="Documentation"
+    >
+      <DocsSearchButton onOpen={onOpenSearch} />
+      {DOCS_SECTIONS.map((section) => (
+        <div key={section.title} className="docs-nav-section">
+          <div className="docs-nav-title">{section.title}</div>
+          {/* The rail: one hairline down the group, with the active item marker
+              sitting on top of it. */}
+          <div className="docs-nav-rail">
+            {section.links.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`docs-nav-link ${pathname === link.href ? 'active' : ''}`}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      ))}
+      {/* Only drawn in the drawer: above the breakpoint these live in the
+          header, and showing them twice is showing them nowhere. */}
+      <div className="docs-nav-foot">
+        <button type="button" onClick={onSuggest}>Suggest an idea</button>
+        <a href={REPO_URL} target="_blank" rel="noreferrer noopener">
+          <RepoIcon />
+          Source on GitHub
+        </a>
+        {socials().map((s) => (
+          <a key={s.network} href={s.url} target="_blank" rel="noreferrer noopener">
+            <LinkOutIcon />
+            {s.label}
+          </a>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/app/docs/_components/DocsThumb.tsx
+++ b/app/docs/_components/DocsThumb.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Template } from '@/lib/types';
+import TemplateThumb from '@/components/TemplateThumb';
+
+/**
+ * TemplateThumb, mounted client-side only.
+ *
+ * The editor never hits this: it loads its whole shell through
+ * next/dynamic with `ssr: false`, so the thumbnails there only ever render in
+ * the browser. The docs DO server-render, and the thumb cannot survive that —
+ * it writes computed floats straight into inline styles, and the server and the
+ * client do not serialize them identically (measured: `27.0082%` from the server
+ * against `27.0081928052793%` from the client, on every card). React reports
+ * that as a hydration mismatch it "won't patch up", which is a broken tree, not
+ * a warning to live with.
+ *
+ * So the frame and the label render on the server — the card keeps its size, the
+ * link is in the static HTML, nothing shifts — and only the moving part waits
+ * for the client. The placeholder is the same `.tpl-thumb` box, so there is no
+ * reflow when the real one arrives.
+ */
+export default function DocsThumb({
+  template,
+  autoPreview = false,
+}: {
+  template: Template;
+  autoPreview?: boolean;
+}) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+
+  if (!mounted) return <div className="tpl-thumb" aria-hidden="true" />;
+  return <TemplateThumb template={template} autoPreview={autoPreview} />;
+}

--- a/app/docs/_components/EasingGallery.tsx
+++ b/app/docs/_components/EasingGallery.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ControlRow } from '@/components/Controls';
+import EasingCurveEditor from '@/components/EasingCurveEditor';
+import type { ControlDef } from '@/lib/types';
+import { EASING_MAP, EASING_PRESETS, resolveEasing, sampleEasing, type EasingSpec } from '@/lib/easing';
+
+/**
+ * The easing playground, in three stacked blocks — the demo, the adjuster, the
+ * presets. An earlier cut put the demo and the editor side by side in a 382px
+ * column with five widgets stacked in it; measured, the 21 strobe marks were
+ * 26px wide at 18px apart, so they overlapped into a smear instead of showing a
+ * pattern. One thing per row now, and the marks are thin ticks on their own
+ * ruler.
+ *
+ * Everything reads the real library: paths from `sampleEasing` over
+ * `resolveEasing`, and the adjuster is the editor's own EasingCurveEditor.
+ */
+
+const TIME: ControlDef = {
+  key: 'time', label: 'Time through one cycle', type: 'slider',
+  min: 0, max: 1, step: 0.01, default: 0.35, precision: 2, section: 'Motion',
+};
+
+const GROUPS: { key: 'signature' | 'standard' | 'physics'; title: string; blurb: string }[] = [
+  { key: 'signature', title: 'Signature', blurb: 'The named curves, and what most families ship with.' },
+  { key: 'standard', title: 'Standard', blurb: 'The in / out / in-out families, gentlest to sharpest.' },
+  { key: 'physics', title: 'Physics', blurb: 'Sampled functions, not beziers — these leave the box on purpose.' },
+];
+
+// Ticks at equal slices of TIME, placed at the curve's output. Crowding means
+// slow, spreading means fast.
+const TICKS = Array.from({ length: 21 }, (_, i) => i / 20);
+
+// A path in a box widened to whatever the curve reaches: the physics curves
+// pass 0 and 1, and a unit box would clip them.
+function miniCurve(fn: (t: number) => number) {
+  const pts = sampleEasing(fn, 48);
+  let lo = 0;
+  let hi = 1;
+  for (const [, y] of pts) { if (y < lo) lo = y; if (y > hi) hi = y; }
+  const pad = 0.06 * (hi - lo);
+  const top = hi + pad;
+  const span = top - (lo - pad);
+  return pts
+    .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${(x * 100).toFixed(2)},${(((top - y) / span) * 100).toFixed(2)}`)
+    .join(' ');
+}
+
+export default function EasingGallery() {
+  const [spec, setSpec] = useState<EasingSpec>({ id: 'glide' });
+  const [time, setTime] = useState(TIME.default as number);
+  const [playing, setPlaying] = useState(false);
+
+  const ease = useMemo(() => resolveEasing(spec), [spec]);
+  const preset = EASING_MAP[spec.id];
+  const name = spec.id === 'custom' ? 'Custom curve' : preset?.label ?? spec.id;
+
+  // Autoplay drives the same state the slider does, so pausing leaves the
+  // square exactly where it is.
+  const raf = useRef(0);
+  useEffect(() => {
+    if (!playing) return;
+    let last = 0;
+    const tick = (t: number) => {
+      if (last) setTime((p) => (p + (t - last) / 1600) % 1);
+      last = t;
+      raf.current = requestAnimationFrame(tick);
+    };
+    raf.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf.current);
+  }, [playing]);
+
+  const out = ease(time);
+  const pct = (n: number) => `${Math.max(0, Math.min(100, n * 100))}%`;
+
+  return (
+    <div className="docs-ez">
+      {/* 1. the demo */}
+      <div className="docs-ez-block">
+        <div className="docs-ez-block-head">
+          <span>{name}</span>
+          <em>time {time.toFixed(2)} &rarr; position {out.toFixed(2)}</em>
+        </div>
+
+        <div className="docs-ez-lane">
+          <div className="docs-ez-runway">
+            <div className="docs-ez-square" style={{ left: pct(out) }} />
+          </div>
+          <div className="docs-ez-ruler">
+            {TICKS.map((t) => (
+              <i key={t} style={{ left: pct(ease(t)) }} />
+            ))}
+          </div>
+        </div>
+
+        <div className="docs-ez-row">
+          <button
+            type="button"
+            className="docs-ez-play"
+            onClick={() => setPlaying((p) => !p)}
+            aria-pressed={playing}
+          >
+            {playing ? 'Pause' : 'Play'}
+          </button>
+          <div className="docs-ez-scrub">
+            <ControlRow def={TIME} value={Number(time.toFixed(2))} onChange={(v) => setTime(v)} />
+          </div>
+        </div>
+
+        <p className="docs-ez-note">
+          The ticks are the square&rsquo;s position at 21 equal slices of time. Where they
+          crowd, the motion is slow; where they spread, it is fast. That spacing is what
+          the curve does — the plot below is the same fact, drawn.
+        </p>
+      </div>
+
+      {/* 2. the adjuster */}
+      <div className="docs-ez-block">
+        <div className="docs-ez-block-head">
+          <span>Adjust the curve</span>
+          <em>the editor&rsquo;s own widget</em>
+        </div>
+
+        <div className="docs-ez-adjust">
+          <div className="docs-ez-editor">
+            <EasingCurveEditor spec={spec} onChange={setSpec} />
+          </div>
+          <div className="docs-ez-adjust-side">
+            <p>
+              Drag either handle and the square above changes with it. The four numbers are
+              the bezier control points — x is clamped to the unit interval, y is free, so a
+              curve can overshoot.
+            </p>
+            <p>
+              The physics curves have nothing to drag: they are sampled from real functions
+              rather than built from handles, so the plot shows the curve and the handles
+              disappear.
+            </p>
+            <div className="docs-ez-readout">
+              <span>the scene stores</span>
+              <code>
+                {spec.id === 'custom'
+                  ? `{ id: 'custom', bezier: [${(spec.bezier ?? []).map((n) => n.toFixed(2)).join(', ')}] }`
+                  : preset?.bezier
+                    ? `{ id: '${spec.id}' }   // cubic-bezier(${preset.bezier.map((n) => n.toFixed(2)).join(', ')})`
+                    : `{ id: '${spec.id}' }   // sampled function, no handles`}
+              </code>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 3. the presets */}
+      <div className="docs-ez-block">
+        <div className="docs-ez-block-head">
+          <span>The {EASING_PRESETS.length} curves</span>
+          <em>pick one to load it above</em>
+        </div>
+
+        {GROUPS.map((group) => (
+          <div key={group.key} className="docs-ez-group">
+            <div className="docs-ez-group-head">
+              <span>{group.title}</span>
+              <em>{group.blurb}</em>
+            </div>
+            <div className="docs-ez-grid">
+              {EASING_PRESETS.filter((p) => p.group === group.key).map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  className={`docs-ez-card ${p.id === spec.id ? 'active' : ''}`}
+                  onClick={() => setSpec({ id: p.id })}
+                  aria-pressed={p.id === spec.id}
+                >
+                  <svg viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+                    <path className="docs-ez-curve" d={miniCurve(resolveEasing({ id: p.id }))} vectorEffect="non-scaling-stroke" />
+                  </svg>
+                  <span>{p.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/docs/_components/MockupControlGallery.tsx
+++ b/app/docs/_components/MockupControlGallery.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState } from 'react';
+import { ControlRow } from '@/components/Controls';
+import RotationBall from '@/components/RotationBall';
+import { mockupGroups } from '@/three3d/mockupControls';
+
+/**
+ * The Mockup studio's panels, read from its real schema
+ * (`three3d/mockupControls.ts`) — real ranges, real defaults, live.
+ *
+ * One block per panel, each paired with what it is for. An earlier cut dropped
+ * all six into an auto-fill grid: measured, it collapsed to a single 450px
+ * column 2099px tall, with Material and Lights at 592px each and no explanation
+ * anywhere — a wall of sliders. The prose here is not invented; it is what the
+ * schema's own comments say about why those defaults are what they are.
+ */
+
+interface PanelNote {
+  /** One line under the panel name: what this panel governs. */
+  governs: string;
+  /** Paragraphs beside the controls. */
+  body: string[];
+}
+
+const NOTES: Record<string, PanelNote> = {
+  'Camera & Hardware': {
+    governs: 'The lens, and the one part of the device that moves.',
+    body: [
+      'Field of View is the lens, not the camera position. Widening it fits more in the frame but also bends the device — a wide angle exaggerates the perspective on its edges, a narrow one flattens the whole thing toward an elevation drawing. If you want the device bigger without that distortion, move the camera instead, which is what the animation presets do.',
+      'Laptop Lid only applies to the laptop slot, and it is the one piece of the hardware itself that animates: the presets keyframe it open or shut along the same pose timeline that carries the camera.',
+    ],
+  },
+  Material: {
+    governs: 'Overrides on top of the model’s own materials.',
+    body: [
+      'The device arrives with real materials of its own, and Use Model Materials keeps them. Everything below it is an override for when you deliberately turn that off — a tint, a glow, transparency, or the two diagnostic looks.',
+      'Emissive is not lighting: it makes the body emit rather than reflect, so it stays bright no matter where the key light is. Wireframe and Flat Shading are there to inspect the mesh and the shading, not to ship a product shot.',
+    ],
+  },
+  Screen: {
+    governs: 'How the panel emits, and how much room it mirrors.',
+    body: [
+      'Brightness scales the screen’s own emission, so your artwork can hold up against a bright studio without being washed out by it.',
+      'Glare defaults to zero on purpose. The studio environment has rectangular panels baked into it, and a mirror-smooth display returns one as a hard softbox — the single clearest tell that an image was rendered rather than photographed. Raise it when a glossy screen is the look you want, not as a default.',
+    ],
+  },
+  Lights: {
+    governs: 'The studio rig: direction, balance, reflection, exposure.',
+    body: [
+      'Light Direction X and Y are the two axes of a direction pad, and they are applied as an OFFSET on top of whatever the active animation preset is doing with the key light. So a preset can swing the light through a shot and your offset still means the same thing relative to it.',
+      'Key, Fill and Ambient are the balance. A strong key against a low fill and ambient floor is what actually reads as sharp — enough contrast that the device’s edges and its finish stay defined instead of washing into a bright backdrop. Raising all three together just flattens the shot.',
+      'Reflections is how much of the room the surfaces return. Exposure is the render’s own exposure, and it is the control on this page that changes the render itself rather than grading it afterwards.',
+    ],
+  },
+  Adjustments: {
+    governs: 'Post-grade on the rendered device, not lighting.',
+    body: [
+      'These are filters applied to the canvas after the device is rendered, and they touch the device only — the backdrop keeps its own colours.',
+      'Which means: if the device looks too dark, Exposure up in Lights is the honest fix. Brightness here will lift it, and it will lift the noise and flatten the blacks with it. Use these for finishing, the way you would grade a photo.',
+    ],
+  },
+  Ground: {
+    governs: 'The contact shadow under the device.',
+    body: [
+      'Zero by default, because the default shot has no contact shadow at all: the device floats on a plain backdrop. Raising this introduces a ground plane for the device to sit on and cast onto.',
+      'Worth knowing before you reach for it: a shadow needs a floor, and a floor is a real plane in the scene. On a pose that floats or tilts far, that plane can end up crossing the device rather than sitting under it — if you see a straight dark edge that does not follow the device’s shape, that is the ground, not the shadow.',
+    ],
+  },
+};
+
+export default function MockupControlGallery() {
+  const [values, setValues] = useState<Record<string, any>>(() =>
+    Object.fromEntries(mockupGroups.flatMap((g) => g.controls.map((c) => [c.key, c.default]))),
+  );
+  const [rotation, setRotation] = useState({ x: 0, y: -18, z: 0 });
+
+  const set = (key: string) => (val: any) => setValues((v) => ({ ...v, [key]: val }));
+
+  return (
+    <div className="docs-mk">
+      {mockupGroups.map((group, i) => {
+        const note = NOTES[group.title];
+        return (
+          <section key={group.title} className="docs-mk-block">
+            <div className="docs-mk-block-head">
+              <span className="docs-mk-index">{String(i + 1).padStart(2, '0')}</span>
+              <span className="docs-mk-name">{group.title}</span>
+              <em>{group.controls.length} control{group.controls.length === 1 ? '' : 's'}</em>
+            </div>
+
+            <div className="docs-mk-body">
+              <div className="docs-mk-panel">
+                <div className="docs-mk-rows">
+                  {group.controls.map((def) => (
+                    <ControlRow key={def.key} def={def} value={values[def.key]} onChange={set(def.key)} />
+                  ))}
+                </div>
+              </div>
+
+              <div className="docs-mk-side">
+                {note && <p className="docs-mk-governs">{note.governs}</p>}
+                {note?.body.map((p) => <p key={p.slice(0, 24)}>{p}</p>)}
+              </div>
+            </div>
+          </section>
+        );
+      })}
+
+      <section className="docs-mk-block">
+        <div className="docs-mk-block-head">
+          <span className="docs-mk-index">07</span>
+          <span className="docs-mk-name">Orientation</span>
+          <em>outside the vocabulary</em>
+        </div>
+        <div className="docs-mk-body">
+          <div className="docs-mk-panel">
+            <div className="docs-mk-rows">
+              <RotationBall value={rotation} onChange={setRotation} />
+            </div>
+          </div>
+          <div className="docs-mk-side">
+            <p className="docs-mk-governs">Three rotations in one widget.</p>
+            <p>
+              Drag inside the disc for X and Y, drag the outer ring for Z, and type the
+              fields for the degrees a drag cannot land on. It replaced an XY pad, which
+              could only ever reach two of the three axes.
+            </p>
+            <p>
+              Degrees here, radians in the store, converted at the boundary — because
+              degrees are what you read and type, and radians are what the scene does
+              maths with.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/docs/_components/PageFeedback.tsx
+++ b/app/docs/_components/PageFeedback.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { ThumbDownIcon, ThumbUpIcon } from './DocsIcons';
+import { REPO_URL } from '../_lib/docsLinks';
+
+const KEY = 'motion-docs-feedback';
+type Verdict = 'yes' | 'no';
+
+function read(): Record<string, Verdict> {
+  try { return JSON.parse(localStorage.getItem(KEY) || '{}'); }
+  catch { return {}; }
+}
+
+function remember(pathname: string, verdict: Verdict | null) {
+  try {
+    const all = read();
+    if (verdict) all[pathname] = verdict;
+    else delete all[pathname];
+    localStorage.setItem(KEY, JSON.stringify(all));
+  } catch { /* Remembering the choice is optional. */ }
+}
+
+function issueUrl(title: string, body: string) {
+  return REPO_URL + '/issues/new?' + new URLSearchParams({ title, body }).toString();
+}
+
+export default function PageFeedback() {
+  const pathname = usePathname();
+  const [given, setGiven] = useState<Verdict | null>(null);
+  const [reporting, setReporting] = useState(false);
+  const [problem, setProblem] = useState('');
+
+  useEffect(() => {
+    setGiven(read()[pathname] ?? null);
+    setReporting(false);
+    setProblem('');
+  }, [pathname]);
+
+  const problemHref = useMemo(() => issueUrl(
+    'Docs problem: ' + (problem.trim().slice(0, 72) || pathname),
+    ['## What is wrong or unclear?', problem.trim() || 'Describe the problem here.', '', 'Docs page: ' + pathname].join('\n'),
+  ), [pathname, problem]);
+
+  const markHelpful = () => {
+    setGiven('yes');
+    remember(pathname, 'yes');
+  };
+
+  const reset = () => {
+    setGiven(null);
+    setReporting(false);
+    setProblem('');
+    remember(pathname, null);
+  };
+
+  return (
+    <footer className="docs-feedback">
+      {given === null && !reporting && (
+        <>
+          <span className="docs-feedback-q">Was this page helpful?</span>
+          <div className="docs-feedback-actions">
+            <button type="button" className="docs-feedback-btn" onClick={markHelpful}>
+              <ThumbUpIcon /> Yes
+            </button>
+            <button type="button" className="docs-feedback-btn" onClick={() => setReporting(true)}>
+              <ThumbDownIcon /> No
+            </button>
+          </div>
+        </>
+      )}
+
+      {reporting && given === null && (
+        <div className="docs-feedback-detail">
+          <label htmlFor="docs-feedback-problem">What is wrong or unclear?</label>
+          <textarea
+            id="docs-feedback-problem"
+            value={problem}
+            onChange={(event) => setProblem(event.target.value)}
+            maxLength={1000}
+            rows={3}
+            autoFocus
+            placeholder="Describe the problem with this page"
+          />
+          <div className="docs-feedback-detail-actions">
+            <button type="button" className="docs-feedback-cancel" onClick={() => setReporting(false)}>Cancel</button>
+            <a
+              className={'docs-feedback-send ' + (problem.trim() ? '' : 'disabled')}
+              href={problem.trim() ? problemHref : undefined}
+              target="_blank"
+              rel="noreferrer noopener"
+              aria-disabled={!problem.trim()}
+              onClick={() => {
+                if (!problem.trim()) return;
+                setGiven('no');
+                remember(pathname, 'no');
+              }}
+            >
+              Open problem issue
+            </a>
+          </div>
+          <p className="docs-feedback-hint">You will review and submit it on GitHub.</p>
+        </div>
+      )}
+
+      {given !== null && (
+        <>
+          <span className="docs-feedback-q">
+            {given === 'yes' ? 'Glad it helped.' : 'Problem prepared for GitHub.'}
+          </span>
+          <button type="button" className="docs-feedback-undo" onClick={reset}>Change answer</button>
+        </>
+      )}
+
+    </footer>
+  );
+}

--- a/app/docs/_components/PresetSample.tsx
+++ b/app/docs/_components/PresetSample.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+import DocsThumb from './DocsThumb';
+import { catalogTemplateList } from '@/templates';
+
+/**
+ * A handful of presets, running, as an illustration inside a concept page —
+ * not a catalogue. The catalogue is the editor; browsing belongs there, where
+ * search, favourites and the real stage are.
+ *
+ * A client component that reads the registry itself, on purpose: a Template
+ * carries functions (`transform`), which a server component cannot hand across
+ * the boundary as props. The ids cross; the templates are looked up on this side.
+ *
+ * Unknown or withheld ids are skipped rather than thrown: this list is written
+ * by hand in prose pages, and a preset that leaves the catalogue should quietly
+ * drop out of the illustration instead of breaking the page.
+ */
+export default function PresetSample({ ids }: { ids: string[] }) {
+  const byId = new Map(catalogTemplateList.map((t) => [t.meta.id, t]));
+  const items = ids.map((id) => byId.get(id)).filter((t) => t !== undefined);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="docs-grid">
+      {items.map((t) => (
+        // Same app now, so this is an in-app route rather than a cross-origin
+        // link — Link also carries the deploy basePath, which a raw href would
+        // drop on the subpath build.
+        <Link
+          key={t.meta.id}
+          href={`/library?tpl=${encodeURIComponent(t.meta.id)}`}
+          className="tpl-card docs-preset"
+        >
+          {/* .tpl-card is what TemplateThumb looks for to drive its preview, and
+              what gives the card its hairline; both come from globals.css. */}
+          <DocsThumb template={t} autoPreview />
+          <span className="tpl-card-label">{t.meta.name}</span>
+          <code className="docs-preset-id">?tpl={t.meta.id}</code>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/app/docs/_lib/docsLinks.ts
+++ b/app/docs/_lib/docsLinks.ts
@@ -1,0 +1,30 @@
+/**
+ * Outbound links shown in the docs header.
+ *
+ * The repository URL is not guessed — it is the one the app itself uses for the
+ * local updater and the export dialog (`lib/localUpdate.ts`,
+ * `components/ExportDialog.tsx`), so there is one truth for it.
+ *
+ * Social accounts: fill these in and they appear. Entries with an empty `url`
+ * are skipped, so an unfilled slot renders nothing rather than a dead link —
+ * this file is the only place to edit.
+ */
+
+export const REPO_URL = 'https://github.com/appariciojunior/motion-studio-open';
+
+export type SocialNetwork = 'x' | 'instagram' | 'linkedin' | 'youtube' | 'discord' | 'site';
+
+export interface SocialLink {
+  network: SocialNetwork;
+  label: string;
+  url: string;
+}
+
+export const SOCIAL_LINKS: SocialLink[] = [
+  // { network: 'x',         label: 'X',         url: 'https://x.com/…' },
+  // { network: 'instagram', label: 'Instagram', url: 'https://instagram.com/…' },
+  // { network: 'linkedin',  label: 'LinkedIn',  url: 'https://linkedin.com/company/…' },
+];
+
+/** Only the ones actually filled in. */
+export const socials = (): SocialLink[] => SOCIAL_LINKS.filter((s) => s.url.trim() !== '');

--- a/app/docs/_lib/docsNav.ts
+++ b/app/docs/_lib/docsNav.ts
@@ -1,0 +1,142 @@
+/**
+ * The docs navigation.
+ *
+ * Deliberately a short, fixed list. An earlier cut generated one sidebar entry
+ * per template family straight from the registry, which turned the docs into a
+ * second catalogue browser — and the editor already is one, with search,
+ * favourites and the real stage. These pages explain how the thing works; the
+ * browsing happens in the app.
+ */
+
+export interface DocsLink {
+  href: string;
+  label: string;
+}
+
+export interface DocsSection {
+  title: string;
+  links: DocsLink[];
+}
+
+export const DOCS_SECTIONS: DocsSection[] = [
+  {
+    title: 'Getting started',
+    links: [
+      { href: '/docs', label: 'Introduction' },
+      { href: '/docs/quick-start', label: 'Quick start' },
+    ],
+  },
+  {
+    title: 'How it works',
+    links: [
+      { href: '/docs/library', label: 'The Library' },
+      { href: '/docs/media', label: 'Media' },
+      { href: '/docs/canvas', label: 'Canvas' },
+      { href: '/docs/timeline', label: 'Timeline' },
+      { href: '/docs/effects', label: 'Effects' },
+      { href: '/docs/mobile', label: 'On a phone' },
+      { href: '/docs/mockup', label: 'The Mockup studio' },
+      { href: '/docs/tracks', label: 'Motion tracks' },
+      { href: '/docs/export', label: 'Export' },
+    ],
+  },
+  {
+    // Two subgroups, because there are exactly two places motion controls are
+    // declared: per template, and once for the whole studio.
+    title: 'Controls',
+    links: [
+      { href: '/docs/controls/library', label: 'Library' },
+      { href: '/docs/controls/mockup', label: 'Mockup' },
+    ],
+  },
+  {
+    title: 'Changing it',
+    links: [
+      { href: '/docs/easing', label: 'Easing' },
+      { href: '/docs/design', label: 'Design and theming' },
+      { href: '/docs/new-motion', label: 'New motion' },
+    ],
+  },
+];
+
+/**
+ * The search index.
+ *
+ * Hand-maintained on purpose: the pages are TSX, so there is no MDX AST to
+ * harvest headings from, and a wrong-but-silent index is worse than a short
+ * honest one. Keep the terms to what the page actually answers — when a page
+ * gains a section, add its words here.
+ */
+export interface DocsSearchEntry {
+  href: string;
+  title: string;
+  section: string;
+  terms: string[];
+}
+
+export const DOCS_SEARCH: DocsSearchEntry[] = [
+  {
+    href: '/docs', title: 'Introduction', section: 'Getting started',
+    terms: ['what is', 'overview', 'library', 'mockup', 'runs locally', 'nothing uploaded', 'browser'],
+  },
+  {
+    href: '/docs/quick-start', title: 'Quick start', section: 'Getting started',
+    terms: ['install', 'npm run dev', 'first clip', 'media', 'canvas', 'adjust', 'undo', 'autosave'],
+  },
+  {
+    href: '/docs/library', title: 'The Library', section: 'How it works',
+    terms: ['preset', 'family', 'transform', 'pure function', 'card shape', 'lattice', 'loop', 'deep link', 'tpl'],
+  },
+  {
+    href: '/docs/media', title: 'Media', section: 'How it works',
+    terms: ['assets', 'images', 'video', 'reorder', 'crop', 'crop focus', 'card shape', 'auto', 'loop', 'hold', 'uploads', 'indexeddb', 'demo assets'],
+  },
+  {
+    href: '/docs/canvas', title: 'Canvas', section: 'How it works',
+    terms: ['aspect', 'ratio', '9:16', '1:1', 'pixel size', 'background', 'gradient', 'reflected card', 'blur', 'safe area', 'guides', 'logo', 'watermark'],
+  },
+  {
+    href: '/docs/timeline', title: 'Timeline', section: 'How it works',
+    terms: ['playhead', 'scrub', 'duration', 'frame rate', 'fps', 'ruler', 'lanes', 'blend mode', 'undo', 'redo', 'clock', 'playback'],
+  },
+  {
+    href: '/docs/effects', title: 'Effects', section: 'How it works',
+    terms: ['effect', 'filter', 'filter stack', 'pixelate', 'createFilter', 'order', 'post'],
+  },
+  {
+    href: '/docs/mobile', title: 'On a phone', section: 'How it works',
+    terms: ['mobile', 'phone', 'touch', 'tablet', 'breakpoint', 'sheet', 'bottom bar', 'drawer', 'hamburger', 'transport', 'scrubber'],
+  },
+  {
+    href: '/docs/mockup', title: 'The Mockup studio', section: 'How it works',
+    terms: ['device', 'iphone', 'ipad', 'macbook', 'display', 'finish', 'screen', 'status bar', 'animation preset', 'camera', 'lighting', 'save'],
+  },
+  {
+    href: '/docs/tracks', title: 'Motion tracks', section: 'How it works',
+    terms: ['track', 'layer', 'timeline', 'window', 'blend mode', 'clock', 'composite'],
+  },
+  {
+    href: '/docs/export', title: 'Export', section: 'How it works',
+    terms: ['mp4', 'webm', 'gif', 'h264', 'vp9', 'resolution', '4k', '1080p', 'webcodecs', 'ffmpeg', 'loop', 'encoder'],
+  },
+  {
+    href: '/docs/controls/library', title: 'Library controls', section: 'Controls',
+    terms: ['slider', 'toggle', 'pills', 'select', 'direction', 'color', 'xypad', 'upload', 'text', 'control types', 'declaration', 'visibleWhen', 'section', 'advanced', 'default', 'key', 'preset bundle'],
+  },
+  {
+    href: '/docs/controls/mockup', title: 'Mockup controls', section: 'Controls',
+    terms: ['mockup controls', 'lights', 'key light', 'fill light', 'ambient', 'exposure', 'material', 'wireframe', 'emissive', 'screen brightness', 'glare', 'adjustments', 'ground', 'shadow', 'rotation ball', 'trackball', 'view gizmo', 'field of view', 'laptop lid'],
+  },
+  {
+    href: '/docs/easing', title: 'Easing', section: 'Changing it',
+    terms: ['curve', 'bezier', 'phase', 'bounce', 'spring', 'wiggle', 'overshoot', 'sine', 'quad', 'cubic', 'expo', 'loop', 'timing function'],
+  },
+  {
+    href: '/docs/design', title: 'Design and theming', section: 'Changing it',
+    terms: ['tokens', 'colour', 'color', 'theme', 'dark mode', 'radius', 'type scale', 'restyle', 'accent', 'palette', 'hairline'],
+  },
+  {
+    href: '/docs/new-motion', title: 'New motion', section: 'Changing it',
+    terms: ['template', 'transform', 'pose', 'dim', 'alpha', 'clip', 'taper', 'depth', 'pure', 'seeded', 'registry', 'loopCycles', 'webgl', 'camera', 'tests'],
+  },
+];

--- a/app/docs/canvas/page.tsx
+++ b/app/docs/canvas/page.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link';
+import { ASPECTS } from '@/store/useSceneStore';
+
+export const metadata = { title: 'Canvas' };
+
+export default function CanvasPage() {
+  const aspects = Object.keys(ASPECTS);
+
+  return (
+    <>
+      <p className="docs-eyebrow">How it works</p>
+      <h1>Canvas</h1>
+
+      <p className="docs-lead">
+        The frame everything happens inside: its shape, what sits behind the cards, and the
+        guides that keep your content out of the places a platform will cover.
+      </p>
+
+      <h2>Shape</h2>
+      <p>
+        {aspects.length} presets —{' '}
+        {aspects.map((a, i) => (
+          <span key={a}>{i > 0 ? ', ' : ''}<code>{a}</code></span>
+        ))}{' '}
+        — plus an exact pixel size when none of them is the answer. The presets are built
+        from a fixed longest edge, so switching shape reframes the scene rather than
+        rescaling your work.
+      </p>
+      <p>
+        Some presets set the shape for you when you pick them. That is not the app being
+        opinionated: those motions were authored against a specific frame, and their
+        framing is measured against its half-height — at another ratio the sides show a
+        different amount of the ring, which is a different composition.
+      </p>
+
+      <h2>Background</h2>
+      <p>Three sources, and the third is the interesting one.</p>
+      <div className="docs-table-wrap">
+        <table className="docs-table">
+          <thead><tr><th>Source</th><th>What it does</th></tr></thead>
+          <tbody>
+            <tr>
+              <td><strong>Colour</strong></td>
+              <td>A solid, or a two-stop gradient when you turn gradient on.</td>
+            </tr>
+            <tr>
+              <td><strong>Image</strong></td>
+              <td>Your own file behind the cards, with a blur so it reads as a backdrop rather than competing with them.</td>
+            </tr>
+            <tr>
+              <td><strong>Card</strong></td>
+              <td>The featured card itself, reflected and blurred behind the scene. The background follows the motion — as the featured card changes, so does the wash behind it.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        A background you set explicitly is remembered as <em>yours</em>: the presets that
+        would otherwise impose a white backdrop leave it alone once you have made a choice.
+      </p>
+
+      <h2>Safe-area guides</h2>
+      <p>
+        An overlay marking the edges a platform is likely to cover — the caption bar, the
+        profile row, the buttons stacked down one side. They are drawn on the stage only:
+        they never appear in the export, and turning them off changes nothing about the
+        file.
+      </p>
+      <p>
+        Worth switching on before you finish rather than after, because the fix for
+        something sitting under a caption bar is usually a different canvas shape, not a
+        nudge.
+      </p>
+
+      <h2>Logo slot</h2>
+      <p>
+        A single image pinned to a corner, with a size, kept separate from the card list so
+        it is not swept into the motion. It sits above the scene and stays put while
+        everything else moves — a watermark, a wordmark, an end-card badge.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/timeline">Timeline →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/controls/library/page.tsx
+++ b/app/docs/controls/library/page.tsx
@@ -1,0 +1,138 @@
+import Link from 'next/link';
+import ControlGallery, { CONTROL_TYPE_COUNT } from '../../_components/ControlGallery';
+
+export const metadata = { title: 'Library controls' };
+
+export default function LibraryControlsPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">Changing it</p>
+      <h1>Library controls</h1>
+
+      <p className="docs-lead">
+        The Adjust panel is not written per template. Each motion declares the controls it
+        has, and the panel renders that declaration — which is why every family shows
+        exactly its own settings and no dead ones, and why adding a control is a one-line
+        change with no UI to touch.
+      </p>
+
+      <p className="docs-note">
+        Controls are declared in two places in this app, and they are edited in different
+        files for different reasons. This page is the motion side. The studio side is{' '}
+        <Link href="/docs/controls/mockup">Mockup controls</Link>.
+      </p>
+
+      <h2>The vocabulary is closed</h2>
+      <p>
+        A template may only use these {CONTROL_TYPE_COUNT} types. The limit is the point: a motion cannot
+        invent a widget the panel does not know how to draw, so every motion stays fully
+        editable, thumbnailable and exportable by the same code.
+      </p>
+      <p>
+        The controls below are live, and they are the editor&rsquo;s own — the same
+        component the Adjust panel mounts, not a drawing of it. Drag them. The readout
+        beside each one is the value your transform would read that instant, which is the
+        whole contract between the panel and the motion.
+      </p>
+
+      <ControlGallery />
+
+      <h2>The slider has more in it than a track</h2>
+      <p>
+        It carries most of the controls in the app, so it earned some depth. None of this
+        is configured per template — declare <code>type: 'slider'</code> and you get all
+        of it.
+      </p>
+      <div className="docs-table-wrap">
+        <table className="docs-table">
+          <thead>
+            <tr><th>Gesture</th><th>Does</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Drag anywhere on the track</td><td>Sets the value. The whole 34px row is the control, not a thin rail with a knob to hit.</td></tr>
+            <tr><td><strong>Hold Shift while dragging</strong></td><td><strong>Fine adjustment</strong> — the grid becomes a tenth of the declared step, so a step-1 slider lands on 12.4.</td></tr>
+            <tr><td>Click the value</td><td>Types an exact number. It snaps to the same grid a drag uses, so the readout can never show 19 while storing 18.5.</td></tr>
+            <tr><td>Arrow keys, track focused</td><td>Nudges by one step; with Shift, by a tenth. Enter opens the typed field.</td></tr>
+            <tr><td>Arrow keys while typing</td><td>Nudges from what is <em>typed</em>, not from what is stored — and Shift means the finer grid here too.</td></tr>
+            <tr><td>Double-click the track</td><td>Back to the control&rsquo;s declared default.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        The fine adjustment is why a control can declare a coarse step without becoming
+        imprecise. A rotation in whole degrees is the right default for dragging, and Shift
+        is there for the one shot that needs 12.4.
+      </p>
+      <p className="docs-note">
+        Two details that look cosmetic and are not. A drag belongs to the track that was
+        pressed: without that, a pointer held down and swept across a panel rewrote every
+        slider it crossed. And the typed field is a text input with a decimal input mode
+        rather than a number input, because a number input refuses to report a selection —
+        so the first keystroke landed beside the old value instead of replacing it, and
+        340 followed by 5 became 3405.
+      </p>
+
+      <h2>What one declaration looks like</h2>
+      <p>
+        Every control above is one object in the template&rsquo;s <code>controls</code>{' '}
+        array. The full set of fields:
+      </p>
+      <pre className="docs-code"><code>{`{
+  key: 'tilt',            // unique within the template; transform reads values.tilt
+  label: 'Tilt',          // what the panel shows
+  type: 'slider',
+  min: 0, max: 45, step: 1,
+  default: 12,            // also the value a template switch resets to
+  section: 'Motion',      // Layout | Motion | Depth | Finish — groups the panel
+  unit: '°',              // ° % px × s — drawn next to the number
+  precision: 0,           // decimals shown
+  description: 'How far each card leans out of the plane.',
+  visibleWhen: { key: 'mode', equals: 'perspective' },
+  advanced: true,         // folded away until Advanced is opened
+}`}</code></pre>
+      <p>
+        <code>section</code> is what groups the panel, so a new control lands in the right
+        block without any layout work. <code>visibleWhen</code> is how a family hides
+        settings that do not apply to the mode it is in — cheaper and clearer than shipping
+        two near-identical templates. <code>advanced</code> keeps the long tail out of the
+        way without hiding it.
+      </p>
+
+      <h2>Adding or changing one</h2>
+      <ul className="docs-list">
+        <li>Add the entry to the template&rsquo;s <code>controls</code> array.</li>
+        <li>Read it in the transform as <code>values.yourKey</code>.</li>
+        <li>
+          That is all. The panel row, the default, the reset-on-switch, the undo step, the
+          thumbnail and the export all follow from the declaration.
+        </li>
+      </ul>
+      <p>
+        Changing a <code>default</code> changes what a fresh pick of that template looks
+        like. Changing a <code>key</code> does something else entirely: keys are what saved
+        projects reference, so renaming one silently drops that value from every scene
+        already on disk. Labels are free to change; keys and template ids are not.
+      </p>
+
+      <h2>A new preset is a new set of defaults</h2>
+      <p>
+        Most &ldquo;new motions&rdquo; are not new motions. A preset is the same transform
+        shipped with different declared defaults, built by a small helper that patches
+        them — so a family of six presets is one piece of code and six value bundles.
+        Because picking a template does a full reset from the declaration, the preset look
+        comes out for free.
+      </p>
+      <p className="docs-note">
+        Two traps if you write a preset by hand rather than through the helper: a preset of
+        a 3D family that loses its 3D pose function renders flat while its base renders in
+        perspective, and a preset of a lattice family that loses its layer-count function
+        falls back to reading a card-count control those families do not have — six cards
+        where a wall was expected. Both are silent.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/controls/mockup">Mockup controls →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/controls/mockup/page.tsx
+++ b/app/docs/controls/mockup/page.tsx
@@ -1,0 +1,103 @@
+import Link from 'next/link';
+import MockupControlGallery from '../../_components/MockupControlGallery';
+import { mockupGroups } from '@/three3d/mockupControls';
+
+export const metadata = { title: 'Mockup controls' };
+
+export default function MockupControlsPage() {
+  const total = mockupGroups.reduce((n, g) => n + g.controls.length, 0);
+
+  return (
+    <>
+      <p className="docs-eyebrow">Changing it</p>
+      <h1>Mockup controls</h1>
+
+      <p className="docs-lead">
+        The studio is one scene, not two hundred, so its controls are declared once — as{' '}
+        {mockupGroups.length} titled groups holding {total} controls, in{' '}
+        <code>three3d/mockupControls.ts</code>. Every panel below is read from that file:
+        real ranges, real defaults, live.
+      </p>
+
+      <p className="docs-note">
+        This is the studio side. The motion side — declared per template, one panel per
+        family — is <Link href="/docs/controls/library">Library controls</Link>.
+      </p>
+
+      <h2>How this differs from a template&rsquo;s panel</h2>
+      <div className="docs-table-wrap">
+        <table className="docs-table">
+          <thead>
+            <tr><th></th><th>Library</th><th>Mockup</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Declared by</td>
+              <td>each template, in its own file</td>
+              <td>the studio, in one schema file</td>
+            </tr>
+            <tr>
+              <td>Shape</td>
+              <td>a flat list; <code>section</code> on each entry groups the panel</td>
+              <td>titled groups, each holding its own list</td>
+            </tr>
+            <tr>
+              <td>Scope</td>
+              <td>only that motion — hundreds of families, hundreds of panels</td>
+              <td>one panel for the whole studio</td>
+            </tr>
+            <tr>
+              <td>Reset</td>
+              <td>picking a template wipes and refills from the declaration</td>
+              <td>persistent; it is the studio&rsquo;s state, not a motion&rsquo;s</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        What the two share is the vocabulary and the renderer: the same nine types and the
+        same row component, so a control looks and behaves identically in either place.
+        Notice what the studio actually uses — almost all sliders, a few toggles, two
+        colours. A 3D studio does not need a wider vocabulary than a 2D motion does, and it
+        did not get one.
+      </p>
+
+      <h2>The studio&rsquo;s panels</h2>
+
+      <MockupControlGallery />
+
+      <h2>Two rules that cover all of them</h2>
+      <ul className="docs-list">
+        <li>
+          <strong>The groups are declared, not derived.</strong> A motion control carries a{' '}
+          <code>section</code> and the panel groups by it; a studio panel carries a title and
+          holds its own controls. Adding a panel here means adding an object to the schema,
+          not inventing a section name somewhere.
+        </li>
+        <li>
+          <strong>Nothing resets.</strong> These values belong to the studio, so they survive
+          switching device, finish and animation preset. Motion values are wiped on every
+          template pick, by design — which is the sharpest difference between the two sides.
+        </li>
+      </ul>
+
+      <h2>The one control that is not on this page</h2>
+      <p>
+        The <strong>view gizmo</strong>: six axis balls showing how the camera sits relative
+        to the world, drag to orbit, double-click a ball to snap to that axis. Like the
+        trackball above it refused the nine-type vocabulary for the same reason — it is
+        spatial, and a list of words would make you translate language back into geometry.
+      </p>
+      <p>
+        It is not mounted here because it needs a real camera rig to point at; it lives over
+        the 3D stage in the editor. Its axis colours are the one place in the app that uses
+        hue deliberately, following the red/green/blue convention for X/Y/Z — see{' '}
+        <Link href="/docs/design">Design and theming</Link>.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/easing">Easing →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/design/page.tsx
+++ b/app/docs/design/page.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Design and theming' };
+
+export default function DesignPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">Changing it</p>
+      <h1>Design and theming</h1>
+
+      <p className="docs-lead">
+        Every colour, radius, type size and layout metric in the editor lives in one
+        token sheet. Restyling the whole app is an edit to that file — components never
+        hardcode a colour, so there is nowhere else for one to hide.
+      </p>
+
+      <h2>One file</h2>
+      <p>
+        The sheet is <code>styles/tokens.css</code>. Everything else — panels, the
+        timeline, the template cards, these docs pages — reads from it through{' '}
+        <code>var(--token)</code>. If a change needs touching a component to recolour
+        something, that component has a bug.
+      </p>
+
+      <div className="docs-table-wrap">
+        <table className="docs-table">
+          <thead>
+            <tr><th>Group</th><th>Governs</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Surfaces</td><td>The stage and its dot grid, panels, input wells, card backgrounds, hairlines</td></tr>
+            <tr><td>Text</td><td>The gray scale: active, body, labels, values, muted, faint</td></tr>
+            <tr><td>Inverse</td><td>The dark-on-light pairs — Export button, play button, active segment</td></tr>
+            <tr><td>Radii</td><td>Cards, controls, segments, chips. All <code>0px</code> today</td></tr>
+            <tr><td>Type scale</td><td>Label, UI, meta, eyebrow and micro sizes with their line heights</td></tr>
+            <tr><td>Spacing and layout</td><td>Panel padding, row gaps, and the fixed column widths of the editor grid</td></tr>
+            <tr><td>Motion</td><td>The single UI transition duration</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2>Two examples</h2>
+      <p>
+        <strong>Round the corners.</strong> The design is square on purpose, and that is
+        expressed as tokens rather than as an absence: the radius tokens are all{' '}
+        <code>0px</code>. Set them to <code>6px</code> and every card, control, segment
+        and chip rounds together, in both themes, with no component edited.
+      </p>
+      <p>
+        <strong>Change the palette.</strong> The surface and text tokens are one block
+        each. Replace their values and the whole editor moves, including the parts you
+        did not think about — the timeline lanes, the thumbnail backdrops, the docs.
+      </p>
+
+      <h2>The dark theme is the same tokens</h2>
+      <p>
+        Dark is not a second stylesheet. It redefines the same token names under{' '}
+        <code>{':root[data-theme="dark"]'}</code>, so anything built from tokens is
+        already themed. The theme is written on the root element before first paint from
+        the stored preference, so there is no flash of the wrong theme, and the toggle in
+        the editor and the one in these docs write to the same place.
+      </p>
+      <p className="docs-note">
+        The practical rule when adding UI: never give a colour its only definition
+        outside the token sheet. A literal hex in a component is invisible in light mode
+        review and wrong in dark mode.
+      </p>
+
+      <h2>There is no accent colour</h2>
+      <p>
+        This palette has none, and that is a decision, not an omission. &ldquo;Selected&rdquo;
+        and &ldquo;on&rdquo; are said with <code>--fg</code> — the active template card
+        border, the segmented thumb, a favourited heart, the marker beside the current
+        page in this sidebar. A single hue introduced for one state would be the only
+        colour in the interface and would read as an error rather than as emphasis.
+      </p>
+      <p>
+        The one exception is the 3D view gizmo, whose red, green and blue axes are the
+        established convention for X, Y and Z, and which sits on a user-set background
+        rather than on a themed surface.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/new-motion">New motion →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/docs.css
+++ b/app/docs/docs.css
@@ -1,0 +1,838 @@
+/* ============================================================
+   DOCS — the reading surface.
+   Layout follows the shape of a modern component-docs site: a
+   full-width header, a railed sidebar, one reading column, no
+   right-hand table of contents. Everything it is PAINTED with is
+   ours — flat panels, 1px hairlines, square corners, Inter, the
+   Tailwind-gray text scale — and every colour comes from
+   styles/tokens.css, so the dark theme and any future restyle
+   follow for free. Nothing here hardcodes a colour.
+   ============================================================ */
+
+/* The breakpoint is the editor’s own (919px): below it the desktop grid cannot
+   show the stage at all, and a reader who gets the touch editor should get the
+   touch docs with it. Keep the two in step. */
+.docs-shell {
+  /* Docs-only metric, so it lives here and not in the app token sheet: the
+     height of the bar under the navbar in the narrow layout. */
+  --docs-subbar-h: 48px;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  /* Own viewport height, not inherited: `height: 100%` only worked because the
+     editor globals happen to set html/body to 100%. With that, the sidebar and
+     the header stay put and only the middle column scrolls; without it the whole
+     document scrolls and the left side rides away with it. dvh so a phone browser
+     chrome collapsing does not change the box. */
+  height: 100dvh;
+  background: var(--card);
+}
+
+/* ---- Header ---- */
+.docs-header {
+  display: flex; align-items: center; gap: 24px;
+  height: 56px; padding: 0 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--card);
+}
+
+.docs-brand {
+  display: flex; align-items: baseline; gap: 7px;
+  font-size: var(--fs-label); font-weight: 600; color: var(--fg);
+  text-decoration: none; white-space: nowrap;
+}
+.docs-brand-tag {
+  font-size: var(--fs-eyebrow); font-weight: 500; letter-spacing: 1.5px;
+  text-transform: uppercase; color: var(--fg-faint);
+}
+
+.docs-header-nav { display: flex; align-items: center; gap: 18px; }
+.docs-header-nav a,
+.docs-header-nav button {
+  font-size: var(--fs-label); color: var(--fg-label); text-decoration: none;
+  transition: color var(--t-fast);
+}
+.docs-header-nav button { background: none; padding: 0; }
+.docs-header-nav a:hover,
+.docs-header-nav button:hover { color: var(--fg); }
+.docs-header-nav .docs-suggest-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: var(--ctl-h); padding: 0 10px;
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+  background: var(--card-inset); color: var(--fg-label);
+}
+.docs-suggest-btn span {
+  display: grid; place-items: center;
+  width: 14px; height: 14px;
+  font-size: 17px; line-height: 1; color: var(--fg);
+}
+.docs-header-nav .docs-suggest-btn:hover {
+  border-color: var(--handle); background: var(--card);
+}
+
+.docs-header-end { margin-left: auto; display: flex; align-items: center; gap: 6px; }
+
+.docs-icon-btn {
+  width: var(--ctl-h); height: var(--ctl-h);
+  display: grid; place-items: center;
+  color: var(--fg-muted); border-radius: var(--r-ctrl);
+  transition: background var(--t-fast), color var(--t-fast);
+}
+.docs-icon-btn:hover { background: var(--card-inset); color: var(--fg); }
+.docs-icon-btn svg { width: 16px; height: 16px; }
+
+.docs-header-cta {
+  height: var(--ctl-h); padding: 0 14px;
+  display: inline-flex; align-items: center;
+  background: var(--inverse-bg); color: var(--inverse-fg);
+  border-radius: var(--r-ctrl);
+  font-size: var(--fs-ui); font-weight: 500; text-decoration: none;
+  white-space: nowrap;
+}
+
+/* ---- Body split ---- */
+.docs-body {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  min-height: 0;
+}
+
+/* ---- Sidebar ---- */
+.docs-nav {
+  border-right: 1px solid var(--line);
+  padding: 20px 0 40px;
+  overflow-y: auto;
+}
+
+
+.docs-nav-section { padding-top: 14px; }
+.docs-nav-title {
+  padding: 0 20px 8px;
+  font-size: var(--fs-eyebrow); font-weight: 500; letter-spacing: 1.5px;
+  text-transform: uppercase; color: var(--fg-faint);
+}
+
+.docs-nav-rail { margin-left: 20px; border-left: 1px solid var(--line); }
+
+.docs-nav-link {
+  position: relative;
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 16px 6px 14px;
+  font-size: var(--fs-label); line-height: var(--lh-label);
+  color: var(--fg-muted); text-decoration: none;
+  transition: color var(--t-fast);
+}
+.docs-nav-link:hover { color: var(--fg); }
+/* Selected speaks the same language as every other selected thing in this app —
+   the active template card, the segmented thumb: --fg, never a hue. This palette
+   has no accent colour. The marker sits ON the rail, so the hairline reads as
+   being lit rather than covered. */
+.docs-nav-link.active { color: var(--fg); font-weight: 500; }
+.docs-nav-link.active::before {
+  content: "";
+  position: absolute; left: -1px; top: 4px; bottom: 4px;
+  width: 2px; background: var(--fg);
+}
+
+/* ---- Reading column ---- */
+.docs-main {
+  overflow-y: auto;
+  overflow-x: clip;
+  /* Reserve the scrollbar on both sides: without it the centred column sits 8px
+     left of true centre (measured), and jumps sideways between a page that
+     scrolls and one that does not. */
+  scrollbar-gutter: stable both-edges;
+}
+.docs-article {
+  /* Centred in whatever space is left of the sidebar, so a wide screen does not
+     leave the column pinned to the left with a field of empty page beside it. */
+  margin: 0 auto;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  max-width: 720px;
+  padding: 48px 40px 96px;
+  color: var(--fg-body);
+  font-size: 15px;
+  line-height: 26px;
+}
+
+.docs-eyebrow {
+  margin: 0 0 10px;
+  font-size: var(--fs-eyebrow); font-weight: 500; letter-spacing: 1.5px;
+  text-transform: uppercase; color: var(--fg-faint);
+}
+.docs-eyebrow a { color: inherit; text-decoration: none; }
+.docs-eyebrow a:hover { color: var(--fg-muted); }
+
+.docs-article h1 {
+  margin: 0 0 18px;
+  font-size: 30px; line-height: 38px; font-weight: 600;
+  letter-spacing: -0.4px; color: var(--fg);
+}
+.docs-article h2 {
+  margin: 40px 0 12px;
+  font-size: 17px; line-height: 25px; font-weight: 600; color: var(--fg);
+}
+.docs-article p { margin: 0 0 16px; }
+.docs-lead { font-size: 17px; line-height: 29px; color: var(--fg-muted); }
+.docs-article strong { color: var(--fg); font-weight: 500; }
+.docs-article a { color: var(--fg); text-decoration: underline; text-underline-offset: 2px; }
+
+.docs-list { margin: 0 0 16px; padding-left: 20px; }
+.docs-list li { margin-bottom: 8px; }
+
+.docs-article code {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 13px;
+  padding: 1px 5px;
+  background: var(--card-inset);
+  border: 1px solid var(--line);
+  border-radius: var(--r-chip);
+  color: var(--fg);
+}
+.docs-code {
+  margin: 0 0 16px; padding: 14px 16px;
+  background: var(--card-inset);
+  border: 1px solid var(--line);
+  border-radius: var(--r-card);
+  overflow-x: auto;
+}
+.docs-code code { padding: 0; background: none; border: none; font-size: 13px; line-height: 22px; }
+
+.docs-note {
+  margin: 0 0 16px; padding: 12px 14px;
+  background: var(--card-soft);
+  border: 1px solid var(--line);
+  font-size: var(--fs-label); line-height: var(--lh-label);
+  color: var(--fg-muted);
+}
+
+.docs-next { margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--line); }
+.docs-next a { font-weight: 500; text-decoration: none; }
+
+/* Wide content scrolls inside its own box — the page never scrolls sideways. */
+.docs-table-wrap { margin: 0 0 16px; overflow-x: auto; border: 1px solid var(--line); }
+.docs-table { width: 100%; border-collapse: collapse; font-size: var(--fs-label); }
+.docs-table th, .docs-table td {
+  padding: 10px 12px; text-align: left; vertical-align: top;
+  border-bottom: 1px solid var(--line);
+}
+.docs-table th {
+  font-size: var(--fs-eyebrow); font-weight: 500; letter-spacing: 1.5px;
+  text-transform: uppercase; color: var(--fg-faint);
+  background: var(--card-soft);
+}
+.docs-table tr:last-child td { border-bottom: none; }
+
+/* ---- Live preview grid ---- */
+.docs-grid {
+  margin: 24px 0 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+}
+/* .tpl-card carries the frame and drives the TemplateThumb preview; this only
+   turns the card into a link without inheriting the article underline. */
+/* Beats `.docs-article a`, which is a class+type selector and therefore wins
+   against a bare class — measured: the card label came out underlined. */
+.docs-article a.docs-preset,
+.docs-article a.docs-preset:hover { text-decoration: none; }
+.docs-preset-id {
+  font-size: var(--fs-micro); line-height: 14px;
+  text-align: center; color: var(--fg-faint);
+  background: none; border: none; padding: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* ---- Live control gallery ----
+   Each block pairs the REAL control (mounted from the editor's own ControlRow)
+   with what it is for. The demo box reproduces the surface the Adjust panel
+   gives a control — panel background, one hairline, the panel's side padding —
+   so the control is shown in the context it actually lives in. */
+.docs-ctl-list { margin: 24px 0 8px; display: flex; flex-direction: column; }
+.docs-ctl { padding: 20px 0; border-top: 1px solid var(--line); }
+.docs-ctl:last-child { border-bottom: 1px solid var(--line); }
+
+.docs-ctl-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 14px; }
+.docs-ctl-head code {
+  font-size: var(--fs-label); font-weight: 500;
+  color: var(--inverse-fg); background: var(--inverse-bg);
+  border: none; border-radius: var(--r-chip); padding: 2px 7px;
+}
+.docs-ctl-head span { font-size: var(--fs-label); color: var(--fg); font-weight: 500; }
+
+.docs-ctl-body { display: grid; grid-template-columns: 280px minmax(0, 1fr); gap: 24px; align-items: start; }
+
+.docs-ctl-demo {
+  padding: 14px var(--pad-sect);
+  background: var(--card);
+  border: 1px solid var(--line);
+}
+
+.docs-ctl-side p { margin: 0 0 12px; font-size: var(--fs-label); line-height: var(--lh-label); color: var(--fg-muted); }
+
+.docs-ctl-readout { display: flex; flex-direction: column; gap: 4px; }
+.docs-ctl-readout span {
+  font-size: var(--fs-eyebrow); letter-spacing: 1.5px; text-transform: uppercase;
+  color: var(--fg-faint);
+}
+.docs-ctl-readout code {
+  font-size: 12px; padding: 6px 8px;
+  background: var(--card-inset); border: 1px solid var(--line);
+  color: var(--fg-body);
+  overflow-x: auto; white-space: nowrap;
+}
+
+@media (max-width: 919px) {
+  /* The shell keeps its viewport height here too, and .docs-main keeps its own
+     scroll — the same arrangement as the wide layout. Letting the document
+     scroll instead was a trap: the editor globals pin html/body to 100%, so a
+     7093px shell simply overflowed an 812px body and everything below the fold
+     became unreachable (measured: a block at 5109px would not move). */
+  /* No sticky needed any more: the shell is a viewport-tall grid, so the header
+     and the bar are simply rows that never move. */
+  .docs-header { gap: 14px; padding: 0 14px; }
+  .docs-header-nav { display: none; }
+  /* The whole brand stays now — wordmark and eyebrow. The menu button moved
+     down to its own bar, which freed the room the header did not have before;
+     measured, the brand ends at 146px and the buttons start at 252px. The name
+     may still shrink rather than push the row wider than the screen. */
+  .docs-brand { min-width: 0; }
+  .docs-brand-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .docs-header-end { gap: 2px; }
+  .docs-header-cta { padding: 0 10px; }
+  .docs-ctl-body { grid-template-columns: minmax(0, 1fr); gap: 14px; }
+}
+
+/* ---- The search trigger: looks like a field, opens the palette ---- */
+
+
+/* ---- h3, for pages that need a third level ---- */
+.docs-article h3 {
+  margin: 28px 0 10px;
+  font-size: var(--fs-label); line-height: var(--lh-label); font-weight: 600; color: var(--fg);
+}
+
+
+
+/* ============================================================
+   EASING — three stacked blocks: the demo, the adjuster, the
+   presets. Side by side they fought each other: measured, the
+   demo column came out 382px holding five widgets, and the
+   strobe marks were 26px wide at 18px apart, i.e. a smear.
+   One block per row, and the marks are thin ticks on a ruler
+   of their own so the square never sits on top of them.
+   ============================================================ */
+.docs-ez { margin: 24px 0 8px; display: flex; flex-direction: column; gap: 16px; }
+
+.docs-ez-block { border: 1px solid var(--line); background: var(--card); }
+.docs-ez-block-head {
+  display: flex; align-items: baseline; gap: 10px;
+  padding: 11px 16px; border-bottom: 1px solid var(--line);
+  background: var(--card-soft);
+}
+.docs-ez-block-head span { font-size: var(--fs-label); font-weight: 500; color: var(--fg); }
+.docs-ez-block-head em {
+  margin-left: auto; font-style: normal;
+  font-size: var(--fs-meta); color: var(--fg-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- the demo lane ---- */
+.docs-ez-lane { padding: 16px 16px 0; }
+.docs-ez-runway {
+  position: relative; height: 56px;
+  background: var(--card-inset); border: 1px solid var(--line);
+}
+.docs-ez-square {
+  position: absolute; top: 50%; width: 38px; height: 38px;
+  transform: translate(-50%, -50%);
+  background: var(--fg);
+}
+/* Thin ticks, on their own strip under the runway: 21 of them across ~610px is
+   ~30px apart at best, which a 2px mark can show and a 26px block cannot. */
+.docs-ez-ruler { position: relative; height: 26px; }
+.docs-ez-ruler i {
+  position: absolute; top: 4px; width: 2px; height: 14px;
+  transform: translateX(-50%);
+  background: var(--handle);
+  /* Semi-opaque on purpose: a curve that nearly stops (Glide, Expo Out) piles
+     several ticks within a pixel or two — measured 1px apart — and solid marks
+     would merge into one slab. Stacked, the overlap darkens, so density itself
+     reads as slowness instead of losing the information. */
+  opacity: 0.5;
+}
+
+.docs-ez-row { display: flex; align-items: flex-end; gap: 12px; padding: 4px 16px 0; }
+.docs-ez-play {
+  flex: 0 0 auto; height: var(--ctl-h); padding: 0 16px;
+  background: var(--inverse-bg); color: var(--inverse-fg);
+  border-radius: var(--r-ctrl);
+  font-size: var(--fs-ui); font-weight: 500;
+}
+.docs-ez-scrub { flex: 1; min-width: 0; }
+.docs-ez-note {
+  margin: 0; padding: 12px 16px 16px;
+  font-size: var(--fs-meta); line-height: 16.5px; color: var(--fg-muted);
+}
+
+/* ---- the adjuster ---- */
+.docs-ez-adjust {
+  display: grid; grid-template-columns: 200px minmax(0, 1fr); gap: 20px;
+  padding: 16px; align-items: start;
+}
+/* The widget inside is the editor's own .ez-editor / .ez-nums, which size
+   themselves to this column — nothing here restyles them. */
+.docs-ez-editor { display: flex; flex-direction: column; gap: 8px; }
+.docs-ez-adjust-side p {
+  margin: 0 0 12px;
+  font-size: var(--fs-label); line-height: var(--lh-label); color: var(--fg-muted);
+}
+.docs-ez-readout { display: flex; flex-direction: column; gap: 4px; }
+.docs-ez-readout span {
+  font-size: var(--fs-eyebrow); letter-spacing: 1.5px; text-transform: uppercase;
+  color: var(--fg-faint);
+}
+.docs-ez-readout code {
+  font-size: 12px; padding: 8px 10px;
+  background: var(--card-inset); border: 1px solid var(--line);
+  color: var(--fg-body); overflow-x: auto; white-space: nowrap;
+}
+
+/* ---- the presets ---- */
+.docs-ez-group { padding: 16px 16px 4px; }
+.docs-ez-group + .docs-ez-group { padding-top: 0; }
+.docs-ez-group:last-child { padding-bottom: 16px; }
+.docs-ez-group-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 10px; }
+.docs-ez-group-head span { font-size: var(--fs-label); font-weight: 500; color: var(--fg); }
+.docs-ez-group-head em { font-size: var(--fs-meta); font-style: normal; color: var(--fg-faint); }
+
+.docs-ez-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(92px, 1fr)); gap: 8px; }
+.docs-ez-card {
+  display: flex; flex-direction: column; gap: 6px; padding: 7px;
+  background: var(--card-soft); border: 1px solid var(--line);
+  transition: border-color var(--t-fast);
+}
+.docs-ez-card svg { display: block; width: 100%; aspect-ratio: 3 / 2; }
+.docs-ez-curve { fill: none; stroke: var(--fg-body); stroke-width: 1.6px; }
+.docs-ez-card span { font-size: var(--fs-micro); color: var(--fg-muted); text-align: center; }
+.docs-ez-card:hover { border-color: var(--handle); }
+.docs-ez-card.active { border-color: var(--fg); background: var(--card-inset); }
+.docs-ez-card.active span { color: var(--fg); }
+
+@media (max-width: 919px) {
+  .docs-ez-adjust { grid-template-columns: minmax(0, 1fr); }
+}
+
+/* ============================================================
+   MOCKUP PANELS — one block per panel, controls beside the
+   reason for them. In an auto-fill grid all six collapsed to a
+   single 450px column 2099px tall (Material and Lights 592px
+   each) with no explanation anywhere: a wall of sliders. The
+   prose column also uses up the space the short panels waste.
+   ============================================================ */
+.docs-mk { margin: 24px 0 8px; display: flex; flex-direction: column; gap: 14px; }
+
+.docs-mk-block { border: 1px solid var(--line); background: var(--card); }
+.docs-mk-block-head {
+  display: flex; align-items: baseline; gap: 10px;
+  padding: 11px 16px; border-bottom: 1px solid var(--line);
+  background: var(--card-soft);
+}
+.docs-mk-index {
+  font-size: var(--fs-micro); line-height: 1;
+  font-variant-numeric: tabular-nums; color: var(--fg-faint);
+  padding: 3px 5px; border: 1px solid var(--line); border-radius: var(--r-chip);
+}
+.docs-mk-name { font-size: var(--fs-label); font-weight: 500; color: var(--fg); }
+.docs-mk-block-head em {
+  margin-left: auto; font-style: normal;
+  font-size: var(--fs-meta); color: var(--fg-faint);
+}
+
+.docs-mk-body {
+  display: grid; grid-template-columns: 262px minmax(0, 1fr); gap: 20px;
+  padding: 16px; align-items: start;
+}
+/* The inset panel reproduces the surface the studio's own panel gives a
+   control: its background and its side padding. */
+.docs-mk-panel { background: var(--card-soft); border: 1px solid var(--line); }
+.docs-mk-rows {
+  padding: 14px var(--pad-sect);
+  display: flex; flex-direction: column; gap: var(--gap-row);
+}
+
+.docs-mk-side p {
+  margin: 0 0 12px;
+  font-size: var(--fs-label); line-height: var(--lh-label); color: var(--fg-muted);
+}
+.docs-mk-side p:last-child { margin-bottom: 0; }
+.docs-mk-side .docs-mk-governs { color: var(--fg); font-weight: 500; }
+
+@media (max-width: 919px) {
+  .docs-mk-body { grid-template-columns: minmax(0, 1fr); }
+}
+
+/* ---- "Was this page helpful?" — mounted by the layout, so every page has it ---- */
+.docs-feedback {
+  margin-top: 48px; padding-top: 20px;
+  border-top: 1px solid var(--line);
+  width: 100%; min-width: 0; box-sizing: border-box;
+  display: grid; grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center; gap: 12px;
+}
+.docs-feedback-q { font-size: var(--fs-label); color: var(--fg-muted); }
+.docs-feedback-actions { display: flex; gap: 8px; justify-self: end; }
+.docs-feedback-btn {
+  display: inline-flex; align-items: center; gap: 7px;
+  height: var(--ctl-h); padding: 0 14px;
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--r-ctrl);
+  font-size: var(--fs-ui); color: var(--fg-label);
+  transition: border-color var(--t-fast), color var(--t-fast), background var(--t-fast);
+}
+.docs-feedback-btn:hover { border-color: var(--handle); color: var(--fg); background: var(--card-inset); }
+.docs-feedback-btn svg { width: 15px; height: 15px; }
+.docs-feedback-undo {
+  justify-self: end;
+  font-size: var(--fs-meta); color: var(--fg-faint);
+  text-decoration: underline; text-underline-offset: 2px;
+}
+.docs-feedback-undo:hover { color: var(--fg-muted); }
+
+.docs-feedback-detail,
+.docs-idea {
+  grid-column: 1 / -1;
+  width: 100%; min-width: 0;
+}
+.docs-feedback-detail {
+  display: flex; flex-direction: column; gap: 8px;
+  padding-top: 4px;
+}
+.docs-feedback-detail label,
+.docs-idea label {
+  font-size: var(--fs-label); font-weight: 500; color: var(--fg);
+}
+.docs-feedback-detail textarea,
+.docs-idea input {
+  width: 100%; min-width: 0; box-sizing: border-box;
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+  background: var(--card-inset); color: var(--fg-body);
+  font: inherit; outline: none;
+}
+.docs-feedback-detail textarea {
+  min-height: 88px; padding: 10px 11px; resize: vertical; line-height: 1.5;
+}
+.docs-idea input { height: var(--ctl-h); padding: 0 10px; }
+.docs-feedback-detail textarea:focus,
+.docs-idea input:focus { border-color: var(--handle); }
+.docs-feedback-detail-actions {
+  display: flex; align-items: center; justify-content: flex-end; gap: 8px;
+}
+.docs-feedback-cancel,
+.docs-feedback-send,
+.docs-idea-row a {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-height: var(--ctl-h); padding: 0 12px;
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+  font-size: var(--fs-ui); text-decoration: none;
+}
+.docs-feedback-cancel { background: var(--card); color: var(--fg-muted); }
+.docs-feedback-send,
+.docs-idea-row a { background: var(--inverse-bg); color: var(--inverse-fg); }
+.docs-feedback-send.disabled,
+.docs-idea-row a.disabled { opacity: .38; pointer-events: none; }
+.docs-feedback-hint,
+.docs-idea p {
+  margin: 0; font-size: var(--fs-meta); line-height: 16px; color: var(--fg-faint);
+}
+.docs-idea {
+  margin-top: 8px; padding-top: 18px;
+  border-top: 1px solid var(--line);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.docs-idea-row {
+  display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px;
+}
+
+@media (max-width: 520px) {
+  .docs-idea-row { grid-template-columns: minmax(0, 1fr); }
+  .docs-idea-row a { width: 100%; box-sizing: border-box; }
+}
+
+/* ---- Narrow layout: the page list becomes a panel under the bar ---- */
+/* Above the breakpoint the sidebar is simply a column and the menu button does
+   not exist. Below it, the list hangs from the bar under the navbar. */
+.docs-menu-btn { display: none; }
+
+@media (max-width: 919px) {
+
+  .docs-body { grid-template-columns: minmax(0, 1fr); position: relative; }
+
+  .docs-nav {
+    position: fixed; z-index: 40;
+    /* A panel that drops out from under the navbar: it is anchored to the header,
+       so it reads as part of it rather than as a separate surface. */
+    top: 56px; left: 0; right: 0; bottom: auto;
+    width: auto; max-width: none; max-height: calc(100dvh - 56px);
+    background: var(--card);
+    border-right: none; border-bottom: 1px solid var(--line);
+    padding: 14px 0 20px;
+
+    transform: translateY(-100%);
+    transition: transform 180ms ease-out;
+  }
+  /* The state lives on the drawer itself, not on an ancestor: one class, one
+     element, nothing to out-specify. A closed drawer is also hidden from tab
+     order and from a screen reader, not merely pushed off-screen. */
+  .docs-nav { visibility: hidden; }
+  .docs-nav.is-open { transform: translateY(0); visibility: visible; }
+
+  /* Starts below the navbar, because the panel hangs from it — the header must
+     stay usable while the menu is open. */
+  .docs-scrim {
+    position: fixed; z-index: 39; inset: 56px 0 0 0;
+    background: var(--stage-shadow);
+    border: none;
+  }
+
+  .docs-article { padding: 32px 20px 64px; }
+  .docs-article h1 { font-size: 25px; line-height: 32px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-nav { transition: none; }
+}
+
+/* The drawer's own footer: the repository and any social links. Hidden above
+   the breakpoint, where the header already carries them. */
+.docs-nav-foot { display: none; }
+
+@media (max-width: 919px) {
+  /* Asked for explicitly: the repository does not need to sit at the top of a
+     phone screen. It moves into the sheet, where the rest of the navigation is. */
+  .docs-repo-link { display: none; }
+
+  .docs-nav-foot {
+    display: flex; flex-direction: column; gap: 2px;
+    margin: 14px 20px 0; padding-top: 12px;
+    border-top: 1px solid var(--line);
+  }
+  .docs-nav-foot a,
+  .docs-nav-foot button {
+    display: flex; align-items: center; gap: 9px;
+    width: 100%; background: none; border: none;
+    padding: 7px 0;
+    font-size: var(--fs-label); color: var(--fg-muted); text-decoration: none;
+  }
+  .docs-nav-foot a:hover,
+  .docs-nav-foot button:hover { color: var(--fg); }
+  .docs-nav-foot svg { width: 15px; height: 15px; flex: 0 0 auto; }
+}
+
+/* ============================================================
+   THE BAR UNDER THE NAVBAR (narrow only)
+   Menu button + search, and the page list drops out from under
+   this bar rather than from under the header. Above the
+   breakpoint it does not exist: the sidebar is a column and
+   carries its own search.
+   ============================================================ */
+.docs-subbar { display: none; }
+
+@media (max-width: 919px) {
+  .docs-subbar {
+    display: flex; align-items: center; gap: 10px;
+    height: var(--docs-subbar-h);
+    padding: 0 14px;
+    border-bottom: 1px solid var(--line);
+    background: var(--card);
+  }
+  /* The base rule sizes this for the sidebar (width: calc(100% - 40px), which
+     assumes 20px margins). In the bar it is a flex child, and leaving that width
+     in place made its basis wider than its share — measured, the row overflowed
+     by 94px at a 259px viewport. */
+  .docs-subbar .docs-searchbtn { flex: 1; min-width: 0; margin: 0; width: auto; }
+
+  .docs-menu-btn {
+    display: flex; align-items: center; gap: 7px;
+    flex: 0 0 auto; height: var(--ctl-h); padding: 0 11px;
+    background: var(--card-inset); border: 1px solid var(--line);
+    border-radius: var(--r-ctrl);
+    color: var(--fg-label);
+    font-size: var(--fs-ui); font-weight: 500;
+  }
+  .docs-menu-btn:hover { border-color: var(--handle); color: var(--fg); }
+  .docs-menu-btn svg { width: 15px; height: 15px; }
+
+  /* The sidebar's own search would be a second copy of the same field. */
+  /* The sidebar copy of the trigger would be a second button for one dialog. */
+  .docs-nav > .docs-searchbtn { display: none; }
+
+  /* The panel hangs from the bar, not from the header. */
+  .docs-nav { top: calc(56px + var(--docs-subbar-h)); max-height: calc(100dvh - 56px - var(--docs-subbar-h)); }
+  .docs-scrim { inset: calc(56px + var(--docs-subbar-h)) 0 0 0; }
+}
+
+/* ---- Search trigger ---- */
+.docs-searchbtn {
+  display: flex; align-items: center; gap: 9px;
+  width: calc(100% - 40px); margin: 0 20px 10px;
+  height: var(--ctl-h); padding: 0 8px 0 9px;
+  background: var(--card-inset);
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+  text-align: left;
+}
+.docs-searchbtn:hover { border-color: var(--handle); }
+.docs-searchbtn-ico { display: grid; place-items: center; color: var(--fg-faint); flex: 0 0 auto; }
+.docs-searchbtn-label {
+  flex: 1; min-width: 0;
+  font-size: var(--fs-ui); color: var(--fg-faint);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.docs-searchbtn-kbd {
+  flex: 0 0 auto; min-width: 34px; text-align: center;
+  font-family: inherit; font-size: var(--fs-micro); line-height: 1;
+  padding: 3px 5px; border: 1px solid var(--line); border-radius: var(--r-chip);
+  background: var(--card); color: var(--fg-faint);
+}
+
+/* ============================================================
+   COMMAND PALETTE — Ctrl/Cmd+K
+   Hand-rolled: see components/docs/DocsPalette.tsx for why not
+   a library. Centred over the page, one surface, so results are
+   never clipped by whatever container the trigger sits in.
+   ============================================================ */
+.docs-palette-layer { position: fixed; inset: 0; z-index: 60; }
+.docs-palette-scrim {
+  position: absolute; inset: 0;
+  background: var(--stage-shadow);
+  border: none;
+}
+.docs-palette {
+  position: absolute; left: 50%; top: 14vh;
+  transform: translateX(-50%);
+  width: min(560px, calc(100vw - 28px));
+  max-height: min(64vh, 520px);
+  display: flex; flex-direction: column;
+  background: var(--card);
+  border: 1px solid var(--line);
+  box-shadow: 0 18px 48px var(--stage-shadow);
+}
+
+.docs-palette-field {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 12px; height: 48px;
+  border-bottom: 1px solid var(--line);
+  flex: 0 0 auto;
+}
+.docs-palette-ico { display: grid; place-items: center; color: var(--fg-faint); }
+.docs-palette-input {
+  flex: 1; min-width: 0;
+  background: none; border: none; outline: none;
+  color: var(--fg-body); font-size: 15px;
+}
+.docs-palette-input::placeholder { color: var(--fg-faint); }
+.docs-palette-esc {
+  font-family: inherit; font-size: var(--fs-micro); line-height: 1;
+  padding: 3px 5px; border: 1px solid var(--line); border-radius: var(--r-chip);
+  color: var(--fg-faint);
+}
+
+.docs-palette-list { flex: 1; min-height: 0; overflow-y: auto; padding: 6px 0; }
+.docs-palette-empty { margin: 0; padding: 14px 14px; font-size: var(--fs-label); color: var(--fg-faint); }
+.docs-palette-group {
+  padding: 10px 14px 5px;
+  font-size: var(--fs-eyebrow); font-weight: 500; letter-spacing: 1.5px;
+  text-transform: uppercase; color: var(--fg-faint);
+}
+.docs-palette-hit {
+  width: 100%; display: flex; align-items: baseline; gap: 10px;
+  padding: 8px 14px; text-align: left;
+}
+/* The highlight is the cursor, so it must not depend on hover: arrowing down
+   moves it with the keyboard and the mouse never entered the row. */
+.docs-palette-hit.active { background: var(--card-inset); }
+.docs-palette-hit-title { flex: 1; font-size: var(--fs-label); color: var(--fg); }
+.docs-palette-hit-meta { font-size: var(--fs-micro); color: var(--fg-faint); }
+
+.docs-palette-foot {
+  display: flex; gap: 16px; flex: 0 0 auto;
+  padding: 9px 14px;
+  border-top: 1px solid var(--line);
+  background: var(--card-soft);
+  font-size: var(--fs-micro); color: var(--fg-faint);
+}
+.docs-palette-foot kbd {
+  font-family: inherit;
+  padding: 2px 4px; margin-right: 4px;
+  border: 1px solid var(--line); border-radius: var(--r-chip);
+  background: var(--card);
+}
+
+/* Idea form lives at the top-level chrome, opened from the navbar. It is not
+   page feedback: new feature requests and documentation improvements are a
+   separate GitHub issue flow. */
+.docs-idea-dialog {
+  position: absolute; left: 50%; top: 14vh; transform: translateX(-50%);
+  width: min(560px, calc(100vw - 28px));
+  padding: 18px;
+  background: var(--card); border: 1px solid var(--line);
+  box-shadow: 0 18px 48px var(--stage-shadow);
+}
+.docs-idea-dialog-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+  margin-bottom: 16px;
+}
+.docs-idea-dialog-head .docs-eyebrow { margin: 0 0 4px; }
+.docs-idea-dialog-head h2 { margin: 0; font-size: 20px; line-height: 26px; color: var(--fg); }
+.docs-idea-dialog-head button {
+  padding: 3px 6px; border: 1px solid var(--line);
+  color: var(--fg-faint); font-size: var(--fs-micro);
+}
+.docs-idea-dialog > label { display: block; margin-bottom: 7px; font-size: var(--fs-label); color: var(--fg); }
+.docs-idea-dialog textarea {
+  width: 100%; min-width: 0; min-height: 120px; box-sizing: border-box;
+  padding: 10px 11px; resize: vertical;
+  border: 1px solid var(--line); border-radius: var(--r-ctrl);
+  background: var(--card-inset); color: var(--fg-body);
+  font: inherit; line-height: 1.5; outline: none;
+}
+.docs-idea-dialog textarea:focus { border-color: var(--handle); }
+.docs-idea-dialog-foot {
+  display: flex; align-items: center; gap: 12px; margin-top: 12px;
+}
+.docs-idea-dialog-foot p { flex: 1; margin: 0; font-size: var(--fs-meta); color: var(--fg-faint); }
+.docs-idea-dialog-foot a {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-height: var(--ctl-h); padding: 0 13px;
+  background: var(--inverse-bg); color: var(--inverse-fg);
+  border-radius: var(--r-ctrl); text-decoration: none; font-size: var(--fs-ui);
+}
+.docs-idea-dialog-foot a.disabled { opacity: .38; pointer-events: none; }
+
+@media (max-width: 520px) {
+  .docs-idea-dialog { top: 8vh; padding: 16px; }
+  .docs-idea-dialog-foot { align-items: stretch; flex-direction: column; }
+  .docs-idea-dialog-foot a { width: 100%; box-sizing: border-box; }
+}
+
+@media (max-width: 919px) {
+  .docs-palette { top: 8vh; max-height: 74vh; }
+}
+
+/* Inline keys in prose (the shortcut tables and the mobile page). */
+.docs-article kbd {
+  font-family: inherit; font-size: var(--fs-micro); line-height: 1;
+  padding: 2px 5px;
+  border: 1px solid var(--line); border-radius: var(--r-chip);
+  background: var(--card-inset); color: var(--fg-body);
+}
+
+/* Narrower than any common phone (320px is the floor: SE is 375, small Androids
+   360). Down there the header cannot fit, so the two least urgent things go: the
+   editor button and the brand eyebrow. Measured at 259px, the header wanted
+   353px with both in place and 246px without them. Above 320 nothing is hidden —
+   at 375 the button had 64px of clearance, so cutting it there was pure loss. */
+@media (max-width: 319px) {
+  .docs-header-cta { display: none; }
+  .docs-brand-tag { display: none; }
+}

--- a/app/docs/easing/page.tsx
+++ b/app/docs/easing/page.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+import EasingGallery from '../_components/EasingGallery';
+import { EASING_PRESETS } from '@/lib/easing';
+
+export const metadata = { title: 'Easing' };
+
+export default function EasingPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">Changing it</p>
+      <h1>Easing</h1>
+
+      <p className="docs-lead">
+        Easing here does not move anything. Each motion runs on a cyclic phase, and the
+        curve reshapes that phase — the same path, walked at a different rate. That one
+        decision is why a curve can be dropped on any of the {EASING_PRESETS.length}{' '}
+        families without breaking it, and why swapping one never breaks a loop.
+      </p>
+
+      <h2>Scrub it and watch</h2>
+      <p>
+        Pick a curve, then drag the phase across two full cycles. The two dots are the raw
+        phase and the eased phase.
+      </p>
+
+      <EasingGallery />
+
+      <h2>Why the loop survives</h2>
+      <p>
+        The renderer reshapes a phase as <code>floor(p) + ease(frac(p))</code>. Whole
+        numbers are fixed points of that expression: at every integer the eased phase{' '}
+        <em>is</em> the raw phase. So a motion that was tuned to complete a whole number
+        of cycles per clip still completes them, on any curve, and frame 0 still equals the
+        last frame.
+      </p>
+      <p>
+        That is also the reason easing lives on the track rather than inside each template.
+        A template hands its raw phase to <code>ctx.easedPhase</code> and inherits whatever
+        curve the scene is on; it never needs to know which one.
+      </p>
+
+      <h2>Three groups, on purpose</h2>
+      <p>
+        <strong>Signature</strong> curves are the named ones most families ship with.{' '}
+        <strong>Standard</strong> is the in / out / in-out ladder, from Sine through Expo —
+        the same shapes CSS gives you, so they behave the way your eye already expects.{' '}
+        <strong>Physics</strong> is different in kind: Bounce, Spring, Wiggle and Overshoot
+        have no bezier handles at all and are sampled from real functions, which is why
+        their curves leave the unit box. A bounce that never passes its target is not a
+        bounce.
+      </p>
+      <p className="docs-note">
+        Practical consequence: the curve editor can only show handles for a bezier-backed
+        curve. Drag a handle on one of those and the scene stores{' '}
+        <code>{'{ id: \'custom\', bezier: [...] }'}</code> instead of a preset name. The
+        physics curves have nothing to drag.
+      </p>
+
+      <h2>Every family already ships one</h2>
+      <p>
+        A template declares its own default curve, and a preset can override it — because
+        for anything that steps per item the curve is what separates a glide from a settle.
+        So the honest way to read &ldquo;this preset feels wrong&rdquo; is usually: the
+        curve is right and the clip length is not, or the other way round. See{' '}
+        <Link href="/docs/library">The Library</Link> on why some presets pin the duration.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/new-motion">New motion →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/effects/page.tsx
+++ b/app/docs/effects/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { effectList } from '@/effects';
+
+export const metadata = { title: 'Effects' };
+
+export default function EffectsPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">How it works</p>
+      <h1>Effects</h1>
+
+      <p className="docs-lead">
+        The third seam. A template decides where the cards go, a track decides how they
+        composite, and an effect filters the result — an ordered stack over the rendered
+        scene rather than something applied per card.
+      </p>
+
+      <p className="docs-note">
+        Being straight about the state of it: {effectList.length === 1 ? 'one effect ships today' : `${effectList.length} effects ship today`} —{' '}
+        {effectList.map((e, i) => (
+          <span key={e.meta.id}>{i > 0 ? ', ' : ''}<strong>{e.meta.name}</strong></span>
+        ))}
+        . The panel and the contract are finished; the library behind them is not. That is
+        deliberate rather than abandoned: the pattern was proven with one effect before
+        filling a menu with them.
+      </p>
+
+      <h2>A stack, in order</h2>
+      <p>
+        Effects apply in the order you add them, over the whole frame. Order matters the
+        way it does in any filter chain — pixelate then blur is a soft mosaic, blur then
+        pixelate is mush.
+      </p>
+
+      <h2>Same self-declaring pattern as a template</h2>
+      <p>
+        An effect declares an id, a name, its own controls from the same{' '}
+        <Link href="/docs/controls/library">nine-type vocabulary</Link>, and one function
+        that builds the filter from those values. That is the whole file:
+      </p>
+      <pre className="docs-code"><code>{`export const pixelate: Effect = {
+  meta: { id: 'pixelate', name: 'Pixelate' },
+  controls: [
+    { key: 'size', label: 'Pixel Size', type: 'slider',
+      min: 1, max: 64, step: 1, default: 8 },
+  ],
+  createFilter: (v) => new PixelateFilter(v.size ?? 8),
+};`}</code></pre>
+      <p>
+        Register it in <code>effects/index.ts</code> and the panel row, its controls and
+        its defaults all follow — the same deal templates get, for the same reason.
+      </p>
+
+      <h2>Where they run</h2>
+      <p>
+        The stack is a 2D backend feature: it filters the rendered frame, so it applies to
+        the Library scene. The 3D sections have their own stylised passes, which live with
+        the scene rather than in this stack.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/mockup">The Mockup studio →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/export/page.tsx
+++ b/app/docs/export/page.tsx
@@ -1,0 +1,80 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Export' };
+
+export default function ExportPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">Getting started</p>
+      <h1>Export</h1>
+
+      <p className="docs-lead">
+        The default export path encodes in your browser from the same scene clock the
+        preview uses. Formats and maximum resolution depend on the codecs and memory
+        available on that device.
+      </p>
+
+      <h2>Formats</h2>
+      <div className="docs-table-wrap">
+        <table className="docs-table">
+          <thead>
+            <tr><th>Format</th><th>Encoder</th><th>Notes</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>MP4</strong></td>
+              <td>WebCodecs, H.264 High 5.1</td>
+              <td>Hardware encoder first. The default for anything going into another editor.</td>
+            </tr>
+            <tr>
+              <td><strong>WebM</strong></td>
+              <td>WebCodecs, VP9 profile 0</td>
+              <td>Often smaller at similar quality; browser encoding support and editor compatibility vary.</td>
+            </tr>
+            <tr>
+              <td><strong>GIF</strong></td>
+              <td>Per-frame 256-colour palette, Floyd&ndash;Steinberg dithering</td>
+              <td>A palette per frame, so gradients survive better than a GIF usually does.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2>Resolutions</h2>
+      <p>
+        720p, 1080p, 2K, 4K, or the exact pixel size of a custom canvas. The presets
+        are defined by the <strong>shortest</strong> edge, so a vertical 1080p is
+        1080&times;1920, not 1920&times;1080. Both 3D sections export through the same
+        dialog, because the 2D and 3D renderers implement one capture contract. A listed
+        size is an option, not a guarantee that every phone can encode it.
+      </p>
+
+      <h2>Why the loop does not pop</h2>
+      <p>
+        Every template quantizes its speed to a whole number of motion cycles per clip,
+        so the last frame lands exactly where the first one starts. Conveyor families go
+        further and match their period to the card count, so each image returns to its
+        own slot. A few presets are one-shot by design — a drop-and-bounce has nowhere
+        to loop back to — and those skip the rule rather than fake it.
+      </p>
+      <p>
+        This is also why some presets change the clip length when you pick them: their
+        cadence was measured in seconds per card, and at another duration the motion is
+        simply a different motion.
+      </p>
+
+      <h2>The server route is off by default</h2>
+      <p>
+        There is an optional ffmpeg route for deployments that want it. It ships
+        disabled, and it should stay that way on anything reachable from the internet
+        until it is behind authentication and a queue — it has no auth, no rate limit
+        and no cap on concurrent processes of its own. The browser path needs none of
+        it.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/controls/library">Library controls →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+import DocsChrome from './_components/DocsChrome';
+// docs.css usa ~20 tokens (--fg, --card, --fs-ui...) definidos pelo editor;
+// o alias @ aponta para ele, entao a folha vem da mesma fonte que os componentes.
+import '@/styles/tokens.css';
+// The galleries mount the editor's REAL components — ControlRow, TemplateThumb,
+// RotationBall, EasingCurveEditor — and every rule that makes those look like
+// controls (.strack, .sfill, .shandle, .ctl-row, .tpl-card, .ez-*) lives in the
+// editor's globals, not here. Without it they render as bare divs: measured,
+// .strack came out position:static, transparent, with no cursor.
+// Imported BEFORE docs.css so the docs sheet still wins where they overlap.
+import '@/app/globals.css';
+import './docs.css';
+
+export const metadata: Metadata = {
+  title: { default: 'Docs', template: '%s · Motion Studio docs' },
+  description: 'How to use Motion Studio: the motion catalogue, tracks, canvas and export.',
+};
+
+/**
+ * Its own route group, deliberately NOT inside (editor): the editor group's
+ * layout mounts EditorShell, which owns the Pixi and three contexts, the
+ * autosave loop and the whole store graph. Docs need none of that, and a reader
+ * should not pay for a WebGL context to read a page.
+ *
+ * The live previews still work here, because TemplateThumb renders the
+ * template's own transform as plain DOM.
+ */
+export default function DocsLayout({ children }: { children: React.ReactNode }) {
+  return <DocsChrome>{children}</DocsChrome>;
+}

--- a/app/docs/library/page.tsx
+++ b/app/docs/library/page.tsx
@@ -1,0 +1,128 @@
+import Link from 'next/link';
+import PresetSample from '../_components/PresetSample';
+import { catalogTemplateList, templateGroups } from '@/templates';
+
+export const metadata = { title: 'The Library' };
+
+export default function LibraryPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">How it works</p>
+      <h1>The Library</h1>
+
+      <p className="docs-lead">
+        The Library is the 2D side of the editor: your images, arranged and moved by
+        one piece of motion, on a canvas you frame. This page explains the pieces and
+        how they fit; the browsing itself belongs in the app, where there is search,
+        favourites and the real stage.
+      </p>
+
+      <h2>A preset is a function, not a recording</h2>
+      <p>
+        Every motion in the catalogue is a small pure function. It is handed a frame
+        number and a card index, and it answers where that card sits at that instant:
+        position, scale, rotation, transparency, depth. Nothing is baked and nothing is
+        pre-rendered.
+      </p>
+      <p>
+        Three things follow from that, and they are the reason the editor behaves the
+        way it does. The preview, the thumbnails and the exported file are all the same
+        function, so they cannot disagree. Any control can change while the clip plays,
+        because the next frame is simply computed again. And a preset works with 3
+        images or 300, because the count is an input, not a property of the motion.
+      </p>
+
+      <h2>Families and presets</h2>
+      <p>
+        A <strong>family</strong> is one idea — cards gliding past in a row, a ring you
+        can film from inside, a marquee band. A <strong>preset</strong> is that idea at
+        one set of values. The catalogue currently publishes{' '}
+        <strong>{catalogTemplateList.length} presets</strong> in{' '}
+        <strong>{templateGroups.length} families</strong>; both numbers are counted from
+        the registry when this page is built, so they cannot drift from the editor.
+      </p>
+      <p>
+        Picking a preset resets its controls to the values it was authored with. Some
+        families also set the clip length and the canvas shape, and that is not a
+        liberty — their motion was measured in seconds per card, so at another duration
+        it is a different motion, and their framing was authored against a specific
+        aspect.
+      </p>
+
+      <PresetSample ids={['carousel', 'orbit-3d-12', 'ticker-01', 'wipe-01', 'bloom-01', 'flip-01']} />
+      <p className="docs-note">
+        Six presets from six families, running here as an illustration. Hover one to
+        play it; click one to open it in the editor. The whole catalogue lives in the
+        editor&rsquo;s Templates panel.
+      </p>
+
+      <h2>The controls belong to the motion</h2>
+      <p>
+        A template declares its own controls, so what you see in the Adjust panel is
+        whatever that motion actually has — not a fixed set of sliders that some
+        families ignore. They are drawn from a small vocabulary: sliders, toggles,
+        pills, dropdowns, colours, an XY pad, an upload and a text field. Nothing else
+        is needed, and the limit is deliberate: a template cannot invent a control the
+        panel does not know how to render, so every motion stays fully editable by the
+        same UI.
+      </p>
+
+      <h2>Easing reshapes time, not position</h2>
+      <p>
+        Easing does not move cards. Each motion runs on a cyclic phase, and the easing
+        curve reshapes that phase — the same path, walked at a different rate. That is
+        why a curve can be swapped on any family without breaking it, and why the loop
+        survives the swap. There are 28 curves, from the standard families to physics
+        ones, plus a bezier you can drag yourself.
+      </p>
+
+      <h2>Some families count their own cards</h2>
+      <p>
+        Most motions place as many cards as you have images. The lattice families — a
+        woven gallery wall, an aligned grid — do the opposite: they derive how many
+        cells they need from the canvas, so the wall fills the frame instead of leaving
+        a gap when you supply six photos. Those cycle your images across the field, so
+        a small set can fill a large wall.
+      </p>
+
+      <h2>Why clips loop cleanly</h2>
+      <p>
+        Every template quantizes its speed to a whole number of motion cycles per clip,
+        so the last frame lands exactly where the first one starts. Conveyors go further
+        and match their period to the card count, so each image returns to its own slot.
+        A few presets are one-shot by design — something that drops and bounces has
+        nowhere to loop back to — and those skip the rule rather than fake it.
+      </p>
+
+      <h2>Sharing a starting point</h2>
+      <p>
+        Any preset is addressable: <code>/library?tpl=&lt;preset-id&gt;</code> opens the
+        editor with it already applied, exactly as clicking its card would. Useful for
+        handing a teammate the exact starting point instead of describing it. The id
+        appears under each card above.
+      </p>
+
+      <h2>Keep what you tuned</h2>
+      <p>
+        Two shelves sit above the catalogue, and both are yours rather than ours.
+      </p>
+      <p>
+        <strong>Favourites</strong> are a heart on any card: they collect into a shelf
+        pinned above the families, in the order you hearted them. A family withheld from
+        the catalogue keeps its hearts rather than losing them — bring it back and they are
+        still there.
+      </p>
+      <p>
+        <strong>Saved presets</strong> are the step after adjusting. The Custom tab holds
+        the value bundles you name and save, and applying one puts those values back
+        without touching anything else. It is the honest answer to &ldquo;I got this
+        right once&rdquo; — a preset is nothing but a set of defaults, so saving your own
+        is the same mechanism the shipped ones use.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/media">Media →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/media/page.tsx
+++ b/app/docs/media/page.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link';
+import { CARD_SHAPES } from '@/lib/crop';
+
+export const metadata = { title: 'Media' };
+
+export default function MediaPage() {
+  const shapes = Object.keys(CARD_SHAPES);
+
+  return (
+    <>
+      <p className="docs-eyebrow">How it works</p>
+      <h1>Media</h1>
+
+      <p className="docs-lead">
+        Your images and videos, and the slots a motion puts them in. Drop files into the
+        Media panel; the active motion takes them in order.
+      </p>
+
+      <h2>Order is meaning</h2>
+      <p>
+        A motion asks for layer <em>index</em> 0, 1, 2 — so the order of the list is the
+        order of the cards. Drag to reorder, and hide a card without deleting it when you
+        want to try the clip without it.
+      </p>
+      <p>
+        When a motion places more cards than you have files, it cycles the set across the
+        field rather than leaving gaps — which is how six photos fill a gallery wall of a
+        hundred cells.
+      </p>
+
+      <h2>Video is a live texture, not a still</h2>
+      <p>
+        A video card decodes into a texture that updates every frame, on both backends. It
+        plays inside the card while the card moves, and it is captured that way in the
+        export too.
+      </p>
+      <p>
+        A video shorter than the clip has to do something when it runs out, and that is a
+        choice: <strong>loop</strong> restarts it, <strong>hold</strong> freezes on its
+        final frame. The setting applies to the preview and the export identically, so
+        what you watched is what you get.
+      </p>
+
+      <h2>Card shape and the crop</h2>
+      <p>
+        Cards are not the shape of your files — they are the shape the scene asks for, and
+        your image is cropped to fill it. The scene-level choice is{' '}
+        <code>auto</code> plus {shapes.length} explicit ratios:{' '}
+        {shapes.map((s, i) => (
+          <span key={s}>{i > 0 ? ', ' : ''}<code>{s}</code></span>
+        ))}.
+      </p>
+      <p>
+        <strong><code>auto</code> is the one worth understanding.</strong> It defers to the
+        shape the template itself declares, falling back to a 4:5 portrait. That is why
+        picking one family gives you square cards and another gives you portrait ones
+        without you touching anything — and why the ported families set{' '}
+        <code>auto</code> on purpose: their presets each declare their own shape, and
+        pinning one ratio for the whole family came out wrong on most of them.
+      </p>
+      <p>
+        Full-bleed motions ignore all of it and crop to the canvas aspect instead. A
+        part-screen card in a full-bleed field would leave a gap, so the choice is not
+        offered.
+      </p>
+
+      <h2>Crop focus, per card</h2>
+      <p>
+        Cropping to a shape throws pixels away, and which pixels is your call. Each card
+        carries its own focus point — the middle by default — so a face near the top of a
+        landscape photo survives being squeezed into a portrait card. It is stored per
+        card, not per scene: one badly framed photo does not force a compromise on the
+        rest.
+      </p>
+
+      <h2>Your uploads survive a reload</h2>
+      <p>
+        Uploaded files are kept in the browser&rsquo;s own database, not as temporary links
+        that die when the tab closes. Reopen the project and your images come back with it.
+      </p>
+      <p className="docs-note">
+        Which also means they live in <em>that</em> browser, on <em>that</em> machine.
+        Nothing is uploaded anywhere — that is the point of the tool — so a project moved
+        to another computer needs its files again.
+      </p>
+
+      <h2>What the demo set is for</h2>
+      <p>
+        A new scene starts with a demo set so the catalogue previews are not empty
+        rectangles. They are marked as demo assets: replace them with your own and nothing
+        of yours is mixed in with them.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/canvas">Canvas →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/mobile/page.tsx
+++ b/app/docs/mobile/page.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'On a phone' };
+
+export default function MobilePage() {
+  return (
+    <>
+      <p className="docs-eyebrow">How it works</p>
+      <h1>On a phone</h1>
+
+      <p className="docs-lead">
+        Below 920px the editor swaps to a touch layout — not a squeezed version of the
+        desktop one, a different arrangement of the same scene. Everything renders and
+        exports the same; what changes is where the controls live.
+      </p>
+
+      <h2>Why 920px, and not a round number</h2>
+      <p>
+        The desktop layout is a five-column grid whose four fixed columns — the rail, the
+        templates panel and the two side panels — need 64 + 296 + 280 + 280 = 920px before
+        the stage gets any width at all. Below that the stage is what collapses, because it
+        is the flexible column: measured at 769px it was zero pixels wide and the canvas
+        rendered 0&times;525.
+      </p>
+      <p>
+        So the breakpoint is not a taste call about phones. It is the width at which the
+        desktop arrangement stops being able to show you your work.
+      </p>
+
+      <h2>The panels become a bottom bar</h2>
+      <p>
+        Five items across the bottom: <strong>Templates</strong>, <strong>Media</strong>,{' '}
+        <strong>Adjust</strong>, <strong>Canvas</strong> and <strong>Export</strong>. The
+        first four open the matching panel as a sheet over the stage; Export opens the same
+        export dialog the desktop uses.
+      </p>
+      <p>
+        A sheet carries its title and closes on <code>Escape</code> or on its own close
+        control, and the stage keeps playing behind it — so you can watch the effect of a
+        slider without dismissing the panel holding it.
+      </p>
+
+      <h2>Playback lives above the bar</h2>
+      <p>
+        A compact transport: play and pause, the current time, a scrubber, and the clip
+        length. The full timeline with its track lanes is a desktop surface — there is no
+        room to place a lane, a gutter and four per-lane actions on a phone and still leave
+        the stage visible.
+      </p>
+
+      <h2>Controls are built for a thumb</h2>
+      <div className="docs-table-wrap">
+        <table className="docs-table">
+          <thead><tr><th>Control</th><th>On touch</th></tr></thead>
+          <tbody>
+            <tr>
+              <td>Slider</td>
+              <td>A 52px track with a round handle instead of the 34px row and its 2px marker, and a value bubble above your finger while you drag — because your finger is covering the number.</td>
+            </tr>
+            <tr>
+              <td>Template cards</td>
+              <td>Previews play on their own. There is no hover to start them, so an observer keeps the cards on screen animating and the ones off screen at a still pose rather than animating a hundred at once.</td>
+            </tr>
+            <tr>
+              <td>Favourite heart</td>
+              <td>Always visible. On desktop it appears on hover, which does not exist here.</td>
+            </tr>
+            <tr>
+              <td>Pads and the trackball</td>
+              <td>Take the gesture directly and suppress the browser&rsquo;s own scroll and zoom while you are dragging inside them.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2>What the touch layout leaves out</h2>
+      <p>
+        <strong>Saved presets.</strong> The Templates sheet shows the catalogue only — the
+        Custom tab is a desktop surface. Your saved presets are not lost, they are simply
+        not reachable from a phone.
+      </p>
+      <p>
+        <strong>The track lanes.</strong> Stacking motion tracks is desktop work, for the
+        room reason above. A project with tracks still plays and exports correctly on a
+        phone; you just cannot rearrange them there.
+      </p>
+      <p className="docs-note">
+        Export itself is not one of the omissions. On a phone whose browser and hardware
+        expose the required WebCodecs encoder, the same export dialog writes the file on
+        the device. Available formats and maximum resolution still depend on that browser,
+        encoder and the memory the device can spare.
+      </p>
+
+      <h2>These docs, too</h2>
+      <p>
+        The same breakpoint applies to this site. A bar appears under the navbar carrying
+        the menu button and the search, the page list drops out from under that bar, and it
+        closes itself when you open a page. Search is the same palette either way —{' '}
+        <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>K</kbd> opens it from anywhere, on a phone
+        too if you have a keyboard attached.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/mockup">The Mockup studio →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/mockup/page.tsx
+++ b/app/docs/mockup/page.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'The Mockup studio' };
+
+export default function MockupPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">How it works</p>
+      <h1>The Mockup studio</h1>
+
+      <p className="docs-lead">
+        The Mockup studio is the other half of the editor: one screenshot or screen
+        recording of yours, put on a real 3D device, lit and filmed. Where the Library
+        moves many cards in 2D, this moves a camera around one object.
+      </p>
+
+      <h2>It is a real 3D scene</h2>
+      <p>
+        The device is an actual model with physically-based materials, standing in a
+        studio rig that lights it and gives its body and glass something to reflect. So
+        the highlights move when the camera moves, and the metal reads as metal. Nothing
+        here is a flat image with a perspective transform faked on top.
+      </p>
+
+      <h2>Seven devices in four slots</h2>
+      <div className="docs-table-wrap">
+        <table className="docs-table">
+          <thead>
+            <tr><th>Slot</th><th>Device</th><th>Finishes</th><th>Screen</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Phone</td><td>iPhone 17 Pro</td><td>3</td><td>1206 &times; 2622</td></tr>
+            <tr><td>Phone</td><td>iPhone Air</td><td>1</td><td>1260 &times; 2736</td></tr>
+            <tr><td>Laptop</td><td>MacBook Pro 14&quot;</td><td>2</td><td>3024 &times; 1964</td></tr>
+            <tr><td>Tablet</td><td>iPad Pro</td><td>2</td><td>2752 &times; 2064</td></tr>
+            <tr><td>Tablet</td><td>iPad Air</td><td>1</td><td>2732 &times; 2048</td></tr>
+            <tr><td>Display</td><td>Pro Display XDR</td><td>1</td><td>6016 &times; 3384</td></tr>
+            <tr><td>Display</td><td>Studio Display</td><td>1</td><td>5120 &times; 2880</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        The screen column is each panel&rsquo;s real native pixel count, and it is in the
+        UI for one practical reason: it tells you what size to capture your screenshot
+        at so it lands on the glass without resampling.
+      </p>
+
+      <h2>What goes on the screen</h2>
+      <p>
+        An image or a video — a video plays on the device as a live texture, not as a
+        still. It is fitted <strong>Cover</strong>, <strong>Fit width</strong> or{' '}
+        <strong>Contain</strong>, with zoom and position on top, so a tall screenshot on
+        a wide panel is your decision rather than a crop you inherit. A synthetic status
+        bar can be drawn over it — time, battery, signal — for when the capture came
+        without one, or came with the wrong one.
+      </p>
+
+      <h2>The animations drive the rig, not the device</h2>
+      <p>
+        There are <strong>16 animation presets</strong> in five groups: studio (4),
+        turntable (2), cinematic (5), dynamic (2) and product (3). What they animate is
+        the <em>rig</em> — the camera, the lighting, and on a laptop the lid — along a
+        keyframed pose timeline. The device itself mostly stays put; the shot is what
+        moves. Each preset previews in its own live 3D thumbnail, so you pick by looking
+        rather than by name.
+      </p>
+
+      <h2>A project is one document or the other</h2>
+      <p>
+        This matters more than it sounds. A project holds <em>either</em> a Library scene
+        or a Mockup studio, never both, and the two are separate shelves in the project
+        list. Entering a section opens that section&rsquo;s most recent project, or makes
+        one. The reason is blunt: with one project holding both, clicking a rail tab
+        would make it save a document you were not editing.
+      </p>
+      <p>
+        It autosaves, like the 2D scene does — within half a second of an edit. There is
+        a <strong>Save now</strong> in the project dock next to the save state, but it is
+        a reassurance, not the save path.
+      </p>
+
+      <h2>Export is the same dialog</h2>
+      <p>
+        Both 3D sections export through the same dialog as the Library, at the same
+        resolutions, because the 2D and 3D renderers implement one capture contract. See{' '}
+        <Link href="/docs/export">Export</Link>.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/tracks">Motion tracks →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/new-motion/page.tsx
+++ b/app/docs/new-motion/page.tsx
@@ -1,0 +1,132 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'New motion' };
+
+export default function NewMotionPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">Changing it</p>
+      <h1>New motion</h1>
+
+      <p className="docs-lead">
+        A new family is one file and one line in the registry. The codebase is built
+        around that seam on purpose: everything downstream — the panel, the thumbnail,
+        the timeline, the export — is generated from what the template declares, so
+        there is nothing else to wire up.
+      </p>
+
+      <h2>The contract</h2>
+      <p>
+        A template is a <code>meta</code> block, a list of <Link href="/docs/controls/library">controls</Link>,
+        and one function:
+      </p>
+      <pre className="docs-code"><code>{`transform(frame, index, count, values, ctx) -> pose`}</code></pre>
+      <p>
+        It is asked where layer <code>index</code> of <code>count</code> sits at{' '}
+        <code>frame</code>, and answers a pose: <code>x</code>, <code>y</code>,{' '}
+        <code>scale</code>, <code>rotation</code>, <code>alpha</code>,{' '}
+        <code>depth</code>. Canvas centre is <code>0,0</code>; rotation is radians;{' '}
+        <code>depth</code> is the sort order, higher drawn nearer.
+      </p>
+      <p>
+        <code>ctx</code> carries the frame it is living in — canvas size, fps, clip
+        length, the resolved card shape — plus the scene&rsquo;s easing as{' '}
+        <code>ease</code> and <code>easedPhase</code>.
+      </p>
+
+      <h2>Reach for the right pose field</h2>
+      <p>
+        Several of these look interchangeable and are not. Getting them wrong is the
+        most common way a new family looks subtly broken.
+      </p>
+      <div className="docs-table-wrap">
+        <table className="docs-table">
+          <thead><tr><th>Want</th><th>Use</th><th>Not</th></tr></thead>
+          <tbody>
+            <tr>
+              <td>A card is far away</td>
+              <td><code>dim</code> — it darkens toward black</td>
+              <td><code>alpha</code>, which makes it see-through so whatever it overlaps ghosts through and the field reads as broken glass</td>
+            </tr>
+            <tr>
+              <td>A card is genuinely arriving or leaving</td>
+              <td><code>alpha</code></td>
+              <td><code>dim</code></td>
+            </tr>
+            <tr>
+              <td>An edge uncovers a still image</td>
+              <td><code>clip</code> — the card does not move at all</td>
+              <td>Translating it (that slides) or scaling it (that distorts)</td>
+            </tr>
+            <tr>
+              <td>A card tilts out of the plane</td>
+              <td><code>taper</code>, drawn through a perspective mesh</td>
+              <td><code>skew</code> or <code>scale</code>, which keep opposite edges parallel and equal — no affine transform can say &ldquo;this edge turned away&rdquo;</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        <code>taper</code> is the expensive path, so use it only when a card really is
+        folding; everything else stays on the cheaper sprite path.
+      </p>
+
+      <h2>Stay pure</h2>
+      <ul className="docs-list">
+        <li>
+          Same inputs, same output, always. No <code>Math.random</code> — scattered
+          fields use a seeded hash of the index, so the scatter is stable across a
+          reload and identical in the preview and the export.
+        </li>
+        <li>
+          Read nothing outside <code>values</code> and <code>ctx</code>. No store, no
+          DOM, no clock.
+        </li>
+        <li>
+          No side effects. The function is called for every layer of every frame, by the
+          preview, the thumbnails and the encoder.
+        </li>
+      </ul>
+
+      <h2>Make it loop</h2>
+      <p>
+        Route your phase through <code>ctx.easedPhase</code> so the scene&rsquo;s easing
+        applies, and quantize speed with the loop helper so the clip holds a whole number
+        of motion cycles — that is what makes frame 0 identical to the last frame.
+        Conveyors pass their card count as the period so each image lands back on its own
+        slot. If your motion is genuinely one-shot, skip the helper rather than faking a
+        loop.
+      </p>
+
+      <h2>Register it</h2>
+      <p>
+        Add it to the registry in <code>templates/index.ts</code>. The sidebar group, the
+        control panel, the easing block, the live thumbnail and the export all pick it up
+        from there. Ship variations as preset bundles rather than as copies of the
+        transform.
+      </p>
+      <p>
+        Keep the id stable once it has shipped: ids are what saved projects reference.
+        Display names can change freely.
+      </p>
+
+      <h2>If it needs real perspective</h2>
+      <p>
+        Set the engine to the 3D backend and add a second pose function returning true 3D
+        positions and rotations, plus a camera. The 2D transform stays as the thumbnail
+        and fallback projection, so the catalogue card still previews correctly.
+      </p>
+
+      <h2>Before you call it done</h2>
+      <pre className="docs-code"><code>{`npm test          # invariants over every registered template
+npx tsc --noEmit  # the required check`}</code></pre>
+      <p>
+        The suites run without a browser and check that geometry is well formed and finite,
+        that the template holds in every canvas aspect and card shape, that its render
+        context is complete and its thumbnail stays inside budget. A family that breaks one
+        of those breaks it for the whole catalogue, which is why the check is cheap and
+        mandatory rather than a review comment.
+      </p>
+    </>
+  );
+}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Introduction' };
+
+export default function IntroductionPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">Getting started</p>
+      <h1>Introduction</h1>
+
+      <p className="docs-lead">
+        Motion Studio turns a folder of images into a short video, a GIF or a device
+        mockup. It runs on your own machine: nothing is uploaded, and the MP4 you download
+        was encoded by your own browser.
+      </p>
+
+      <h2>Two ways to work</h2>
+      <p>
+        The editor is one shell over several sections, and two of them are where the
+        work happens. <strong>The Library</strong> moves many images in 2D — cards on a
+        row, a ring, a wall — on a canvas you frame. <strong>The Mockup studio</strong>
+        {' '}does the opposite: one screenshot of yours on a real 3D device, lit and
+        filmed by a camera that moves.
+      </p>
+      <p>
+        They share the timeline, the export dialog and the project list, and they are
+        described one each in the pages below.
+      </p>
+
+      <h2>What these docs are for</h2>
+      <p>
+        They explain the concepts — what a preset actually is, what easing does, what a
+        track is, why clips loop cleanly, how the mockup rig is put together. They are
+        not a catalogue: the editor already is one, with search, favourites, live
+        thumbnails and the real stage. Read here, browse there.
+      </p>
+
+      <h2>Start here</h2>
+      <ul className="docs-list">
+        <li>
+          <Link href="/docs/quick-start">Quick start</Link> — from an empty project to
+          an exported clip.
+        </li>
+        <li>
+          <Link href="/docs/library">The Library</Link> — presets, controls, easing, and
+          why any of it can change mid-playback.
+        </li>
+        <li>
+          <Link href="/docs/mockup">The Mockup studio</Link> — devices, screens, and
+          what the animation presets actually animate.
+        </li>
+        <li>
+          <Link href="/docs/tracks">Motion tracks</Link> — stacking more than one motion
+          on the same clip.
+        </li>
+        <li>
+          <Link href="/docs/export">Export</Link> — formats, resolutions and the loop
+          rule.
+        </li>
+      </ul>
+
+      <h2>Changing it</h2>
+      <p>
+        The editor is meant to be edited. Three pages cover the seams most changes go
+        through — <Link href="/docs/controls/library">Controls</Link>, where a motion declares
+        its own panel; <Link href="/docs/design">Design and theming</Link>, where one
+        token sheet holds every colour and metric in the app; and{' '}
+        <Link href="/docs/new-motion">New motion</Link>, which is one file and one line
+        in the registry.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/quick-start">Quick start →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/quick-start/page.tsx
+++ b/app/docs/quick-start/page.tsx
@@ -1,0 +1,101 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Quick start' };
+
+export default function QuickStartPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">Getting started</p>
+      <h1>Quick start</h1>
+
+      <p className="docs-lead">
+        An exported clip in five steps. A new project opens empty on purpose — nothing
+        from the catalogue is in it until you choose something.
+      </p>
+
+      <h2>1. Run it</h2>
+      <pre className="docs-code"><code>{`npm install
+npm run dev          # → http://localhost:3000`}</code></pre>
+      <p>
+        That is the whole setup. Export runs in the browser, so there is no ffmpeg to
+        install and no key to configure.
+      </p>
+
+      <h2>2. Pick a motion</h2>
+      <p>
+        Open <strong>Templates</strong> in the left bar and choose a family, or go
+        through the preset cards on <Link href="/docs/library">The Library</Link> page and click a
+        card — it opens the editor with that preset already applied. Picking a preset
+        resets its controls to the values it was authored with, and some families also
+        pin the clip length and the canvas shape, because their motion was measured at
+        a specific cadence and only reads right there.
+      </p>
+
+      <h2>3. Bring your own images</h2>
+      <p>
+        Drop files into <strong>Media</strong>. Images and video both work — a video
+        card becomes a live texture, not a still. Drag to reorder, set a crop focus per
+        card, and pick a card shape (or leave it on <code>auto</code>, which defers to
+        whatever proportion the preset was built for).
+      </p>
+
+      <h2>4. Set the frame</h2>
+      <p>
+        <strong>Canvas</strong> holds the aspect — six presets from 3:4 to 16:9, plus
+        an exact pixel size — the safe-area guides, a logo slot, and the background,
+        which can be a colour, a gradient, an image, or the featured card reflected and
+        blurred behind itself.
+      </p>
+      <p>
+        <strong>Adjust</strong> is where the preset&rsquo;s own controls live, alongside
+        the easing curve. Every family ships with a default curve; the 28 presets cover
+        the standard families plus physics curves, and you can drag your own bezier.
+      </p>
+
+      <h2>5. Export</h2>
+      <p>
+        <strong>Export</strong> can write MP4, WebM or GIF at 720p up to 4K when the
+        browser and hardware expose the required encoder and enough memory. It captures
+        from the same scene clock the preview uses. See <Link href="/docs/export">Export</Link>{' '}
+        for format support, encoders and the loop rule.
+      </p>
+
+      <h2>Two things worth knowing early</h2>
+      <ul className="docs-list">
+        <li>
+          <strong>Undo covers gestures, not keystrokes.</strong> A whole drag, a typed
+          number or a template pick is one step back.
+        </li>
+        <li>
+          <strong>Projects autosave.</strong> Each one is its own storage key, written
+          within half a second of an edit. The Mockup studio saves the same way.
+        </li>
+      </ul>
+
+      <h2>The keys worth knowing</h2>
+      <div className="docs-table-wrap">
+        <table className="docs-table">
+          <thead><tr><th>Key</th><th>Does</th></tr></thead>
+          <tbody>
+            <tr><td><code>Ctrl</code>/<code>Cmd</code> + <code>K</code></td><td>Open the docs search palette. A bare <code>/</code> does the same.</td></tr>
+            <tr><td><code>Ctrl</code>/<code>Cmd</code> + <code>Z</code></td><td>Undo — one whole gesture at a time, not one pixel of a drag.</td></tr>
+            <tr><td><code>Ctrl</code>/<code>Cmd</code> + <code>Shift</code> + <code>Z</code>, or <code>Y</code></td><td>Redo.</td></tr>
+            <tr><td><code>Shift</code> while dragging a slider</td><td>Fine adjustment — a grid ten times finer than the step.</td></tr>
+            <tr><td>Arrow keys on a focused slider</td><td>Nudge by a step; with <code>Shift</code>, by a tenth.</td></tr>
+            <tr><td><code>Enter</code> on a focused slider</td><td>Open the typed field. <code>Escape</code> leaves without writing.</td></tr>
+            <tr><td>Double-click a slider</td><td>Back to the control&rsquo;s declared default.</td></tr>
+            <tr><td><code>Shift</code> while dragging an XY pad</td><td>Hold the line the drag is already on.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        Undo and redo are ignored while you are typing in a field, so the shortcut never
+        steals a keystroke from a number you are entering.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/library">The Library →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/timeline/page.tsx
+++ b/app/docs/timeline/page.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Timeline' };
+
+export default function TimelinePage() {
+  return (
+    <>
+      <p className="docs-eyebrow">How it works</p>
+      <h1>Timeline and playback</h1>
+
+      <p className="docs-lead">
+        One clock runs the whole scene. The preview reads it, the thumbnails read it, and
+        the encoder reads it — which is why the file you export is frame-for-frame the clip
+        you watched.
+      </p>
+
+      <h2>Frames, not seconds</h2>
+      <p>
+        The scene is a whole number of frames: the duration in seconds times the frame
+        rate. Everything downstream is asked for a frame index, never for a timestamp, so
+        there is no rounding drift between what plays and what encodes.
+      </p>
+      <p>
+        Changing the frame rate keeps the moment you were looking at rather than the frame
+        number, so the playhead does not jump to a different part of the clip when you go
+        from 30 to 60.
+      </p>
+
+      <h2>The ruler and the playhead</h2>
+      <p>
+        The ruler is labelled every two seconds with three ticks between, so a beat lands
+        on something you can see. Drag the playhead to scrub; the scene recomputes at that
+        frame rather than replaying up to it, so scrubbing backwards costs the same as
+        scrubbing forwards.
+      </p>
+
+      <h2>Duration is part of the motion</h2>
+      <p>
+        It is tempting to treat clip length as packaging, and for most families it is. For
+        the ported ones it is not: their cadence was authored in seconds per card, so the
+        duration is what pins how fast a card advances. Those presets set the length when
+        you pick them, and changing it afterwards genuinely changes the motion — a settle
+        becomes a drift.
+      </p>
+      <p>
+        This is also what makes loops clean. Speeds are quantised to a whole number of
+        motion cycles per clip, so the last frame lands exactly where the first one starts.
+        See <Link href="/docs/easing">Easing</Link> for why a curve cannot break that.
+      </p>
+
+      <h2>Lanes are tracks</h2>
+      <p>
+        Each lane below the ruler is a motion track with its own template, values and
+        window. The gutter beside a lane carries its visibility, its stacking, and the
+        duplicate and remove actions — and the selected lane is the one the control panel
+        is editing, which is the single most useful thing to keep an eye on when a slider
+        seems to do nothing.
+      </p>
+      <p>
+        A lane also carries a <strong>blend mode</strong>. The renderer draws one container
+        per track, in order, so a lane set to something other than normal composites
+        against the lanes beneath it rather than simply covering them — which is how a
+        light wash or a texture pass goes over a carousel without hiding it.
+      </p>
+      <p>
+        Tracks never keep their own clock. Each is handed the length of its own window, so
+        it loops inside that window, and a single track spanning the whole clip behaves
+        exactly like having no tracks at all. <Link href="/docs/tracks">Motion tracks</Link>{' '}
+        goes into it.
+      </p>
+
+      <h2>Undo covers gestures</h2>
+      <p>
+        A whole drag is one step back, not forty. So is a typed number and a template pick.
+        The history coalesces by gesture on purpose: undoing a slider drag one pixel at a
+        time is not undo, it is punishment.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/effects">Effects →</Link>
+      </p>
+    </>
+  );
+}

--- a/app/docs/tracks/page.tsx
+++ b/app/docs/tracks/page.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Motion tracks' };
+
+export default function TracksPage() {
+  return (
+    <>
+      <p className="docs-eyebrow">Getting started</p>
+      <h1>Motion tracks</h1>
+
+      <p className="docs-lead">
+        One preset is one motion. A track is how you get several in the same clip —
+        a ticker along the bottom while a carousel runs above it, say.
+      </p>
+
+      <h2>What a track holds</h2>
+      <p>
+        A track is a self-contained mini-clip. It carries its own template, its own
+        control values, its own easing curve, its own slice of the image list, a blend
+        mode, and a window on the timeline. The renderer draws one container per track,
+        in order, so tracks composite over each other the way layers do.
+      </p>
+
+      <h2>There is still only one clock</h2>
+      <p>
+        Tracks never keep their own time. Each one is handed the length of{' '}
+        <em>its window</em> as its total frame count, so it loops seamlessly inside
+        that window rather than against the whole clip. A single track spanning the
+        whole clip behaves exactly like having no tracks at all — that is a property
+        the project holds itself to, not a coincidence.
+      </p>
+
+      <h2>Where values live</h2>
+      <p>
+        The track is the source of truth for values and easing. Nothing writes those
+        into the scene directly — which matters if you are reading the code: reach for
+        the track, not the scene, when you want to know what a layer is doing.
+      </p>
+
+      <h2>Reusing a small image set across many cards</h2>
+      <p>
+        Some families place hundreds of cards — a woven gallery wall, a scatter field.
+        Those cycle a small image set across the whole field instead of demanding one
+        file per cell, so six photos can fill a wall.
+      </p>
+
+      <p className="docs-next">
+        <Link href="/docs/export">Export →</Link>
+      </p>
+    </>
+  );
+}

--- a/components/EditorIcons.tsx
+++ b/components/EditorIcons.tsx
@@ -393,6 +393,18 @@ export function FullscreenIcon(props: EditorIconProps) {
 // with a gap, which is what this was, reads as an arrow instead.
 // Isometric here is a second named perspective exception to rule 07: a
 // stack of planes is a depth concept the same way the 3D shelf is.
+// A page with text on it. Deliberately NOT a book: LibraryIcon is already three
+// standing spines, and two book glyphs one above the other in the same rail read
+// as the same button twice. This one is portrait and narrower than the square
+// icons (Canvas, Media, Mockup), so the silhouette alone separates it — the
+// arrangement does the work, not the detail, which is what survives at 20px.
+export function DocsIcon(props: EditorIconProps) {
+  return <svg {...iconProps(props)}>
+    <path d="M4.5 3h11v14h-11Z"/>
+    <path d="M7 7h6M7 10h6M7 13h3.5" opacity=".5"/>
+  </svg>;
+}
+
 export function LayersIcon(props: EditorIconProps) {
   return <svg {...iconProps(props)}>
     <path d="M10 4.5L17 8L10 11.5L3 8Z"/>

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -85,6 +85,8 @@ export default function ExportDialog({ onClose }: { onClose: () => void }) {
   const [saving, setSaving] = useState(false);
   const [savedTo, setSavedTo] = useState<string | null>(null);
   const [saveErr, setSaveErr] = useState('');
+  // Distinct from saveErr: not a failure, a nudge. See saveToFolder.
+  const [saveHint, setSaveHint] = useState('');
   const [confirmDemo, setConfirmDemo] = useState(false);
   // Probed after mount: WebCodecs is absent during SSR, and branching the first
   // render on it would desync hydration.
@@ -134,16 +136,43 @@ export default function ExportDialog({ onClose }: { onClose: () => void }) {
     return resp.blob();
   };
 
+  // Ask once per file instead of once for a folder. This path never touches a
+  // directory handle, so the blocklist below cannot reach it — which is why it
+  // is offered as its own button rather than only as a fallback.
+  const saveEachFile = async () => {
+    for (const file of outputs) {
+      const handle = await window.showSaveFilePicker({ suggestedName: file.name });
+      const writable = await handle.createWritable();
+      await writable.write(await fileBytes(file));
+      await writable.close();
+    }
+    setSavedTo(outputs.map((o) => o.name).join(', '));
+  };
+
   // Copy the freshly-encoded files into a folder the user picks. Folder-level
   // write permission is often denied (the browser's "save changes" prompt, or
   // Windows/OneDrive controlled-folder protection) — when that happens, fall
   // back to a per-file "Save as" dialog, which needs no folder permission.
   const saveToFolder = async () => {
     setSaveErr('');
+    setSaveHint('');
     setSaving(true);
     try {
       try {
-        const dir = await window.showDirectoryPicker({ id: 'motion-exports', mode: 'readwrite' });
+        // startIn matters. The browser keeps a blocklist of directories this API
+        // refuses — drive roots, Windows and Program Files, the macOS Library,
+        // and the user's HOME ROOT, which on Windows is where the picker lands
+        // with no startIn. Picking one of those shows the browser's own
+        // "contains system files" dialog and leaves the picker open; the way out
+        // is Cancel, and the call then rejects with AbortError — the SAME error
+        // a plain cancel gives, so the two cannot be told apart afterwards.
+        // Hence both halves of this fix: open somewhere always-allowed, and make
+        // the AbortError branch say what might have happened.
+        const dir = await window.showDirectoryPicker({
+          id: 'motion-exports',
+          mode: 'readwrite',
+          startIn: 'downloads',
+        });
         for (const file of outputs) {
           const handle = await dir.getFileHandle(file.name, { create: true });
           const writable = await handle.createWritable();
@@ -153,19 +182,35 @@ export default function ExportDialog({ onClose }: { onClose: () => void }) {
         setSavedTo(dir.name);
         return;
       } catch (e: any) {
-        if (e?.name === 'AbortError') return; // user cancelled the picker
+        if (e?.name === 'AbortError') {
+          // Cancelling and being refused arrive here as the same error, so this
+          // has to cover both without accusing the user of either. Saying it
+          // costs a line and turns a dead end into a next step; the silent
+          // `return` that used to be here is what made this look broken.
+          setSaveHint('Nothing was saved. If the browser said the folder contains system files: drive roots, Windows, Program Files and your user folder itself are off limits to it — pick a folder inside one of those, or save the files one by one.');
+          return;
+        }
         if (e?.name !== 'NotAllowedError' && e?.name !== 'SecurityError') throw e;
         // fall through — write access to the folder was denied
       }
-      for (const file of outputs) {
-        const handle = await window.showSaveFilePicker({ suggestedName: file.name });
-        const writable = await handle.createWritable();
-        await writable.write(await fileBytes(file));
-        await writable.close();
-      }
-      setSavedTo(outputs.map((o) => o.name).join(', '));
+      await saveEachFile();
     } catch (e: any) {
       if (e?.name !== 'AbortError') setSaveErr(String(e?.message ?? e)); // ignore user cancel
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // The same per-file path, reachable directly rather than only after a folder
+  // save has already failed.
+  const saveFilesOnly = async () => {
+    setSaveErr('');
+    setSaveHint('');
+    setSaving(true);
+    try {
+      await saveEachFile();
+    } catch (e: any) {
+      if (e?.name !== 'AbortError') setSaveErr(String(e?.message ?? e));
     } finally {
       setSaving(false);
     }
@@ -490,7 +535,14 @@ npm run dev`}</code></pre>
                     <button className="btn primary full" onClick={saveToFolder} disabled={saving}>
                       {saving ? 'Saving…' : savedTo ? 'Save to another folder…' : 'Choose folder & save'}
                     </button>
+                    {/* Second, not hidden: this one asks per file and never
+                        takes a directory handle, so it works in the places the
+                        folder picker refuses. */}
+                    <button className="btn full" onClick={saveFilesOnly} disabled={saving}>
+                      {outputs.length > 1 ? 'Save files one by one…' : 'Save file…'}
+                    </button>
                     {savedTo && <p className="ctl-hint">Saved to <code>{savedTo}</code>.</p>}
+                    {saveHint && <p className="ctl-hint">{saveHint}</p>}
                     {saveErr && <div className="export-error">Save failed: {saveErr}</div>}
                   </>
                 )}

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -87,6 +87,10 @@ export default function ExportDialog({ onClose }: { onClose: () => void }) {
   const [saveErr, setSaveErr] = useState('');
   // Distinct from saveErr: not a failure, a nudge. See saveToFolder.
   const [saveHint, setSaveHint] = useState('');
+  // Set once a folder attempt has come back with nothing. The retry then omits
+  // the picker's `id`, which is the only way to stop a remembered directory
+  // overriding startIn — see saveToFolder.
+  const [pickerIgnoresMemory, setPickerIgnoresMemory] = useState(false);
   const [confirmDemo, setConfirmDemo] = useState(false);
   // Probed after mount: WebCodecs is absent during SSR, and branching the first
   // render on it would desync hydration.
@@ -159,17 +163,26 @@ export default function ExportDialog({ onClose }: { onClose: () => void }) {
     setSaving(true);
     try {
       try {
-        // startIn matters. The browser keeps a blocklist of directories this API
-        // refuses — drive roots, Windows and Program Files, the macOS Library,
-        // and the user's HOME ROOT, which on Windows is where the picker lands
-        // with no startIn. Picking one of those shows the browser's own
-        // "contains system files" dialog and leaves the picker open; the way out
-        // is Cancel, and the call then rejects with AbortError — the SAME error
+        // The browser keeps a blocklist of directories this API refuses — drive
+        // roots, Windows and Program Files, the macOS Library, and the user's
+        // HOME ROOT. Picking one shows the browser's own "contains system files"
+        // dialog, and backing out of it rejects with AbortError: the SAME error
         // a plain cancel gives, so the two cannot be told apart afterwards.
-        // Hence both halves of this fix: open somewhere always-allowed, and make
-        // the AbortError branch say what might have happened.
+        //
+        // `startIn` alone does not prevent it. Per the spec, when `startIn` is a
+        // well-known directory it is only a FALLBACK: "If there is an existing
+        // mapping from the given ID to a path, this mapping is used. Otherwise,
+        // the path suggested via the WellKnownDirectory is used." So `id` wins,
+        // and a browser that remembers somewhere unusable keeps reopening there
+        // no matter what startIn says. Adding startIn while keeping id — which
+        // is what the first fix did — helps only a first-time user.
+        //
+        // Dropping `id` removes the mapping from the equation and lets startIn
+        // decide. That also forgets the last folder, which is worth keeping, so
+        // it is not dropped up front: the first attempt remembers, and an
+        // attempt that came back empty-handed retries without it.
         const dir = await window.showDirectoryPicker({
-          id: 'motion-exports',
+          ...(pickerIgnoresMemory ? {} : { id: 'motion-exports' }),
           mode: 'readwrite',
           startIn: 'downloads',
         });
@@ -184,10 +197,14 @@ export default function ExportDialog({ onClose }: { onClose: () => void }) {
       } catch (e: any) {
         if (e?.name === 'AbortError') {
           // Cancelling and being refused arrive here as the same error, so this
-          // has to cover both without accusing the user of either. Saying it
-          // costs a line and turns a dead end into a next step; the silent
-          // `return` that used to be here is what made this look broken.
-          setSaveHint('Nothing was saved. If the browser said the folder contains system files: drive roots, Windows, Program Files and your user folder itself are off limits to it — pick a folder inside one of those, or save the files one by one.');
+          // has to cover both without accusing the user of either, and it has to
+          // name the button that always works rather than describe a rule.
+          setPickerIgnoresMemory(true);
+          // The label below changes with the file count, so point at the button
+          // by position rather than by a name that might not match it.
+          setSaveHint(pickerIgnoresMemory
+            ? 'Still nothing saved. Use the button below instead — it asks per file, never asks for a folder, and is not subject to the directories the browser holds back.'
+            : 'Nothing was saved. Some folders are off limits to the browser — drive roots, Windows, Program Files and your user folder itself. Trying the folder again will now start from Downloads; the button below always works.');
           return;
         }
         if (e?.name !== 'NotAllowedError' && e?.name !== 'SecurityError') throw e;
@@ -532,14 +549,24 @@ npm run dev`}</code></pre>
                 </ul>
                 {canPickDir && (
                   <>
-                    <button className="btn primary full" onClick={saveToFolder} disabled={saving}>
-                      {saving ? 'Saving…' : savedTo ? 'Save to another folder…' : 'Choose folder & save'}
-                    </button>
-                    {/* Second, not hidden: this one asks per file and never
-                        takes a directory handle, so it works in the places the
-                        folder picker refuses. */}
-                    <button className="btn full" onClick={saveFilesOnly} disabled={saving}>
-                      {outputs.length > 1 ? 'Save files one by one…' : 'Save file…'}
+                    {/* One file is the normal case — every in-browser export
+                        produces exactly one. For that, picking a FOLDER buys
+                        nothing: it is the same single dialog as saving the file,
+                        and it is the one the browser refuses over its blocked
+                        directories. So the folder route only appears when there
+                        is actually more than one file to place, which is the
+                        only time it saves the user a dialog. */}
+                    {outputs.length > 1 && (
+                      <button className="btn primary full" onClick={saveToFolder} disabled={saving}>
+                        {saving ? 'Saving…' : savedTo ? 'Save to another folder…' : 'Choose folder & save'}
+                      </button>
+                    )}
+                    <button
+                      className={`btn full ${outputs.length > 1 ? '' : 'primary'}`}
+                      onClick={saveFilesOnly}
+                      disabled={saving}
+                    >
+                      {saving ? 'Saving…' : outputs.length > 1 ? 'Save files one by one…' : 'Save file…'}
                     </button>
                     {savedTo && <p className="ctl-hint">Saved to <code>{savedTo}</code>.</p>}
                     {saveHint && <p className="ctl-hint">{saveHint}</p>}

--- a/components/IconRail.tsx
+++ b/components/IconRail.tsx
@@ -12,7 +12,7 @@ import { preloadMockupProject } from '@/lib/mockupPreload';
 import { IS_HOSTED_DEPLOYMENT } from '@/lib/deployment';
 import NewsNotifier from './NewsNotifier';
 import UpdateNotifier from './UpdateNotifier';
-import { AddIcon, BoardIcon, ChevronDownIcon, ExperimentalsIcon, LibraryIcon, MockupIcon, ProjectsIcon, ThemeGlyph, ThreeDIcon, WebIcon } from './EditorIcons';
+import { AddIcon, BoardIcon, ChevronDownIcon, DocsIcon, ExperimentalsIcon, LibraryIcon, MockupIcon, ProjectsIcon, ThemeGlyph, ThreeDIcon, WebIcon } from './EditorIcons';
 
 const ICONS: Record<NavSectionId, React.ReactNode> = {
   projects: <ProjectsIcon />,
@@ -140,6 +140,16 @@ export default function IconRail() {
       </div>
       <div className="rail-bottom">
         {IS_HOSTED_DEPLOYMENT ? <NewsNotifier /> : <UpdateNotifier />}
+        {/* /docs sits outside the (editor) route group and does NOT mount
+            EditorShell, so opening it drops the Pixi and three contexts instead
+            of keeping a second set alive behind a reader. It is therefore not a
+            section — it stays out of NAV_SECTIONS — and it takes no active
+            state: the docs bring their own chrome, so this rail is not even on
+            screen while you are reading them. */}
+        <Link href="/docs" className="rail-item" title="Documentation">
+          <span className="rail-ico"><DocsIcon /></span>
+          <span className="rail-label">Docs</span>
+        </Link>
         <button
           className="rail-item rail-theme"
           onClick={toggleTheme}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Motion Studio — an open-source factory for quick videos and GIFs.",
   "main": "index.js",
   "scripts": {
-    "test": "node scripts/verify-tilt.cjs && node scripts/verify-catalogue.cjs && node scripts/verify-contexts.cjs && node scripts/verify-reference.cjs && node scripts/verify-effects.cjs && node scripts/verify-gradients.cjs",
+    "test": "node scripts/verify-tilt.cjs && node scripts/verify-catalogue.cjs && node scripts/verify-contexts.cjs && node scripts/verify-reference.cjs && node scripts/verify-effects.cjs && node scripts/verify-gradients.cjs && node scripts/verify-docs-routes.cjs",
     "dev": "next dev",
     "dev:network": "next dev -H 0.0.0.0",
     "build": "next build",

--- a/scripts/verify-docs-routes.cjs
+++ b/scripts/verify-docs-routes.cjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// ============================================================
+//  verify-docs-routes — every link in the docs sidebar must have a page
+//
+//  The sidebar is a hand-written list (app/docs/_lib/docsNav.ts) and the pages
+//  are folders on disk. Nothing connects the two, so a renamed folder or a
+//  section added to the nav before its page exists gives a link that 404s —
+//  and nothing else in the build notices, because Next resolves routes at
+//  request time.
+//
+//  This is the check that would have caught the mistake made while moving the
+//  docs into the editor: /docs/controls looks like a page in the tree, but it
+//  is only a folder — the pages are /docs/controls/library and .../mockup.
+//
+//  Usage: node scripts/verify-docs-routes.cjs
+// ============================================================
+
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+require('sucrase/register');
+const root = path.resolve(__dirname, '..');
+const originalResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (request.startsWith('@/')) request = path.join(root, request.slice(2));
+  return originalResolve.call(this, request, parent, isMain, options);
+};
+
+const { DOCS_SECTIONS } = require('../app/docs/_lib/docsNav');
+
+const DOCS_DIR = path.join(root, 'app', 'docs');
+
+let assertions = 0;
+const failures = [];
+function check(ok, message) {
+  assertions++;
+  if (!ok) failures.push(message);
+}
+
+// ---------- every nav href resolves to a page.tsx ----------
+const linked = new Set();
+for (const section of DOCS_SECTIONS) {
+  check(section.links.length > 0, `section "${section.title}" has no links`);
+  for (const link of section.links) {
+    check(link.href === '/docs' || link.href.startsWith('/docs/'),
+      `"${link.label}" points outside the docs: ${link.href}`);
+    const rel = link.href.replace(/^\/docs\/?/, '');
+    const file = path.join(DOCS_DIR, rel, 'page.tsx');
+    check(fs.existsSync(file),
+      `"${link.label}" (${link.href}) has no page — expected ${path.relative(root, file)}`);
+    check(!linked.has(link.href), `${link.href} is listed twice in the sidebar`);
+    linked.add(link.href);
+  }
+}
+
+// ---------- and every page on disk is reachable from the sidebar ----------
+// The other direction matters too: a page nobody links to is a page nobody
+// reads, and the docs have no search of their own to fall back on.
+function walk(dir, prefix) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith('_')) continue;
+    const next = path.join(dir, entry.name);
+    const href = `${prefix}/${entry.name}`;
+    if (fs.existsSync(path.join(next, 'page.tsx'))) {
+      check(linked.has(href), `${href} exists on disk but no sidebar link reaches it`);
+    }
+    walk(next, href);
+  }
+}
+check(fs.existsSync(path.join(DOCS_DIR, 'page.tsx')), 'the docs index page is missing');
+walk(DOCS_DIR, '/docs');
+
+if (failures.length) {
+  console.error(`\nDocs route verification FAILED — ${failures.length} problem(s):\n`);
+  for (const f of failures) console.error(`  ${f}`);
+  process.exit(1);
+}
+
+console.log(`Docs route verification passed (${assertions} assertions; ${linked.size} pages, sidebar and disk agree).`);

--- a/types/file-system-access.d.ts
+++ b/types/file-system-access.d.ts
@@ -1,0 +1,31 @@
+export {};
+
+// @types/wicg-file-system-access declares `interface DirectoryPickerOptions {}`
+// — empty. TypeScript's excess-property check has nothing to check against, so
+// every option passed to showDirectoryPicker is accepted, including a typo. The
+// browser then silently ignores the unknown key and the call still resolves, so
+// the mistake reaches production looking like it worked.
+//
+// That is not hypothetical here: the export dialog already passed `mode` and
+// `id` unvalidated, and the fix for the blocked-folder bug turns on the exact
+// spelling of `startIn`. Declaration merging fills the interface in, so a
+// mistyped option is a build error instead of a shrug.
+//
+// Values follow the spec's well-known directories:
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker
+declare global {
+  type WellKnownDirectory = 'desktop' | 'documents' | 'downloads' | 'music' | 'pictures' | 'videos';
+
+  interface DirectoryPickerOptions {
+    /** Lets the browser remember a directory per picker. */
+    id?: string;
+    /** Defaults to 'read'; writing into the folder needs 'readwrite'. */
+    mode?: FileSystemPermissionMode;
+    /**
+     * Where the dialog opens. A directory remembered under `id` takes
+     * precedence, so this steers the first pick — which is the one that lands
+     * on a blocked location when it is left out.
+     */
+    startIn?: WellKnownDirectory | FileSystemHandle;
+  }
+}


### PR DESCRIPTION
Four merged changes, in one piece: the unfinished sections are closed in a built
app, the documentation moves into the editor and gets a way in, and the export
dialog's "save" stops failing on folders the browser refuses to open.

**43 files, +4,305 / −30.** Two suites join `npm test`, which goes from 6 to 8 and
gains 107 assertions — both of them written to fail on the specific mistake they
guard against, and proved to do so before being committed.

---

## 1. The unfinished sections are closed in a built app

3D, Web and Boards ship in the repository without being finished. A built app now
closes all three; development leaves them open so the work can carry on.

**The gate is on the route, not the button.** Every `page.tsx` under `app/(editor)`
returns `null` — `EditorShell` picks its stage from `sectionFromPathname` — so
dropping the rail buttons alone would have left `/web` reachable to anyone who
typed it. `sectionFromPathname` now answers `DEFAULT_SECTION` for a gated
section, which is what actually shuts the door.

The buttons stay on screen, greyed and inert: the work exists, and saying so is
honest. A gated item renders as an `aria-disabled` `<span>`, not a `Link` — a
Link would navigate, the route gate would send the reader to the Library, and
that reads as a bug rather than as "not yet".

`EXPERIMENTS_ENABLED` lives in `lib/deployment.ts` next to the deployment mode:

| Context | Sections |
|---|---|
| `next build` | closed |
| `next dev` | open |
| `NEXT_PUBLIC_EXPERIMENTS=1` / `=0` | wins over both |

So a build with them switched on needs an env value, not a code edit.

**Known cost, stated rather than discovered later:** gating Boards takes the React
component export with it. `BoardExportBar` is the only caller of
`downloadSceneZip`, and `DesktopEditor` only mounts it while the board section is
active, so a built app has no route to the zip. This is a decision, not an
oversight — `lib/exportScene.ts` packs `boardPose`/`boardCompose` and emits a
*board*, not a generic scene, so the export needs a home outside Boards before it
can come back. `verify-gated-sections` asserts the cost so it cannot be quietly
forgotten.

`scripts/verify-gated-sections.cjs` (39 assertions) drives `sectionFromPathname`
from the outside across four environments, and requires `experimental` and gated
to agree across the whole list so a section added later without `gated` cannot
ship inside the drawer. It was proved to fail on the obvious half-fix — the route
gate removed while the rail filter stays:

```
Gated-section verification FAILED — 2 problem(s):
  /3d must resolve to the default section, not to 3d — the route is the door
  /web must resolve to the default section, not to web — the route is the door
```

## 2. The documentation now ships with the editor

The docs lived in the landing app and were reachable from nowhere in the product:
`SITE_CONFIG.docsUrl` still pointed at the GitHub README, so there was no
published docs URL for a button to open. They now live at `/docs`, with a **Docs**
item in the rail directly under Updates.

**This is a move, not a port.** The pages already imported the editor's own
modules — `@/components/Controls`, `@/templates`, `@/lib/easing`, `@/effects`,
`@/store/useSceneStore`, `@/three3d/mockupControls` — which the landing resolved
through a `vendor/` alias; here they resolve natively. `app/docs/layout.tsx` was
already written for this home: it imports `@/styles/tokens.css` and
`@/app/globals.css`, and its own comment says it belongs *outside* the `(editor)`
route group. It still does, so reading a page mounts no `EditorShell` and pays for
no Pixi or three context.

Two links changed meaning. In the landing they crossed an origin and opened a tab;
here the editor **is** this app, so "Open the editor" and the preset cards become
in-app `<Link>`s — which also carry the deploy `basePath` that a raw `href` drops
on the subpath build. That removed the only imports reaching outside the editor.

`DocsIcon` follows the one icon spec: optical box on the 20-grid, no radius, two
opacity levels. A page with text, deliberately **not** a book — `LibraryIcon` is
already three standing spines, and two book glyphs in one rail read as the same
button twice.

`scripts/verify-docs-routes.cjs` (68 assertions) checks both directions: every
sidebar link has a `page.tsx`, and every page on disk is reachable from the
sidebar — a page nobody links to is a page nobody reads, and the docs have no
search of their own to fall back on. Proved to fail by moving
`app/docs/effects/page.tsx` aside. It also catches the mistake made during the
move itself: `/docs/controls` looks like a page in the tree but is only a folder,
the pages being `/docs/controls/library` and `.../mockup`.

**Known debt:** the landing keeps its copy, so there are two to keep in step. The
suite guards structure, not prose.

## 3. Saving an export stopped working on most folders

"Choose folder & save" called `showDirectoryPicker` with no `startIn`. With no
folder yet remembered for its `id`, the dialog lands on the user's home root on
Windows — which is on the browser's blocklist for this API, along with drive
roots, Windows, Program Files and the macOS Library. Accepting the location the
picker opened on produced "this folder contains system files" every time, which
reads as *every* folder failing.

Backing out of that dialog rejects with `AbortError` — the **same** error a plain
cancel gives, so the two cannot be told apart afterwards. The old code returned
silently, which is why being blocked looked like nothing happening at all. It now
says what might have happened, and names the way forward.

`startIn` alone does not fix it, and the spec says why:

> If there is an existing mapping from the given ID to a path, this mapping is
> used. Otherwise, the path suggested via the WellKnownDirectory is used.

`startIn` as a well-known directory is a **fallback**; `id` wins. A browser holding
a remembered directory reopens there whatever `startIn` says. Dropping `id` takes
the mapping out of the equation — but `id` is also what remembers the last good
folder, so it is not dropped up front: the first attempt keeps it, and an attempt
that came back empty-handed retries without it.

**And one file does not need a folder picker at all.** Every in-browser export
produces exactly one file, and for one file choosing a *folder* buys nothing — it
is the same single dialog as saving the file, only subject to the blocklist. So
the folder route now appears only when there is more than one file to place, and
the per-file save (`showSaveFilePicker`, which never takes a directory handle and
so cannot hit the blocklist) is the primary action:

| Outputs | Buttons |
|---|---|
| 1 — every in-browser export | one: `Save file…` |
| more than 1 — the server route | folder save, plus per-file |

**`types/file-system-access.d.ts` is why this is trustworthy.**
`@types/wicg-file-system-access` declares `interface DirectoryPickerOptions {}` —
empty — so TypeScript validated nothing: `mode` and `id` were already going in
unchecked, and a misspelt `startIn` would have been dropped by the browser with
the call still resolving, reaching production looking like it worked. Measured:
before the declaration, `tsc` accepted an invented `startInX` without complaint.
After it, both mistakes are build errors — `TS2561` for the unknown key, `TS2820`
for a bad well-known directory.

## Verification

Everything above was checked in a running dev server rather than reasoned about:

| Change | Measured |
|---|---|
| Gated sections | typing `/board` renders the Library; rail reads Updates / Docs / Dark; 3D, Web and Boards are `SPAN`s at opacity 0.38, `aria-disabled`, and clicking one leaves `location.pathname` untouched |
| Docs | `/docs` renders with its 16 sidebar links and no `EditorShell`; on `/docs/controls/library` the editor's real controls render as controls — `.strack` came back `position: relative`, `rgb(243,244,246)`, 34px, `cursor: ew-resize`, which is exactly the measurement that fails when `globals.css` is missing; no failing network requests |
| Export | a real export produces one file and one primary `Save file…`; with the picker stubbed to reject with `AbortError`, the retry omits `id` (first call `{id, mode, startIn}`, second `{mode, startIn}`), the hint escalates across the two attempts, and no false "Save failed" appears |
| Production build | `next build` clean, with all 16 docs routes prerendered as static |

The native OS folder dialog cannot be driven from a test harness, so the
`startIn` value rests on the spec plus the type check rather than on a
click-through. Said plainly rather than implied.

## Merging notes

Four PRs, already merged on the fork in this order: gated sections, docs, then
the two export fixes. Only `package.json` ever conflicted — each change appended
its suite to the same `test` line — and the resolution is to keep them all, in
that order.

Open debt this leaves behind, none of it hidden:

- the React component export has no route in a built app until it lives outside
  Boards;
- the docs exist in two repositories;
- a gated route still takes its `<title>` from the route metadata, so `/board`
  shows the Library under a tab that says "Boards".