### PR TITLE
feat: add sidebar media crop editor and fix favorite contrast

### DIFF
--- a/components/AssetsPanel.tsx
+++ b/components/AssetsPanel.tsx
@@ -6,9 +6,8 @@ import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-
 import { CSS } from '@dnd-kit/utilities';
 import { useSceneStore, type AssetItem } from '@/store/useSceneStore';
 import { getTemplate, layerCountFor } from '@/templates';
-import { CARD_SHAPES, DEFAULT_FOCUS, cardAspectFor, parseCardShape, type CropFocus } from '@/lib/crop';
+import { CARD_SHAPES, cardAspectFor, parseCardShape } from '@/lib/crop';
 import { isVideoSource } from '@/lib/videoTexture';
-import MobileSheet from './MobileSheet';
 import { useMobileInteractions } from './MobileInteractions';
 import { DimInput } from './CanvasPanel';
 import { AddIcon, ChevronDownIcon, ChevronUpIcon, CloseIcon, CropIcon, EyeIcon as Eye, EyeOffIcon, GripIcon } from './EditorIcons';
@@ -27,58 +26,6 @@ const pixelPairFor = (ratio: number): [number, number] => (ratio >= 1
   : [Math.round(PIXEL_SEED_LONG_EDGE * ratio), PIXEL_SEED_LONG_EDGE]);
 
 const AssetEyeIcon = ({ off }: { off?: boolean }) => (off ? <EyeOffIcon size={12}/> : <Eye size={12}/>);
-
-// 3×3 focal-point picker: images cover-fill their card without stretching;
-// the focus chooses which part survives the crop.
-const FOCUS_CELLS: CropFocus[] = [0, 0.5, 1].flatMap((y) => [0, 0.5, 1].map((x) => ({ x, y })));
-
-function CropPopover({ asset, onClose }: { asset: AssetItem; onClose: () => void }) {
-  const setAssetCrop = useSceneStore((s) => s.setAssetCrop);
-  const setAllAssetCrops = useSceneStore((s) => s.setAllAssetCrops);
-  const focus = asset.crop ?? DEFAULT_FOCUS;
-  return (
-    <>
-      <div className="crop-scrim" onClick={onClose} />
-      <div className="crop-pop" onPointerDown={(e) => e.stopPropagation()}>
-        <span className="crop-pop-title">Crop focus</span>
-        <div className="crop-grid">
-          {FOCUS_CELLS.map((c) => (
-            <button
-              key={`${c.x}-${c.y}`}
-              className={`crop-cell ${focus.x === c.x && focus.y === c.y ? 'active' : ''}`}
-              title={`${['Left','Centre','Right'][c.x * 2]} / ${['Top','Middle','Bottom'][c.y * 2]}`}
-              onClick={() => setAssetCrop(asset.id, c)}
-            />
-          ))}
-        </div>
-        <button className="link-btn" onClick={() => { setAllAssetCrops(focus); onClose(); }}>
-          Apply to all images
-        </button>
-      </div>
-    </>
-  );
-}
-
-function MobileCropSheet({ asset, onClose }: { asset: AssetItem; onClose: () => void }) {
-  const setAssetCrop = useSceneStore((s) => s.setAssetCrop);
-  const setAllAssetCrops = useSceneStore((s) => s.setAllAssetCrops);
-  const focus = asset.crop ?? DEFAULT_FOCUS;
-  return (
-    <MobileSheet title="Crop focus" onClose={onClose}>
-      <div className="mobile-crop-grid">
-        {FOCUS_CELLS.map((cell) => (
-          <button
-            key={`${cell.x}-${cell.y}`}
-            className={focus.x === cell.x && focus.y === cell.y ? 'active' : ''}
-            onClick={() => setAssetCrop(asset.id, cell)}
-            aria-label={`${['Left', 'Centre', 'Right'][cell.x * 2]} / ${['Top', 'Middle', 'Bottom'][cell.y * 2]}`}
-          />
-        ))}
-      </div>
-      <button className="btn full" onClick={() => { setAllAssetCrops(focus); onClose(); }}>Apply to all images</button>
-    </MobileSheet>
-  );
-}
 
 function MobileAssetRow({
   asset,
@@ -156,6 +103,7 @@ function MobileAssetRow({
           <img className="asset-thumb" src={asset.url} alt={asset.name} onClick={onReplace} />
         )}
         <span className="asset-name" title={asset.name}>{asset.name}</span>
+        <button className="icon-btn mobile-crop-open" data-crop-asset={asset.id} aria-label={`Adjust ${asset.name}`} disabled={!asset.url} onClick={onCrop}><CropIcon size={16}/></button>
         <button
           className="mobile-drag-handle"
           data-drag-handle
@@ -170,7 +118,7 @@ function MobileAssetRow({
   );
 }
 
-export default function AssetsPanel() {
+export default function AssetsPanel({ onEditAsset }: { onEditAsset: (id: string) => void }) {
   const mobile = useMobileInteractions();
   const assets = useSceneStore((s) => s.assets);
   // How many card slots the active template will actually fill — asked of the
@@ -221,7 +169,6 @@ export default function AssetsPanel() {
   const [dragIdx, setDragIdx] = useState<number | null>(null);
   const [overIdx, setOverIdx] = useState<number | null>(null);
   const [dropActive, setDropActive] = useState(false);
-  const [cropOpenId, setCropOpenId] = useState<string | null>(null);
   const [swipeOpenId, setSwipeOpenId] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
@@ -451,7 +398,7 @@ export default function AssetsPanel() {
                     open={swipeOpenId === asset.id}
                     onOpen={(open) => setSwipeOpenId(open ? asset.id : null)}
                     onReplace={() => openSlotPicker(index)}
-                    onCrop={() => setCropOpenId(asset.id)}
+                    onCrop={() => onEditAsset(asset.id)}
                     onToggle={() => toggleAsset(asset.id)}
                     onRemove={() => removeAsset(asset.id)}
                   />
@@ -470,10 +417,7 @@ export default function AssetsPanel() {
                 return asset ? <div className="mobile-asset-overlay"><span className="asset-thumb asset-thumb-empty" /><span>{asset.name}</span><GripIcon size={18}/></div> : null;
               })()}
             </DragOverlay>
-            {cropOpenId && (() => {
-              const asset = assets.find((item) => item.id === cropOpenId);
-              return asset ? <MobileCropSheet asset={asset} onClose={() => setCropOpenId(null)} /> : null;
-            })()}
+
           </DndContext>
         ) : (
         <ul className="asset-list">
@@ -537,9 +481,9 @@ export default function AssetsPanel() {
                   </button>
                 </span>
                 <button
-                  className={`icon-btn ${a.crop && (a.crop.x !== 0.5 || a.crop.y !== 0.5) ? 'crop-set' : ''}`}
-                  title="Crop focus"
-                  onClick={() => setCropOpenId(cropOpenId === a.id ? null : a.id)}
+                  className={`icon-btn ${a.crop && (a.crop.x !== 0.5 || a.crop.y !== 0.5 || (a.crop.zoom ?? 1) !== 1) ? 'crop-set' : ''}`}
+                  data-crop-asset={a.id} title="Adjust media" aria-label={`Adjust ${a.name}`} disabled={!a.url}
+                  onClick={() => onEditAsset(a.id)}
                 >
                   <CropIcon size={12}/>
                 </button>
@@ -549,7 +493,6 @@ export default function AssetsPanel() {
                 <button className="icon-btn" title="Remove" onClick={() => removeAsset(a.id)}>
                   <CloseIcon size={12}/>
                 </button>
-                {cropOpenId === a.id && <CropPopover asset={a} onClose={() => setCropOpenId(null)} />}
               </li>
             ) : (
               <li

--- a/components/DesktopEditor.tsx
+++ b/components/DesktopEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import dynamic from 'next/dynamic';
-import AssetsPanel from '@/components/AssetsPanel';
+import MediaSidebar from '@/components/MediaSidebar';
 import BackgroundFill from '@/components/BackgroundFill';
 import BoardExportBar from '@/components/BoardExportBar';
 import BoardPanel from '@/components/BoardPanel';
@@ -124,7 +124,7 @@ export default function DesktopEditor() {
         ) : isMockup ? (
           <><CanvasPanel is3DMode /><div className="hairline" /><BackgroundFill hideTexture /></>
         ) : (
-          <><CanvasPanel /><div className="hairline" /><AssetsPanel /></>
+          <MediaSidebar showCanvas />
         )}
       </section>
 

--- a/components/MediaCropEditor.css
+++ b/components/MediaCropEditor.css
@@ -1,0 +1,64 @@
+.media-sidebar.is-editing { height: 100%; min-height: 0; }
+.media-sidebar > .hairline { margin: 0; }
+.media-crop {
+  display: flex; flex-direction: column; height: 100%; min-height: 0;
+  padding: 0; margin: 0; width: 100%; background: var(--card); color: var(--fg);
+  font-size: var(--fs-ui); outline: none;
+}
+.media-crop:focus { outline: none; }
+.media-crop button, .media-crop input { font: inherit; }
+.media-crop button { cursor: pointer; }
+.media-crop button:disabled { opacity: .4; cursor: default; }
+.media-crop :focus-visible { outline: 2px solid var(--fg); outline-offset: 3px; }
+.media-crop-head { display: flex; align-items: center; justify-content: space-between; padding: 16px 20px; border-bottom: 1px solid var(--line); }
+.media-crop-head > div { display: flex; align-items: center; gap: 10px; }
+.media-crop-head h2 { margin: 0; font-size: 13px; font-weight: 500; }
+.media-crop-body { flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior: contain; }
+.media-crop-preview { padding: 12px 20px 16px; background: var(--card); display: flex; flex-direction: column; min-width: 0; }
+.media-crop-preview-bar, .media-crop-label { display: flex; align-items: center; justify-content: space-between; }
+.media-crop-preview-bar > span { font-size: 10px; letter-spacing: 1.2px; color: var(--fg-muted); }
+.media-crop-preview-bar button, .media-crop-label button { border: 0; background: transparent; color: var(--fg-muted); padding: 4px 0; font-size: 11px; }
+.media-crop-preview-bar button[aria-pressed=true] { color: var(--fg); }
+.media-crop-stage { min-height: 0; display: flex; align-items: center; justify-content: center; padding: 14px 0; position: relative; }
+.media-crop-frame { position: relative; overflow: hidden; flex-shrink: 0; background: var(--card-inset); box-shadow: 0 0 0 1px var(--line-soft), 0 10px 28px #0002; touch-action: none; cursor: grab; user-select: none; }
+.media-crop-frame:active { cursor: grabbing; }
+.media-crop-image { position: absolute; max-width: none; object-fit: fill; pointer-events: none; }
+.media-crop-thirds { position: absolute; inset: 0; pointer-events: none; opacity: 0; border: 1px solid #fff9; }
+.has-grid .media-crop-thirds { opacity: 1; }
+.media-crop-thirds i { position: absolute; background: #ffffff70; }
+.media-crop-thirds i:nth-child(1), .media-crop-thirds i:nth-child(2) { top: 0; bottom: 0; width: 1px; left: 33.333%; }
+.media-crop-thirds i:nth-child(2) { left: 66.666%; }
+.media-crop-thirds i:nth-child(3), .media-crop-thirds i:nth-child(4) { left: 0; right: 0; height: 1px; top: 33.333%; }
+.media-crop-thirds i:nth-child(4) { top: 66.666%; }
+.media-crop-status { position: absolute; max-width: 240px; padding: 12px; background: var(--card); color: var(--fg-muted); text-align: center; }
+.media-crop-help { text-align: center; color: var(--fg-muted); font-size: 11px; margin: 0 0 12px; }
+.media-crop-file { display: flex; flex-direction: column; gap: 5px; padding-top: 12px; border-top: 1px solid var(--line); }
+.media-crop-file strong { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.media-crop-file span { color: var(--fg-muted); font-size: 11px; }
+.media-crop-controls { min-width: 0; margin: 0; padding: 20px; border: 0; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 16px; }
+.media-crop-section > label, .media-crop-position label, .media-crop-label > label { font-size: 12px; color: var(--fg-label); display: block; }
+.media-crop-ratios { display: grid; grid-template-columns: repeat(4, 1fr); gap: 3px; padding: 3px; background: var(--card-inset); margin-top: 10px; }
+.media-crop-ratios button { min-height: 30px; border: 0; background: transparent; color: var(--fg-muted); font-size: 11px; padding: 0 3px; }
+.media-crop-ratios button:hover { color: var(--fg); background: var(--card-thumb); }
+.media-crop-ratios button[aria-pressed=true] { background: var(--seg-active-bg); color: var(--seg-active-fg); }
+.media-crop-note { font-size: 10px; line-height: 1.5; color: var(--fg-muted); margin: 8px 0 0; }
+.media-crop-dimensions { display: flex; align-items: center; gap: 8px; margin-top: 10px; color: var(--fg-muted); }
+.media-crop-dimensions label { min-width: 0; display: flex; align-items: center; gap: 8px; padding: 7px 8px; background: var(--card-inset); }
+.media-crop-dimensions input { width: 100%; min-width: 0; background: transparent; border: 0; color: var(--fg-value); text-align: right; }
+.media-crop-position { display: flex; align-items: center; justify-content: space-between; padding-top: 16px; border-top: 1px solid var(--line); }
+.media-crop-align { display: grid; grid-template-columns: repeat(3, 28px); gap: 2px; padding: 3px; background: var(--card-inset); }
+.media-crop-align button { display: grid; place-items: center; height: 23px; border: 0; background: transparent; color: var(--fg-faint); }
+.media-crop-align button span { width: 3px; height: 3px; background: currentColor; }
+.media-crop-align button[aria-pressed=true] { background: var(--seg-active-bg); color: var(--seg-active-fg); }
+.media-crop-align button:hover { outline: 1px solid var(--handle); }
+.media-crop-footer { display: flex; flex-direction: column; align-items: stretch; gap: 10px; padding: 14px 20px; border-top: 1px solid var(--line); background: var(--card); }
+.media-crop-footer > label { display: flex; align-items: center; gap: 8px; color: var(--fg-muted); font-size: 11px; }
+.media-crop-footer input { accent-color: var(--fg); }
+.media-crop-footer > div { display: flex; gap: 8px; }
+.media-crop-footer > div .btn { flex: 1; }
+.media-crop-footer .btn { min-width: 72px; justify-content: center; }
+.media-crop-footer .media-crop-apply { background: var(--inverse-bg); color: var(--inverse-fg); border-color: var(--inverse-bg); }
+
+.media-crop-head, .media-crop-footer { flex-shrink: 0; }
+
+.mobile-crop-open { flex-shrink: 0; min-width: 36px; min-height: 36px; }

--- a/components/MediaCropEditor.tsx
+++ b/components/MediaCropEditor.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useRef, useState, type CSSProperties, type PointerEvent, type KeyboardEvent } from 'react';
+import { useSceneStore, type AssetItem } from '@/store/useSceneStore';
+import { getTemplate } from '@/templates';
+import { CARD_SHAPES, cardAspectFor, coverCrop, cropFromRect, normalizeCrop, parseCardShape } from '@/lib/crop';
+import { isVideoSource } from '@/lib/videoTexture';
+import { CloseIcon, CropIcon } from './EditorIcons';
+import { ControlRow } from './Controls';
+import './MediaCropEditor.css';
+
+type Gesture = { x: number; y: number; scale: number; rect: ReturnType<typeof coverCrop> };
+const POSITIONS = [0, 0.5, 1].flatMap(y => [0, 0.5, 1].map(x => ({ x, y })));
+
+export default function MediaCropEditor({ asset, onClose }: { asset: AssetItem; onClose: () => void }) {
+  const meta = useSceneStore(s => getTemplate(s.activeTemplateId).meta);
+  const width = useSceneStore(s => s.width);
+  const height = useSceneStore(s => s.height);
+  const savedShape = useSceneStore(s => s.cardShape);
+  const [shape, setShape] = useState(savedShape);
+  const [crop, setCrop] = useState(() => normalizeCrop(asset.crop));
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  const [error, setError] = useState(false);
+  const [grid, setGrid] = useState(true);
+  const [all, setAll] = useState(false);
+  const [custom, setCustom] = useState(!['auto', ...Object.keys(CARD_SHAPES)].includes(savedShape));
+  const initialRatio = cardAspectFor(meta, width, height, savedShape);
+  const [customW, setCustomW] = useState(String(Math.round(initialRatio * 1000)));
+  const [customH, setCustomH] = useState('1000');
+  const panel = useRef<HTMLElement>(null);
+  const frame = useRef<HTMLDivElement>(null);
+  const gesture = useRef<Gesture | null>(null);
+  const video = isVideoSource(asset.url, asset.kind);
+  const fullBleed = meta.cardAspect === 'canvas';
+  const aspect = cardAspectFor(meta, width, height, shape);
+  const ready = size.w > 0 && size.h > 0 && !error;
+  const rect = coverCrop(size.w || 1, size.h || 1, aspect, crop);
+  const customValid = !custom || parseCardShape(`${customW}:${customH}`) !== null;
+
+  useEffect(() => {
+    panel.current?.focus({ preventScroll: true });
+  }, []);
+
+  // Native wheel listener prevents the page from scrolling while zooming.
+  useEffect(() => {
+    const el = frame.current;
+    if (!el || !ready) return;
+    const wheel = (e: WheelEvent) => {
+      e.preventDefault();
+      setCrop(c => normalizeCrop({ ...c, zoom: c.zoom * Math.exp(-e.deltaY * 0.002) }));
+    };
+    el.addEventListener('wheel', wheel, { passive: false });
+    return () => el.removeEventListener('wheel', wheel);
+  }, [ready]);
+
+  const begin = (e: PointerEvent<HTMLDivElement>) => {
+    if (!ready || e.button !== 0 || gesture.current) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.currentTarget.focus();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const bounds = e.currentTarget.getBoundingClientRect();
+    gesture.current = { x: e.clientX, y: e.clientY, scale: bounds.width / rect.fw, rect };
+
+  };
+  const move = (e: PointerEvent<HTMLDivElement>) => {
+    const g = gesture.current;
+    if (!g || !e.currentTarget.hasPointerCapture(e.pointerId)) return;
+    const dx = (e.clientX - g.x) / g.scale, dy = (e.clientY - g.y) / g.scale;
+    const { fx, fy, fw } = g.rect;
+    setCrop(cropFromRect(size.w, size.h, aspect, fx - dx, fy - dy, fw));
+  };
+  const end = () => { gesture.current = null; };
+  const keyboard = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!ready) return;
+    const step = e.shiftKey ? 20 : 2;
+    const delta: Record<string, [number, number]> = { ArrowLeft: [-step, 0], ArrowRight: [step, 0], ArrowUp: [0, -step], ArrowDown: [0, step] };
+    if (!delta[e.key]) return;
+    e.preventDefault(); e.stopPropagation();
+    const [dx, dy] = delta[e.key];
+    setCrop(cropFromRect(size.w, size.h, aspect, rect.fx + dx, rect.fy + dy, rect.fw));
+  };
+  const changeCustom = (w: string, h: string) => {
+    setCustomW(w); setCustomH(h);
+    if (parseCardShape(`${w}:${h}`) !== null) setShape(`${w}:${h}`);
+  };
+  const apply = () => {
+    if (!ready || !customValid) return;
+    // Commit once, so cancel is lossless and history records one adjustment.
+    useSceneStore.setState(s => ({
+      cardShape: fullBleed ? s.cardShape : shape,
+      assets: s.assets.map(a => all || a.id === asset.id ? { ...a, crop: { ...crop } } : a),
+    }));
+    onClose();
+  };
+  const mediaStyle: CSSProperties = { width: `${size.w / rect.fw * 100}%`, height: `${size.h / rect.fh * 100}%`, left: `${-rect.fx / rect.fw * 100}%`, top: `${-rect.fy / rect.fh * 100}%` };
+  const interactions = { onPointerMove: move, onPointerUp: end, onPointerCancel: end, onLostPointerCapture: end, onKeyDown: keyboard };
+
+  return (
+    <section ref={panel} className="media-crop" aria-labelledby="media-crop-title" tabIndex={-1}
+      onKeyDown={e => { e.stopPropagation(); if (e.key === 'Escape') onClose(); }}>
+      <header className="media-crop-head">
+        <div><CropIcon size={16}/><h2 id="media-crop-title">Adjust media</h2></div>
+        <button className="icon-btn" aria-label="Back to media" title="Back to media" onClick={onClose}><CloseIcon size={16}/></button>
+      </header>
+      <div className="media-crop-body">
+        <section className="media-crop-preview" aria-label="Crop preview">
+          <div className="media-crop-preview-bar"><span>PREVIEW</span><button aria-pressed={grid} onClick={() => setGrid(!grid)}>Grid {grid ? 'on' : 'off'}</button></div>
+          <div className="media-crop-stage">
+            <div ref={frame} className={`media-crop-frame ${grid ? 'has-grid' : ''}`} style={{ aspectRatio: aspect, width: `min(${Math.min(1, aspect) * 100}%, ${Math.min(1, aspect) * 220}px)` }}
+              tabIndex={0} role="group" aria-label="Drag image to reposition. Use arrow keys to move the selection. Scroll to zoom."
+              onPointerDown={begin} {...interactions}>
+              {asset.url && (video ? <video className="media-crop-image" src={asset.url} style={mediaStyle} muted playsInline preload="auto"
+                onLoadedMetadata={e => setSize({ w: e.currentTarget.videoWidth, h: e.currentTarget.videoHeight })} onError={() => setError(true)} />
+                : <img className="media-crop-image" src={asset.url} style={mediaStyle} alt={asset.name} draggable={false}
+                  onLoad={e => setSize({ w: e.currentTarget.naturalWidth, h: e.currentTarget.naturalHeight })} onError={() => setError(true)} />)}
+              {ready && <div className="media-crop-thirds" aria-hidden="true"><i/><i/><i/><i/></div>}
+            </div>
+            {!ready && <p className="media-crop-status" role="status">{error || !asset.url ? 'Media unavailable. Close and replace this file.' : 'Loading media…'}</p>}
+          </div>
+          <p className="media-crop-help">Drag to reposition · Scroll to zoom</p>
+          <div className="media-crop-file"><strong title={asset.name}>{asset.name}</strong><span>{ready ? `${size.w} × ${size.h}` : '—'}</span></div>
+        </section>
+        <fieldset className="media-crop-controls" disabled={!ready}>
+          <div className="media-crop-section">
+            <label>Aspect ratio</label>
+            {fullBleed ? <p className="media-crop-note">Follows the canvas · {width} × {height}</p> : <>
+              <div className="media-crop-ratios">
+                {['auto', '3:4', '9:16', '1:1', '4:5', '4:3', '16:9'].map(value => <button key={value} aria-pressed={!custom && shape === value}
+                  onClick={() => { setCustom(false); setShape(value); }}>{value === 'auto' ? 'Auto' : value}</button>)}
+                <button aria-pressed={custom} onClick={() => { setCustom(true); changeCustom(customW, customH); }}>Custom</button>
+              </div>
+              {custom && <div className="media-crop-dimensions"><label>W<input aria-label="Crop ratio width" type="number" min="1" value={customW} onChange={e => changeCustom(e.target.value, customH)} /></label><span>×</span><label>H<input aria-label="Crop ratio height" type="number" min="1" value={customH} onChange={e => changeCustom(customW, e.target.value)} /></label></div>}
+              {!customValid && <p role="alert" className="media-crop-note">Use positive dimensions with a ratio between 1:10 and 10:1.</p>}
+              <p className="media-crop-note">Card ratio applies to all media.</p>
+            </>}
+          </div>
+          <div className="media-crop-section">
+            <ControlRow
+              def={{ key: 'mediaCropZoom', label: 'Zoom', type: 'slider', min: 100, max: 500, step: 1, default: 100, unit: '%' }}
+              value={Math.round(crop.zoom * 100)}
+              onChange={value => { if (ready) setCrop(c => normalizeCrop({ ...c, zoom: Number(value) / 100 })); }}
+            />
+            <div className="media-crop-label"><button onClick={() => setCrop(normalizeCrop())}>Reset crop</button></div>
+          </div>
+          <div className="media-crop-position">
+            <div><label>Position</label><p className="media-crop-note">Quick alignment</p></div>
+            <div className="media-crop-align" role="group" aria-label="Align crop">
+              {POSITIONS.map(p => <button key={`${p.x}-${p.y}`} aria-label={`${['Left', 'Center', 'Right'][p.x * 2]} / ${['Top', 'Middle', 'Bottom'][p.y * 2]}`} aria-pressed={Math.abs(crop.x - p.x) < 0.001 && Math.abs(crop.y - p.y) < 0.001} onClick={() => setCrop(c => ({ ...c, ...p }))}><span/></button>)}
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <footer className="media-crop-footer">
+        <label><input type="checkbox" checked={all} onChange={e => setAll(e.target.checked)}/> Apply crop to all media</label>
+        <div><button className="btn" onClick={onClose}>Cancel</button><button className="btn media-crop-apply" disabled={!ready || !customValid} onClick={apply}>Apply</button></div>
+      </footer>
+    </section>
+  );
+}

--- a/components/MediaSidebar.tsx
+++ b/components/MediaSidebar.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useSceneStore } from '@/store/useSceneStore';
+import AssetsPanel from './AssetsPanel';
+import CanvasPanel from './CanvasPanel';
+import MediaCropEditor from './MediaCropEditor';
+
+// Media adjustment replaces the inspector contents; the stage stays interactive.
+export default function MediaSidebar({ showCanvas = false }: { showCanvas?: boolean }) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const asset = useSceneStore(s => s.assets.find(a => a.id === editingId));
+  const container = useRef<HTMLDivElement>(null);
+  const previousScroll = useRef(0);
+  const open = (id: string) => {
+    const scroller = container.current?.closest('.card-scroll, .mobile-panel-scroll');
+    previousScroll.current = scroller?.scrollTop ?? 0;
+    if (scroller) scroller.scrollTop = 0;
+    setEditingId(id);
+  };
+  const close = () => {
+    const id = editingId;
+    setEditingId(null);
+    requestAnimationFrame(() => {
+      const scroller = container.current?.closest('.card-scroll, .mobile-panel-scroll');
+      if (scroller) scroller.scrollTop = previousScroll.current;
+      const buttons = container.current?.querySelectorAll<HTMLButtonElement>('button[data-crop-asset]');
+      const trigger = Array.from(buttons ?? []).find(button => button.dataset.cropAsset === id);
+      trigger?.focus({ preventScroll: true });
+    });
+  };
+  return (
+    <div ref={container} className={`media-sidebar ${asset ? 'is-editing' : ''}`}>
+      {asset ? <MediaCropEditor key={asset.id + asset.url} asset={asset} onClose={close} /> : <>
+        {showCanvas && <><CanvasPanel /><div className="hairline" /></>}
+        <AssetsPanel onEditAsset={open} />
+      </>}
+    </div>
+  );
+}

--- a/components/MobileEditor.tsx
+++ b/components/MobileEditor.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import TemplatesCard from './TemplatesCard';
-import AssetsPanel from './AssetsPanel';
+import MediaSidebar from './MediaSidebar';
 import ScenePanel from './ScenePanel';
 import EffectsPanel from './EffectsPanel';
 import CanvasPanel from './CanvasPanel';
@@ -97,7 +97,7 @@ export default function MobileEditor() {
               onSelect={() => setPanelOpen(false)}
             />
           )}
-          {tab === 'media' && <AssetsPanel />}
+          {tab === 'media' && <MediaSidebar />}
           {tab === 'adjust' && (
             <div className="mobile-composed-panel">
               {trackCount > 1 && <div className="mobile-desktop-hint">This project has {trackCount} layers. Manage layers and their timeline on desktop.</div>}

--- a/components/TemplatesCard.tsx
+++ b/components/TemplatesCard.tsx
@@ -14,7 +14,7 @@ const Chevron = ({ dir = 'right' }: { dir?: 'right' | 'left' }) => (
 );
 
 const Heart = ({ filled, size = 12 }: { filled: boolean; size?: number }) => (
-  <HeartIcon size={size} fill={filled ? 'currentColor' : undefined} stroke={filled ? 'none' : undefined}/>
+  <HeartIcon size={size} fill={filled ? 'currentColor' : 'none'} stroke={filled ? 'none' : 'currentColor'}/>
 );
 
 // Favourites resolve through the CATALOGUE, not the full registry: a template

--- a/lib/crop.ts
+++ b/lib/crop.ts
@@ -1,11 +1,20 @@
 import type { Template } from '@/lib/types';
 
 // Focal point for cover-fit cropping, both axes 0..1 (0.5/0.5 = centre).
-export interface CropFocus { x: number; y: number }
+export interface CropFocus { x: number; y: number; zoom?: number }
 
 export const DEFAULT_FOCUS: CropFocus = { x: 0.5, y: 0.5 };
 
 const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+
+export const MAX_CROP_ZOOM = 5;
+export function normalizeCrop(focus?: CropFocus | null): Required<CropFocus> {
+  return {
+    x: Number.isFinite(focus?.x) ? clamp01(focus!.x) : 0.5,
+    y: Number.isFinite(focus?.y) ? clamp01(focus!.y) : 0.5,
+    zoom: Number.isFinite(focus?.zoom) ? Math.max(1, Math.min(MAX_CROP_ZOOM, focus!.zoom!)) : 1,
+  };
+}
 
 // User-selectable card shapes (the scene-level crop aspect). 'auto' defers to
 // the template's declared cardAspect (or the 4:5 default).
@@ -69,10 +78,12 @@ export function cardAspectFor(
 // anchored by the focal point — like CSS object-fit: cover + object-position.
 // Images never stretch; the excess on the longer axis is cropped away.
 export function coverCrop(tw: number, th: number, aspect: number, focus?: CropFocus | null) {
-  const f = focus ?? DEFAULT_FOCUS;
+  const f = normalizeCrop(focus);
   let fw = tw;
   let fh = tw / aspect;
   if (fh > th) { fh = th; fw = th * aspect; }
+  fw /= f.zoom;
+  fh /= f.zoom;
   return {
     fx: (tw - fw) * clamp01(f.x),
     fy: (th - fh) * clamp01(f.y),
@@ -83,6 +94,14 @@ export function coverCrop(tw: number, th: number, aspect: number, focus?: CropFo
 
 // Cache key for a cropped texture (shared by both renderers).
 export function cropKey(url: string, aspect: number, focus?: CropFocus | null) {
-  const f = focus ?? DEFAULT_FOCUS;
-  return `${url}|${aspect.toFixed(4)}|${f.x}|${f.y}`;
+  const f = normalizeCrop(focus);
+  return `${url}|${aspect.toFixed(4)}|${f.x}|${f.y}|${f.zoom}`;
+}
+
+// Source-pixel selection shared by direct manipulation and the renderers.
+export function cropFromRect(tw: number, th: number, aspect: number, fx: number, fy: number, width: number): Required<CropFocus> {
+  const base = coverCrop(tw, th, aspect);
+  const zoom = Math.max(1, Math.min(MAX_CROP_ZOOM, base.fw / Math.max(Number.EPSILON, width)));
+  const fw = base.fw / zoom, fh = base.fh / zoom;
+  return normalizeCrop({ x: tw > fw ? fx / (tw - fw) : 0.5, y: th > fh ? fy / (th - fh) : 0.5, zoom });
 }

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -7,7 +7,7 @@ import { useSceneStore, type SceneState } from '@/store/useSceneStore';
 import { resolveEasing } from '@/lib/easing';
 import { assetIndexForSlot, clamp } from '@/lib/motion';
 import { resolveTrackTime, trackAssetIndices, type MotionTrack } from '@/lib/tracks';
-import { cardAspectFor, coverCrop, cropKey } from '@/lib/crop';
+import { cardAspectFor, coverCrop, cropKey, type CropFocus } from '@/lib/crop';
 import { advanceVideoForExport, createCardVideo, isVideoSource, prepareVideoForSequentialExport, useVideoProxies, whenVideoReady } from '@/lib/videoTexture';
 import { BASE_PATH, IS_STATIC_EXPORT } from '@/lib/paths';
 import { advancedRasterSize, gradientRasterMaxEdge, gradientSignature, normalizeGradientSpec, paintGradientCanvas } from '@/lib/gradient';
@@ -233,7 +233,7 @@ export class SceneRenderer {
 
   // Cover-fit a loaded texture into the template's card shape: a cropped view
   // (no stretch) anchored at the asset's focal point. Cached per url/aspect/focus.
-  private croppedView(url: string, base: PIXI.Texture, aspect: number, crop?: { x: number; y: number }): PIXI.Texture {
+  private croppedView(url: string, base: PIXI.Texture, aspect: number, crop?: CropFocus): PIXI.Texture {
     const key = cropKey(url, aspect, crop);
     const hit = this.croppedCache.get(key);
     if (hit) return hit;
@@ -292,7 +292,7 @@ export class SceneRenderer {
     const pool = indices.map((i) => s.assets[i]).filter(Boolean);
 
     const assetSig = (repeat ? 'R|' : '') + 'A' + aspect.toFixed(4) + '|' +
-      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + (a.crop ? a.crop.x + ',' + a.crop.y : 'c')).join('|');
+      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + cropKey(a.url, aspect, a.crop)).join('|');
 
     if (count === rt.countSig && assetSig === rt.assetSig) return;
     rt.countSig = count;
@@ -328,7 +328,7 @@ export class SceneRenderer {
       let asset = pool[assetIndexForSlot(i, pool.length, repeat)];
       if (!asset && pool.length > 0) asset = pool[i % pool.length];
       const binding = asset
-        ? `${asset.id}|${asset.url}|${aspect.toFixed(4)}|${asset.crop?.x ?? 0.5},${asset.crop?.y ?? 0.5}`
+        ? `${asset.id}|${cropKey(asset.url, aspect, asset.crop)}`
         : `placeholder|${i}`;
       const bindingChanged = slot.bindKey !== binding;
       slot.bindKey = binding;

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -7,7 +7,7 @@ import { applyThreeUniforms, disposeThreeMaterials, threeMaterialFor } from '@/e
 import { resolveEasing } from '@/lib/easing';
 import { assetIndexForSlot, clamp, lerp } from '@/lib/motion';
 import { loadImage } from '@/lib/textureLoad';
-import { cardAspectFor, coverCrop, cropKey } from '@/lib/crop';
+import { cardAspectFor, coverCrop, cropKey, type CropFocus } from '@/lib/crop';
 import { advanceVideoForExport, createCardVideo, isVideoSource, prepareVideoForSequentialExport, useVideoProxies } from '@/lib/videoTexture';
 import { BASE_PATH, IS_STATIC_EXPORT } from '@/lib/paths';
 import type { IRenderer } from '@/lib/rendererTypes';
@@ -283,7 +283,7 @@ export class SceneRenderer3D implements IRenderer {
 
   // Cover-fit via UV window (repeat/offset) on a clone sharing the decoded
   // image — mirrors the Pixi renderer's frame-cropped texture views.
-  private croppedView(url: string, base: THREE.Texture, aspect: number, crop?: { x: number; y: number }): { tex: THREE.Texture; fw: number; fh: number } {
+  private croppedView(url: string, base: THREE.Texture, aspect: number, crop?: CropFocus): { tex: THREE.Texture; fw: number; fh: number } {
     const img = base.image as HTMLImageElement;
     const { fx, fy, fw, fh } = coverCrop(img.width, img.height, aspect, crop);
     const key = cropKey(url, aspect, crop);
@@ -387,7 +387,7 @@ export class SceneRenderer3D implements IRenderer {
       { width: s.width, height: s.height, cardAspect: aspect });
     const pool = trackAssetIndices(track, s.assets).map((i) => s.assets[i]).filter(Boolean);
     const assetSig = (repeat ? 'R|' : '') + 'A' + aspect.toFixed(4) + '|' +
-      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + (a.crop ? a.crop.x + ',' + a.crop.y : 'c')).join('|');
+      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + cropKey(a.url, aspect, a.crop)).join('|');
     if (!rt.r3fManaged && r3fManaged) {
       // Entering the R3F-managed Box from another WebGL template keeps the
       // same renderer and track runtime. Remove the previous native meshes
@@ -492,7 +492,7 @@ export class SceneRenderer3D implements IRenderer {
       let asset = pool[assetIndexForSlot(i, pool.length, repeat)];
       if (!asset && pool.length > 0) asset = pool[i % pool.length];
       const binding = asset
-        ? `${asset.id}|${asset.url}|${aspect.toFixed(4)}|${asset.crop?.x ?? 0.5},${asset.crop?.y ?? 0.5}`
+        ? `${asset.id}|${cropKey(asset.url, aspect, asset.crop)}`
         : `placeholder|${i}`;
       const bindingChanged = slot.bindKey !== binding;
       slot.bindKey = binding;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Motion Studio — an open-source factory for quick videos and GIFs.",
   "main": "index.js",
   "scripts": {
-    "test": "node scripts/verify-tilt.cjs && node scripts/verify-catalogue.cjs && node scripts/verify-contexts.cjs && node scripts/verify-reference.cjs && node scripts/verify-effects.cjs && node scripts/verify-gradients.cjs && node scripts/verify-gated-sections.cjs && node scripts/verify-docs-routes.cjs",
+    "test": "node scripts/verify-tilt.cjs && node scripts/verify-catalogue.cjs && node scripts/verify-contexts.cjs && node scripts/verify-reference.cjs && node scripts/verify-effects.cjs && node scripts/verify-gradients.cjs && node scripts/verify-gated-sections.cjs && node scripts/verify-docs-routes.cjs && node scripts/verify-crop.cjs",
     "dev": "next dev",
     "dev:network": "next dev -H 0.0.0.0",
     "build": "next build",

--- a/scripts/verify-crop.cjs
+++ b/scripts/verify-crop.cjs
@@ -1,0 +1,31 @@
+// Crop geometry must stay identical in the editor, Pixi and Three texture views.
+require('sucrase/register');
+const assert = require('node:assert/strict');
+const { coverCrop, cropKey, cropFromRect, normalizeCrop, cardAspectFor } = require('../lib/crop');
+const near = (a, b) => assert.ok(Math.abs(a - b) < 1e-7, `${a} != ${b}`);
+assert.deepEqual(coverCrop(1200, 800, 1), { fx: 200, fy: 0, fw: 800, fh: 800 });
+assert.deepEqual(coverCrop(1200, 800, 1, { x: 1, y: 0 }), { fx: 400, fy: 0, fw: 800, fh: 800 });
+assert.deepEqual(coverCrop(1200, 800, 1, { x: .5, y: .5, zoom: 2 }), { fx: 400, fy: 200, fw: 400, fh: 400 });
+assert.deepEqual(normalizeCrop({ x: NaN, y: Infinity, zoom: NaN }), { x: .5, y: .5, zoom: 1 });
+assert.deepEqual(normalizeCrop({ x: -2, y: 8, zoom: 90 }), { x: 0, y: 1, zoom: 5 });
+assert.equal(cropKey('a', 1), cropKey('a', 1, { x: .5, y: .5, zoom: 1 }));
+assert.notEqual(cropKey('a', 1), cropKey('a', 1, { x: .5, y: .5, zoom: 2 }));
+assert.equal(cardAspectFor({ cardAspect: 'canvas' }, 1920, 1080, '1:1'), 1920 / 1080);
+let cases = 0;
+for (const [w, h] of [[1200, 800], [800, 1200], [1000, 1000], [1, 1]]) {
+  for (const aspect of [.1, 9/16, .8, 1, 16/9, 10]) {
+    for (const zoom of [1, 1.01, 2, 5]) {
+      for (const x of [0, .27, .5, 1]) for (const y of [0, .63, 1]) {
+        const r = coverCrop(w, h, aspect, {x, y, zoom});
+        near(r.fw / r.fh, aspect);
+        assert.ok(r.fx >= 0 && r.fy >= 0 && r.fx + r.fw <= w + 1e-7 && r.fy + r.fh <= h + 1e-7);
+        {
+          const roundtrip = coverCrop(w, h, aspect, cropFromRect(w, h, aspect, r.fx, r.fy, r.fw));
+          for (const key of ['fx', 'fy', 'fw', 'fh']) near(roundtrip[key], r[key]);
+        }
+        cases++;
+      }
+    }
+  }
+}
+console.log(`Crop: ${cases} geometry cases passed; legacy crops, zoom, bounds and cache invalidation passed.`);


### PR DESCRIPTION
## Changes
Replace the nine-point crop popover with an Adjust media inspector in the right sidebar, replacing Canvas and Media while keeping the stage visible. Closing or applying restores the inspector and the selected media button.

- Preview and drag the image directly, zoom from 100% to 500% using the existing ControlRow slider, or use the mouse wheel and arrow keys.
- Offer preset/custom aspect ratios, grid, alignment, reset, and apply-to-all. Changes commit once on Apply; Cancel discards the draft. There is no separate Selection section.
- Preserve legacy crops and include zoom in Pixi/Three crop geometry, texture cache keys, and binding invalidation. Existing persistence, history and media exports retain the crop.
- Provide a visible crop button in the mobile media list.
- Fix unselected favorite hearts rendering black in dark mode: explicitly use fill="none" and stroke="currentColor" instead of overriding SVG defaults with undefined.

## Validation
- [x] TypeScript check
- [x] Full npm test suite, including 1,152 crop geometry cases
- [x] Production build with `npm run build -- --webpack`
- [x] Local browser review: sidebar placement, standard zoom control, removed Selection section and visible favorite outline in dark mode

The default Turbopack build rejected the isolated worktree's node_modules junction because it points outside the project root. The Webpack production build completed successfully. No build configuration changes are included.
