### PR TITLE
Feat/effect scope and multipass

### DIFF
--- a/components/AssetsPanel.tsx
+++ b/components/AssetsPanel.tsx
@@ -6,9 +6,8 @@ import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-
 import { CSS } from '@dnd-kit/utilities';
 import { useSceneStore, type AssetItem } from '@/store/useSceneStore';
 import { getTemplate, layerCountFor } from '@/templates';
-import { CARD_SHAPES, DEFAULT_FOCUS, cardAspectFor, parseCardShape, type CropFocus } from '@/lib/crop';
+import { CARD_SHAPES, cardAspectFor, parseCardShape } from '@/lib/crop';
 import { isVideoSource } from '@/lib/videoTexture';
-import MobileSheet from './MobileSheet';
 import { useMobileInteractions } from './MobileInteractions';
 import { DimInput } from './CanvasPanel';
 import { AddIcon, ChevronDownIcon, ChevronUpIcon, CloseIcon, CropIcon, EyeIcon as Eye, EyeOffIcon, GripIcon } from './EditorIcons';
@@ -27,58 +26,6 @@ const pixelPairFor = (ratio: number): [number, number] => (ratio >= 1
   : [Math.round(PIXEL_SEED_LONG_EDGE * ratio), PIXEL_SEED_LONG_EDGE]);
 
 const AssetEyeIcon = ({ off }: { off?: boolean }) => (off ? <EyeOffIcon size={12}/> : <Eye size={12}/>);
-
-// 3×3 focal-point picker: images cover-fill their card without stretching;
-// the focus chooses which part survives the crop.
-const FOCUS_CELLS: CropFocus[] = [0, 0.5, 1].flatMap((y) => [0, 0.5, 1].map((x) => ({ x, y })));
-
-function CropPopover({ asset, onClose }: { asset: AssetItem; onClose: () => void }) {
-  const setAssetCrop = useSceneStore((s) => s.setAssetCrop);
-  const setAllAssetCrops = useSceneStore((s) => s.setAllAssetCrops);
-  const focus = asset.crop ?? DEFAULT_FOCUS;
-  return (
-    <>
-      <div className="crop-scrim" onClick={onClose} />
-      <div className="crop-pop" onPointerDown={(e) => e.stopPropagation()}>
-        <span className="crop-pop-title">Crop focus</span>
-        <div className="crop-grid">
-          {FOCUS_CELLS.map((c) => (
-            <button
-              key={`${c.x}-${c.y}`}
-              className={`crop-cell ${focus.x === c.x && focus.y === c.y ? 'active' : ''}`}
-              title={`${['Left','Centre','Right'][c.x * 2]} / ${['Top','Middle','Bottom'][c.y * 2]}`}
-              onClick={() => setAssetCrop(asset.id, c)}
-            />
-          ))}
-        </div>
-        <button className="link-btn" onClick={() => { setAllAssetCrops(focus); onClose(); }}>
-          Apply to all images
-        </button>
-      </div>
-    </>
-  );
-}
-
-function MobileCropSheet({ asset, onClose }: { asset: AssetItem; onClose: () => void }) {
-  const setAssetCrop = useSceneStore((s) => s.setAssetCrop);
-  const setAllAssetCrops = useSceneStore((s) => s.setAllAssetCrops);
-  const focus = asset.crop ?? DEFAULT_FOCUS;
-  return (
-    <MobileSheet title="Crop focus" onClose={onClose}>
-      <div className="mobile-crop-grid">
-        {FOCUS_CELLS.map((cell) => (
-          <button
-            key={`${cell.x}-${cell.y}`}
-            className={focus.x === cell.x && focus.y === cell.y ? 'active' : ''}
-            onClick={() => setAssetCrop(asset.id, cell)}
-            aria-label={`${['Left', 'Centre', 'Right'][cell.x * 2]} / ${['Top', 'Middle', 'Bottom'][cell.y * 2]}`}
-          />
-        ))}
-      </div>
-      <button className="btn full" onClick={() => { setAllAssetCrops(focus); onClose(); }}>Apply to all images</button>
-    </MobileSheet>
-  );
-}
 
 function MobileAssetRow({
   asset,
@@ -156,6 +103,7 @@ function MobileAssetRow({
           <img className="asset-thumb" src={asset.url} alt={asset.name} onClick={onReplace} />
         )}
         <span className="asset-name" title={asset.name}>{asset.name}</span>
+        <button className="icon-btn mobile-crop-open" data-crop-asset={asset.id} aria-label={`Adjust ${asset.name}`} disabled={!asset.url} onClick={onCrop}><CropIcon size={16}/></button>
         <button
           className="mobile-drag-handle"
           data-drag-handle
@@ -170,7 +118,7 @@ function MobileAssetRow({
   );
 }
 
-export default function AssetsPanel() {
+export default function AssetsPanel({ onEditAsset }: { onEditAsset: (id: string) => void }) {
   const mobile = useMobileInteractions();
   const assets = useSceneStore((s) => s.assets);
   // How many card slots the active template will actually fill — asked of the
@@ -221,7 +169,6 @@ export default function AssetsPanel() {
   const [dragIdx, setDragIdx] = useState<number | null>(null);
   const [overIdx, setOverIdx] = useState<number | null>(null);
   const [dropActive, setDropActive] = useState(false);
-  const [cropOpenId, setCropOpenId] = useState<string | null>(null);
   const [swipeOpenId, setSwipeOpenId] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
@@ -451,7 +398,7 @@ export default function AssetsPanel() {
                     open={swipeOpenId === asset.id}
                     onOpen={(open) => setSwipeOpenId(open ? asset.id : null)}
                     onReplace={() => openSlotPicker(index)}
-                    onCrop={() => setCropOpenId(asset.id)}
+                    onCrop={() => onEditAsset(asset.id)}
                     onToggle={() => toggleAsset(asset.id)}
                     onRemove={() => removeAsset(asset.id)}
                   />
@@ -470,10 +417,7 @@ export default function AssetsPanel() {
                 return asset ? <div className="mobile-asset-overlay"><span className="asset-thumb asset-thumb-empty" /><span>{asset.name}</span><GripIcon size={18}/></div> : null;
               })()}
             </DragOverlay>
-            {cropOpenId && (() => {
-              const asset = assets.find((item) => item.id === cropOpenId);
-              return asset ? <MobileCropSheet asset={asset} onClose={() => setCropOpenId(null)} /> : null;
-            })()}
+
           </DndContext>
         ) : (
         <ul className="asset-list">
@@ -537,9 +481,9 @@ export default function AssetsPanel() {
                   </button>
                 </span>
                 <button
-                  className={`icon-btn ${a.crop && (a.crop.x !== 0.5 || a.crop.y !== 0.5) ? 'crop-set' : ''}`}
-                  title="Crop focus"
-                  onClick={() => setCropOpenId(cropOpenId === a.id ? null : a.id)}
+                  className={`icon-btn ${a.crop && (a.crop.x !== 0.5 || a.crop.y !== 0.5 || (a.crop.zoom ?? 1) !== 1) ? 'crop-set' : ''}`}
+                  data-crop-asset={a.id} title="Adjust media" aria-label={`Adjust ${a.name}`} disabled={!a.url}
+                  onClick={() => onEditAsset(a.id)}
                 >
                   <CropIcon size={12}/>
                 </button>
@@ -549,7 +493,6 @@ export default function AssetsPanel() {
                 <button className="icon-btn" title="Remove" onClick={() => removeAsset(a.id)}>
                   <CloseIcon size={12}/>
                 </button>
-                {cropOpenId === a.id && <CropPopover asset={a} onClose={() => setCropOpenId(null)} />}
               </li>
             ) : (
               <li

--- a/components/DesktopEditor.tsx
+++ b/components/DesktopEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import dynamic from 'next/dynamic';
-import AssetsPanel from '@/components/AssetsPanel';
+import MediaSidebar from '@/components/MediaSidebar';
 import BackgroundFill from '@/components/BackgroundFill';
 import BoardExportBar from '@/components/BoardExportBar';
 import BoardPanel from '@/components/BoardPanel';
@@ -124,7 +124,7 @@ export default function DesktopEditor() {
         ) : isMockup ? (
           <><CanvasPanel is3DMode /><div className="hairline" /><BackgroundFill hideTexture /></>
         ) : (
-          <><CanvasPanel /><div className="hairline" /><AssetsPanel /></>
+          <MediaSidebar showCanvas />
         )}
       </section>
 

--- a/components/EffectsPanel.tsx
+++ b/components/EffectsPanel.tsx
@@ -5,6 +5,7 @@ import { DndContext, PointerSensor, closestCenter, useSensor, useSensors, type D
 import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useSceneStore, type ActiveEffect } from '@/store/useSceneStore';
+import type { EffectScope } from '@/lib/types';
 import { effectList, getEffect, effectDefaults } from '@/effects';
 import { ControlRow } from './Controls';
 import { useMobileInteractions } from './MobileInteractions';
@@ -44,6 +45,36 @@ function MobileEffectCard({
   );
 }
 
+// Onde o efeito age. Uma linha so, na mesma forma das outras do card, para nao
+// virar um controle de segunda classe: e a diferenca entre um Wave que ondula
+// os cards e um que arrasta o fundo junto.
+function ScopeRow({
+  scope,
+  tracks,
+  onChange,
+}: {
+  scope: EffectScope;
+  tracks: { id: string; name?: string }[];
+  onChange: (scope: EffectScope) => void;
+}) {
+  return (
+    <div className="ctl-row effect-scope-row">
+      <span className="ctl-label">Applies to</span>
+      <select
+        className="field"
+        value={scope}
+        onChange={(ev) => onChange(ev.target.value as EffectScope)}
+      >
+        <option value="scene">Whole scene</option>
+        <option value="artwork">Cards only</option>
+        {tracks.map((t, i) => (
+          <option key={t.id} value={`track:${t.id}`}>{t.name || `Layer ${i + 1}`}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
 export default function EffectsPanel() {
   const mobile = useMobileInteractions();
   const effects = useSceneStore((s) => s.effects);
@@ -52,6 +83,8 @@ export default function EffectsPanel() {
   const toggleEffect = useSceneStore((s) => s.toggleEffect);
   const reorderEffects = useSceneStore((s) => s.reorderEffects);
   const setEffectValue = useSceneStore((s) => s.setEffectValue);
+  const setEffectScope = useSceneStore((s) => s.setEffectScope);
+  const tracks = useSceneStore((s) => s.tracks);
   const [pick, setPick] = useState(effectList[0]?.meta.id ?? '');
   const [dragIdx, setDragIdx] = useState<number | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
@@ -71,7 +104,7 @@ export default function EffectsPanel() {
           <select className="field" value={pick} onChange={(e) => setPick(e.target.value)}>
             {effectList.map((e) => <option key={e.meta.id} value={e.meta.id}>{e.meta.name}</option>)}
           </select>
-          <button className="btn" onClick={() => pick && addEffect(pick, effectDefaults(pick))}>Add</button>
+          <button className="btn" onClick={() => pick && addEffect(pick, effectDefaults(pick), getEffect(pick)?.meta.defaultScope)}>Add</button>
         </div>
 
         {mobile ? (
@@ -123,6 +156,11 @@ export default function EffectsPanel() {
                 </button>
               </div>
               <div className="effect-card-body">
+                <ScopeRow
+                  scope={e.scope ?? 'scene'}
+                  tracks={tracks}
+                  onChange={(scope) => setEffectScope(e.instanceId, scope)}
+                />
                 {def.controls.map((c) => (
                   <ControlRow key={c.key} def={c} value={e.values[c.key]} onChange={(val) => setEffectValue(e.instanceId, c.key, val)} />
                 ))}

--- a/components/MediaCropEditor.css
+++ b/components/MediaCropEditor.css
@@ -1,0 +1,64 @@
+.media-sidebar.is-editing { height: 100%; min-height: 0; }
+.media-sidebar > .hairline { margin: 0; }
+.media-crop {
+  display: flex; flex-direction: column; height: 100%; min-height: 0;
+  padding: 0; margin: 0; width: 100%; background: var(--card); color: var(--fg);
+  font-size: var(--fs-ui); outline: none;
+}
+.media-crop:focus { outline: none; }
+.media-crop button, .media-crop input { font: inherit; }
+.media-crop button { cursor: pointer; }
+.media-crop button:disabled { opacity: .4; cursor: default; }
+.media-crop :focus-visible { outline: 2px solid var(--fg); outline-offset: 3px; }
+.media-crop-head { display: flex; align-items: center; justify-content: space-between; padding: 16px 20px; border-bottom: 1px solid var(--line); }
+.media-crop-head > div { display: flex; align-items: center; gap: 10px; }
+.media-crop-head h2 { margin: 0; font-size: 13px; font-weight: 500; }
+.media-crop-body { flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior: contain; }
+.media-crop-preview { padding: 12px 20px 16px; background: var(--card); display: flex; flex-direction: column; min-width: 0; }
+.media-crop-preview-bar, .media-crop-label { display: flex; align-items: center; justify-content: space-between; }
+.media-crop-preview-bar > span { font-size: 10px; letter-spacing: 1.2px; color: var(--fg-muted); }
+.media-crop-preview-bar button, .media-crop-label button { border: 0; background: transparent; color: var(--fg-muted); padding: 4px 0; font-size: 11px; }
+.media-crop-preview-bar button[aria-pressed=true] { color: var(--fg); }
+.media-crop-stage { min-height: 0; display: flex; align-items: center; justify-content: center; padding: 14px 0; position: relative; }
+.media-crop-frame { position: relative; overflow: hidden; flex-shrink: 0; background: var(--card-inset); box-shadow: 0 0 0 1px var(--line-soft), 0 10px 28px #0002; touch-action: none; cursor: grab; user-select: none; }
+.media-crop-frame:active { cursor: grabbing; }
+.media-crop-image { position: absolute; max-width: none; object-fit: fill; pointer-events: none; }
+.media-crop-thirds { position: absolute; inset: 0; pointer-events: none; opacity: 0; border: 1px solid #fff9; }
+.has-grid .media-crop-thirds { opacity: 1; }
+.media-crop-thirds i { position: absolute; background: #ffffff70; }
+.media-crop-thirds i:nth-child(1), .media-crop-thirds i:nth-child(2) { top: 0; bottom: 0; width: 1px; left: 33.333%; }
+.media-crop-thirds i:nth-child(2) { left: 66.666%; }
+.media-crop-thirds i:nth-child(3), .media-crop-thirds i:nth-child(4) { left: 0; right: 0; height: 1px; top: 33.333%; }
+.media-crop-thirds i:nth-child(4) { top: 66.666%; }
+.media-crop-status { position: absolute; max-width: 240px; padding: 12px; background: var(--card); color: var(--fg-muted); text-align: center; }
+.media-crop-help { text-align: center; color: var(--fg-muted); font-size: 11px; margin: 0 0 12px; }
+.media-crop-file { display: flex; flex-direction: column; gap: 5px; padding-top: 12px; border-top: 1px solid var(--line); }
+.media-crop-file strong { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.media-crop-file span { color: var(--fg-muted); font-size: 11px; }
+.media-crop-controls { min-width: 0; margin: 0; padding: 20px; border: 0; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 16px; }
+.media-crop-section > label, .media-crop-position label, .media-crop-label > label { font-size: 12px; color: var(--fg-label); display: block; }
+.media-crop-ratios { display: grid; grid-template-columns: repeat(4, 1fr); gap: 3px; padding: 3px; background: var(--card-inset); margin-top: 10px; }
+.media-crop-ratios button { min-height: 30px; border: 0; background: transparent; color: var(--fg-muted); font-size: 11px; padding: 0 3px; }
+.media-crop-ratios button:hover { color: var(--fg); background: var(--card-thumb); }
+.media-crop-ratios button[aria-pressed=true] { background: var(--seg-active-bg); color: var(--seg-active-fg); }
+.media-crop-note { font-size: 10px; line-height: 1.5; color: var(--fg-muted); margin: 8px 0 0; }
+.media-crop-dimensions { display: flex; align-items: center; gap: 8px; margin-top: 10px; color: var(--fg-muted); }
+.media-crop-dimensions label { min-width: 0; display: flex; align-items: center; gap: 8px; padding: 7px 8px; background: var(--card-inset); }
+.media-crop-dimensions input { width: 100%; min-width: 0; background: transparent; border: 0; color: var(--fg-value); text-align: right; }
+.media-crop-position { display: flex; align-items: center; justify-content: space-between; padding-top: 16px; border-top: 1px solid var(--line); }
+.media-crop-align { display: grid; grid-template-columns: repeat(3, 28px); gap: 2px; padding: 3px; background: var(--card-inset); }
+.media-crop-align button { display: grid; place-items: center; height: 23px; border: 0; background: transparent; color: var(--fg-faint); }
+.media-crop-align button span { width: 3px; height: 3px; background: currentColor; }
+.media-crop-align button[aria-pressed=true] { background: var(--seg-active-bg); color: var(--seg-active-fg); }
+.media-crop-align button:hover { outline: 1px solid var(--handle); }
+.media-crop-footer { display: flex; flex-direction: column; align-items: stretch; gap: 10px; padding: 14px 20px; border-top: 1px solid var(--line); background: var(--card); }
+.media-crop-footer > label { display: flex; align-items: center; gap: 8px; color: var(--fg-muted); font-size: 11px; }
+.media-crop-footer input { accent-color: var(--fg); }
+.media-crop-footer > div { display: flex; gap: 8px; }
+.media-crop-footer > div .btn { flex: 1; }
+.media-crop-footer .btn { min-width: 72px; justify-content: center; }
+.media-crop-footer .media-crop-apply { background: var(--inverse-bg); color: var(--inverse-fg); border-color: var(--inverse-bg); }
+
+.media-crop-head, .media-crop-footer { flex-shrink: 0; }
+
+.mobile-crop-open { flex-shrink: 0; min-width: 36px; min-height: 36px; }

--- a/components/MediaCropEditor.tsx
+++ b/components/MediaCropEditor.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useRef, useState, type CSSProperties, type PointerEvent, type KeyboardEvent } from 'react';
+import { useSceneStore, type AssetItem } from '@/store/useSceneStore';
+import { getTemplate } from '@/templates';
+import { CARD_SHAPES, cardAspectFor, coverCrop, cropFromRect, normalizeCrop, parseCardShape } from '@/lib/crop';
+import { isVideoSource } from '@/lib/videoTexture';
+import { CloseIcon, CropIcon } from './EditorIcons';
+import { ControlRow } from './Controls';
+import './MediaCropEditor.css';
+
+type Gesture = { x: number; y: number; scale: number; rect: ReturnType<typeof coverCrop> };
+const POSITIONS = [0, 0.5, 1].flatMap(y => [0, 0.5, 1].map(x => ({ x, y })));
+
+export default function MediaCropEditor({ asset, onClose }: { asset: AssetItem; onClose: () => void }) {
+  const meta = useSceneStore(s => getTemplate(s.activeTemplateId).meta);
+  const width = useSceneStore(s => s.width);
+  const height = useSceneStore(s => s.height);
+  const savedShape = useSceneStore(s => s.cardShape);
+  const [shape, setShape] = useState(savedShape);
+  const [crop, setCrop] = useState(() => normalizeCrop(asset.crop));
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  const [error, setError] = useState(false);
+  const [grid, setGrid] = useState(true);
+  const [all, setAll] = useState(false);
+  const [custom, setCustom] = useState(!['auto', ...Object.keys(CARD_SHAPES)].includes(savedShape));
+  const initialRatio = cardAspectFor(meta, width, height, savedShape);
+  const [customW, setCustomW] = useState(String(Math.round(initialRatio * 1000)));
+  const [customH, setCustomH] = useState('1000');
+  const panel = useRef<HTMLElement>(null);
+  const frame = useRef<HTMLDivElement>(null);
+  const gesture = useRef<Gesture | null>(null);
+  const video = isVideoSource(asset.url, asset.kind);
+  const fullBleed = meta.cardAspect === 'canvas';
+  const aspect = cardAspectFor(meta, width, height, shape);
+  const ready = size.w > 0 && size.h > 0 && !error;
+  const rect = coverCrop(size.w || 1, size.h || 1, aspect, crop);
+  const customValid = !custom || parseCardShape(`${customW}:${customH}`) !== null;
+
+  useEffect(() => {
+    panel.current?.focus({ preventScroll: true });
+  }, []);
+
+  // Native wheel listener prevents the page from scrolling while zooming.
+  useEffect(() => {
+    const el = frame.current;
+    if (!el || !ready) return;
+    const wheel = (e: WheelEvent) => {
+      e.preventDefault();
+      setCrop(c => normalizeCrop({ ...c, zoom: c.zoom * Math.exp(-e.deltaY * 0.002) }));
+    };
+    el.addEventListener('wheel', wheel, { passive: false });
+    return () => el.removeEventListener('wheel', wheel);
+  }, [ready]);
+
+  const begin = (e: PointerEvent<HTMLDivElement>) => {
+    if (!ready || e.button !== 0 || gesture.current) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.currentTarget.focus();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const bounds = e.currentTarget.getBoundingClientRect();
+    gesture.current = { x: e.clientX, y: e.clientY, scale: bounds.width / rect.fw, rect };
+
+  };
+  const move = (e: PointerEvent<HTMLDivElement>) => {
+    const g = gesture.current;
+    if (!g || !e.currentTarget.hasPointerCapture(e.pointerId)) return;
+    const dx = (e.clientX - g.x) / g.scale, dy = (e.clientY - g.y) / g.scale;
+    const { fx, fy, fw } = g.rect;
+    setCrop(cropFromRect(size.w, size.h, aspect, fx - dx, fy - dy, fw));
+  };
+  const end = () => { gesture.current = null; };
+  const keyboard = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!ready) return;
+    const step = e.shiftKey ? 20 : 2;
+    const delta: Record<string, [number, number]> = { ArrowLeft: [-step, 0], ArrowRight: [step, 0], ArrowUp: [0, -step], ArrowDown: [0, step] };
+    if (!delta[e.key]) return;
+    e.preventDefault(); e.stopPropagation();
+    const [dx, dy] = delta[e.key];
+    setCrop(cropFromRect(size.w, size.h, aspect, rect.fx + dx, rect.fy + dy, rect.fw));
+  };
+  const changeCustom = (w: string, h: string) => {
+    setCustomW(w); setCustomH(h);
+    if (parseCardShape(`${w}:${h}`) !== null) setShape(`${w}:${h}`);
+  };
+  const apply = () => {
+    if (!ready || !customValid) return;
+    // Commit once, so cancel is lossless and history records one adjustment.
+    useSceneStore.setState(s => ({
+      cardShape: fullBleed ? s.cardShape : shape,
+      assets: s.assets.map(a => all || a.id === asset.id ? { ...a, crop: { ...crop } } : a),
+    }));
+    onClose();
+  };
+  const mediaStyle: CSSProperties = { width: `${size.w / rect.fw * 100}%`, height: `${size.h / rect.fh * 100}%`, left: `${-rect.fx / rect.fw * 100}%`, top: `${-rect.fy / rect.fh * 100}%` };
+  const interactions = { onPointerMove: move, onPointerUp: end, onPointerCancel: end, onLostPointerCapture: end, onKeyDown: keyboard };
+
+  return (
+    <section ref={panel} className="media-crop" aria-labelledby="media-crop-title" tabIndex={-1}
+      onKeyDown={e => { e.stopPropagation(); if (e.key === 'Escape') onClose(); }}>
+      <header className="media-crop-head">
+        <div><CropIcon size={16}/><h2 id="media-crop-title">Adjust media</h2></div>
+        <button className="icon-btn" aria-label="Back to media" title="Back to media" onClick={onClose}><CloseIcon size={16}/></button>
+      </header>
+      <div className="media-crop-body">
+        <section className="media-crop-preview" aria-label="Crop preview">
+          <div className="media-crop-preview-bar"><span>PREVIEW</span><button aria-pressed={grid} onClick={() => setGrid(!grid)}>Grid {grid ? 'on' : 'off'}</button></div>
+          <div className="media-crop-stage">
+            <div ref={frame} className={`media-crop-frame ${grid ? 'has-grid' : ''}`} style={{ aspectRatio: aspect, width: `min(${Math.min(1, aspect) * 100}%, ${Math.min(1, aspect) * 220}px)` }}
+              tabIndex={0} role="group" aria-label="Drag image to reposition. Use arrow keys to move the selection. Scroll to zoom."
+              onPointerDown={begin} {...interactions}>
+              {asset.url && (video ? <video className="media-crop-image" src={asset.url} style={mediaStyle} muted playsInline preload="auto"
+                onLoadedMetadata={e => setSize({ w: e.currentTarget.videoWidth, h: e.currentTarget.videoHeight })} onError={() => setError(true)} />
+                : <img className="media-crop-image" src={asset.url} style={mediaStyle} alt={asset.name} draggable={false}
+                  onLoad={e => setSize({ w: e.currentTarget.naturalWidth, h: e.currentTarget.naturalHeight })} onError={() => setError(true)} />)}
+              {ready && <div className="media-crop-thirds" aria-hidden="true"><i/><i/><i/><i/></div>}
+            </div>
+            {!ready && <p className="media-crop-status" role="status">{error || !asset.url ? 'Media unavailable. Close and replace this file.' : 'Loading media…'}</p>}
+          </div>
+          <p className="media-crop-help">Drag to reposition · Scroll to zoom</p>
+          <div className="media-crop-file"><strong title={asset.name}>{asset.name}</strong><span>{ready ? `${size.w} × ${size.h}` : '—'}</span></div>
+        </section>
+        <fieldset className="media-crop-controls" disabled={!ready}>
+          <div className="media-crop-section">
+            <label>Aspect ratio</label>
+            {fullBleed ? <p className="media-crop-note">Follows the canvas · {width} × {height}</p> : <>
+              <div className="media-crop-ratios">
+                {['auto', '3:4', '9:16', '1:1', '4:5', '4:3', '16:9'].map(value => <button key={value} aria-pressed={!custom && shape === value}
+                  onClick={() => { setCustom(false); setShape(value); }}>{value === 'auto' ? 'Auto' : value}</button>)}
+                <button aria-pressed={custom} onClick={() => { setCustom(true); changeCustom(customW, customH); }}>Custom</button>
+              </div>
+              {custom && <div className="media-crop-dimensions"><label>W<input aria-label="Crop ratio width" type="number" min="1" value={customW} onChange={e => changeCustom(e.target.value, customH)} /></label><span>×</span><label>H<input aria-label="Crop ratio height" type="number" min="1" value={customH} onChange={e => changeCustom(customW, e.target.value)} /></label></div>}
+              {!customValid && <p role="alert" className="media-crop-note">Use positive dimensions with a ratio between 1:10 and 10:1.</p>}
+              <p className="media-crop-note">Card ratio applies to all media.</p>
+            </>}
+          </div>
+          <div className="media-crop-section">
+            <ControlRow
+              def={{ key: 'mediaCropZoom', label: 'Zoom', type: 'slider', min: 100, max: 500, step: 1, default: 100, unit: '%' }}
+              value={Math.round(crop.zoom * 100)}
+              onChange={value => { if (ready) setCrop(c => normalizeCrop({ ...c, zoom: Number(value) / 100 })); }}
+            />
+            <div className="media-crop-label"><button onClick={() => setCrop(normalizeCrop())}>Reset crop</button></div>
+          </div>
+          <div className="media-crop-position">
+            <div><label>Position</label><p className="media-crop-note">Quick alignment</p></div>
+            <div className="media-crop-align" role="group" aria-label="Align crop">
+              {POSITIONS.map(p => <button key={`${p.x}-${p.y}`} aria-label={`${['Left', 'Center', 'Right'][p.x * 2]} / ${['Top', 'Middle', 'Bottom'][p.y * 2]}`} aria-pressed={Math.abs(crop.x - p.x) < 0.001 && Math.abs(crop.y - p.y) < 0.001} onClick={() => setCrop(c => ({ ...c, ...p }))}><span/></button>)}
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <footer className="media-crop-footer">
+        <label><input type="checkbox" checked={all} onChange={e => setAll(e.target.checked)}/> Apply crop to all media</label>
+        <div><button className="btn" onClick={onClose}>Cancel</button><button className="btn media-crop-apply" disabled={!ready || !customValid} onClick={apply}>Apply</button></div>
+      </footer>
+    </section>
+  );
+}

--- a/components/MediaSidebar.tsx
+++ b/components/MediaSidebar.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useSceneStore } from '@/store/useSceneStore';
+import AssetsPanel from './AssetsPanel';
+import CanvasPanel from './CanvasPanel';
+import MediaCropEditor from './MediaCropEditor';
+
+// Media adjustment replaces the inspector contents; the stage stays interactive.
+export default function MediaSidebar({ showCanvas = false }: { showCanvas?: boolean }) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const asset = useSceneStore(s => s.assets.find(a => a.id === editingId));
+  const container = useRef<HTMLDivElement>(null);
+  const previousScroll = useRef(0);
+  const open = (id: string) => {
+    const scroller = container.current?.closest('.card-scroll, .mobile-panel-scroll');
+    previousScroll.current = scroller?.scrollTop ?? 0;
+    if (scroller) scroller.scrollTop = 0;
+    setEditingId(id);
+  };
+  const close = () => {
+    const id = editingId;
+    setEditingId(null);
+    requestAnimationFrame(() => {
+      const scroller = container.current?.closest('.card-scroll, .mobile-panel-scroll');
+      if (scroller) scroller.scrollTop = previousScroll.current;
+      const buttons = container.current?.querySelectorAll<HTMLButtonElement>('button[data-crop-asset]');
+      const trigger = Array.from(buttons ?? []).find(button => button.dataset.cropAsset === id);
+      trigger?.focus({ preventScroll: true });
+    });
+  };
+  return (
+    <div ref={container} className={`media-sidebar ${asset ? 'is-editing' : ''}`}>
+      {asset ? <MediaCropEditor key={asset.id + asset.url} asset={asset} onClose={close} /> : <>
+        {showCanvas && <><CanvasPanel /><div className="hairline" /></>}
+        <AssetsPanel onEditAsset={open} />
+      </>}
+    </div>
+  );
+}

--- a/components/MobileEditor.tsx
+++ b/components/MobileEditor.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import TemplatesCard from './TemplatesCard';
-import AssetsPanel from './AssetsPanel';
+import MediaSidebar from './MediaSidebar';
 import ScenePanel from './ScenePanel';
 import EffectsPanel from './EffectsPanel';
 import CanvasPanel from './CanvasPanel';
@@ -97,7 +97,7 @@ export default function MobileEditor() {
               onSelect={() => setPanelOpen(false)}
             />
           )}
-          {tab === 'media' && <AssetsPanel />}
+          {tab === 'media' && <MediaSidebar />}
           {tab === 'adjust' && (
             <div className="mobile-composed-panel">
               {trackCount > 1 && <div className="mobile-desktop-hint">This project has {trackCount} layers. Manage layers and their timeline on desktop.</div>}

--- a/components/TemplatesCard.tsx
+++ b/components/TemplatesCard.tsx
@@ -14,7 +14,7 @@ const Chevron = ({ dir = 'right' }: { dir?: 'right' | 'left' }) => (
 );
 
 const Heart = ({ filled, size = 12 }: { filled: boolean; size?: number }) => (
-  <HeartIcon size={size} fill={filled ? 'currentColor' : undefined} stroke={filled ? 'none' : undefined}/>
+  <HeartIcon size={size} fill={filled ? 'currentColor' : 'none'} stroke={filled ? 'none' : 'currentColor'}/>
 );
 
 // Favourites resolve through the CATALOGUE, not the full registry: a template

--- a/effects/adapters/glsl.ts
+++ b/effects/adapters/glsl.ts
@@ -4,7 +4,12 @@
 // verify script that had to import pixi.js (which wants a DOM) or three (which
 // wants a GL context) to look at a string would test neither. Here it is plain
 // string work, so scripts/verify-effects.cjs exercises the REAL generator.
-import type { Effect } from '@/lib/types';
+import type { Effect, EffectShader } from '@/lib/types';
+
+/** Todo passe do efeito, em ordem. `shader` e sempre o primeiro. */
+export function passesOf(effect: Effect): EffectShader[] {
+  return [effect.shader, ...(effect.passes ?? [])];
+}
 
 /** Names the adapters inject. An effect redeclaring one is a compile error. */
 export const RESERVED = ['uTexture', 'map', 'uInputSize', 'uResolution', 'uTime', 'fxSample', 'fxMain', 'vTextureCoord', 'vUv'];
@@ -45,14 +50,14 @@ vec3 fx_toLinear(vec3 c) {
 RESERVED.push('fx_toSrgb', 'fx_toLinear');
 
 
-function declarations(effect: Effect): string {
-  return Object.entries(effect.shader.uniformTypes ?? {})
+function declarations(pass: EffectShader): string {
+  return Object.entries(pass.uniformTypes ?? {})
     .map(([name, type]) => `uniform ${type} ${name};`)
     .join('\n');
 }
 
 /** GLSL ES 3.00 fragment for Pixi, where a pixel coordinate must unmap through uInputSize. */
-export function pixiFragment(effect: Effect): string {
+export function pixiFragment(effect: Effect, pass: EffectShader = effect.shader): string {
   return `#version 300 es
 precision highp float;
 in vec2 vTextureCoord;
@@ -62,7 +67,7 @@ uniform sampler2D uTexture;
 uniform vec4 uInputSize;
 uniform vec2 uResolution;
 uniform float uTime;
-${declarations(effect)}
+${declarations(pass)}
 
 // uInputSize.xy is the filter area in pixels, .zw its offset inside the texture
 // Pixi actually allocated — a filter's input can be padded, so a pixel
@@ -71,7 +76,7 @@ vec2 fx_toPixels(vec2 uv) { return uv * uInputSize.xy + uInputSize.zw; }
 vec2 fx_toUv(vec2 p)      { return (p - uInputSize.zw) / uInputSize.xy; }
 vec4 fxSample(vec2 p)     { return texture(uTexture, fx_toUv(p)); }
 
-${effect.shader.fragment}
+${pass.fragment}
 
 void main(void) {
   finalColor = fxMain(fx_toPixels(vTextureCoord));
@@ -79,12 +84,12 @@ void main(void) {
 }
 
 /** GLSL ES 1.00 fragment for three, where the pass reads a full-screen target. */
-export function threeFragment(effect: Effect): string {
+export function threeFragment(effect: Effect, pass: EffectShader = effect.shader): string {
   return `
 uniform sampler2D map;
 uniform vec2 uResolution;
 uniform float uTime;
-${declarations(effect)}
+${declarations(pass)}
 varying vec2 vUv;
 
 ${SRGB_HELPERS}
@@ -96,7 +101,7 @@ vec4 fxSample(vec2 p) {
   return vec4(fx_toSrgb(c.rgb), c.a);
 }
 
-${effect.shader.fragment}
+${pass.fragment}
 
 void main() {
   vec4 fx_result = fxMain(vUv * uResolution);

--- a/effects/adapters/pixi.ts
+++ b/effects/adapters/pixi.ts
@@ -48,11 +48,21 @@ void main(void)
 }`;
 
 
+// O PROGRAMA e por efeito; o FILTRO e por instancia.
+//
+// Antes o filtro inteiro era cacheado pelo id do efeito. Enquanto so existia um
+// escopo isso passava despercebido: duas instancias do mesmo efeito na mesma
+// pilha ja dividiam o bloco de uniforms e a ultima a escrever vencia. Com
+// escopo por camada a colisao deixa de ser hipotetica — o uso natural e o MESMO
+// efeito em duas camadas com valores diferentes. Um filtro por instancia com o
+// `GlProgram` compartilhado preserva o motivo do cache original: compilar GLSL
+// a cada frame de um slider arrastado faz o slider engasgar.
+const programas = new Map<string, GlProgram>();
 const cache = new Map<string, Filter>();
 
-/** The filter for this effect, compiled once and reused. */
-export function pixiFilterFor(effect: Effect): Filter {
-  const hit = cache.get(effect.meta.id);
+/** O filtro desta INSTANCIA, com o programa do efeito compilado uma vez so. */
+export function pixiFilterFor(effect: Effect, instanceId = effect.meta.id): Filter {
+  const hit = cache.get(instanceId);
   if (hit) return hit;
 
   const uniforms: Record<string, { value: any; type: string }> = {
@@ -66,12 +76,25 @@ export function pixiFilterFor(effect: Effect): Filter {
     };
   }
 
+  let programa = programas.get(effect.meta.id);
+  if (!programa) {
+    programa = GlProgram.from({ vertex: VERTEX, fragment: pixiFragment(effect), name: `fx-${effect.meta.id}` });
+    programas.set(effect.meta.id, programa);
+  }
+
   const filter = new Filter({
-    glProgram: GlProgram.from({ vertex: VERTEX, fragment: pixiFragment(effect), name: `fx-${effect.meta.id}` }),
+    glProgram: programa,
     resources: { fxUniforms: uniforms },
   });
-  cache.set(effect.meta.id, filter);
+  cache.set(instanceId, filter);
   return filter;
+}
+
+/** Solta os filtros de instancias que sairam da cena. */
+export function dropPixiFilters(vivas: Set<string>): void {
+  for (const id of [...cache.keys()]) {
+    if (!vivas.has(id)) cache.delete(id);
+  }
 }
 
 /** Push this frame's control values into the filter. No recompilation. */
@@ -98,4 +121,5 @@ export function applyPixiUniforms(
 /** Test seam: drop the compiled programs (used by the verify script). */
 export function clearPixiFilterCache(): void {
   cache.clear();
+  programas.clear();
 }

--- a/effects/adapters/pixi.ts
+++ b/effects/adapters/pixi.ts
@@ -16,7 +16,7 @@
 // everywhere else.
 import { Filter, GlProgram } from 'pixi.js';
 import type { Effect, EffectContext } from '@/lib/types';
-import { pixiFragment } from './glsl';
+import { passesOf, pixiFragment } from './glsl';
 
 // Pixi's default filter vertex shader (v8). Kept verbatim: the filter pipeline
 // depends on the exact varyings and uniform block it declares.
@@ -58,36 +58,43 @@ void main(void)
 // `GlProgram` compartilhado preserva o motivo do cache original: compilar GLSL
 // a cada frame de um slider arrastado faz o slider engasgar.
 const programas = new Map<string, GlProgram>();
-const cache = new Map<string, Filter>();
+const cache = new Map<string, Filter[]>();
 
-/** O filtro desta INSTANCIA, com o programa do efeito compilado uma vez so. */
-export function pixiFilterFor(effect: Effect, instanceId = effect.meta.id): Filter {
+/** Um filtro por PASSE desta instancia, na ordem em que rodam. */
+export function pixiFiltersFor(effect: Effect, instanceId = effect.meta.id): Filter[] {
   const hit = cache.get(instanceId);
   if (hit) return hit;
 
-  const uniforms: Record<string, { value: any; type: string }> = {
-    uResolution: { value: new Float32Array([1, 1]), type: 'vec2<f32>' },
-    uTime: { value: 0, type: 'f32' },
-  };
-  for (const [name, type] of Object.entries(effect.shader.uniformTypes ?? {})) {
-    uniforms[name] = {
-      value: type === 'float' ? 0 : new Float32Array(type === 'vec2' ? 2 : type === 'vec3' ? 3 : 4),
-      type: type === 'float' ? 'f32' : `${type}<f32>`,
+  // Pixi encadeia sozinho: `container.filters = [a, b]` roda `a` para uma
+  // textura intermediaria e `b` sobre ela. Um efeito de varios passes vira
+  // varios filtros em sequencia, sem maquinaria nova.
+  const filtros = passesOf(effect).map((pass, i) => {
+    const uniforms: Record<string, { value: any; type: string }> = {
+      uResolution: { value: new Float32Array([1, 1]), type: 'vec2<f32>' },
+      uTime: { value: 0, type: 'f32' },
     };
-  }
-
-  let programa = programas.get(effect.meta.id);
-  if (!programa) {
-    programa = GlProgram.from({ vertex: VERTEX, fragment: pixiFragment(effect), name: `fx-${effect.meta.id}` });
-    programas.set(effect.meta.id, programa);
-  }
-
-  const filter = new Filter({
-    glProgram: programa,
-    resources: { fxUniforms: uniforms },
+    for (const [name, type] of Object.entries(pass.uniformTypes ?? {})) {
+      uniforms[name] = {
+        value: type === 'float' ? 0 : new Float32Array(type === 'vec2' ? 2 : type === 'vec3' ? 3 : 4),
+        type: type === 'float' ? 'f32' : `${type}<f32>`,
+      };
+    }
+    const chave = `${effect.meta.id}#${i}`;
+    let programa = programas.get(chave);
+    if (!programa) {
+      programa = GlProgram.from({ vertex: VERTEX, fragment: pixiFragment(effect, pass), name: `fx-${chave}` });
+      programas.set(chave, programa);
+    }
+    return new Filter({ glProgram: programa, resources: { fxUniforms: uniforms } });
   });
-  cache.set(instanceId, filter);
-  return filter;
+
+  cache.set(instanceId, filtros);
+  return filtros;
+}
+
+/** Atalho para quem so precisa do primeiro passe (efeitos de passe unico). */
+export function pixiFilterFor(effect: Effect, instanceId = effect.meta.id): Filter {
+  return pixiFiltersFor(effect, instanceId)[0];
 }
 
 /** Solta os filtros de instancias que sairam da cena. */
@@ -97,25 +104,34 @@ export function dropPixiFilters(vivas: Set<string>): void {
   }
 }
 
-/** Push this frame's control values into the filter. No recompilation. */
+/** Push this frame's control values into every pass. No recompilation. */
 export function applyPixiUniforms(
-  filter: Filter,
+  filtros: Filter | Filter[],
   effect: Effect,
   values: Record<string, any>,
   ctx: EffectContext,
 ): void {
-  const u = (filter.resources as any).fxUniforms.uniforms;
-  u.uResolution[0] = ctx.width;
-  u.uResolution[1] = ctx.height;
-  u.uTime = ctx.time;
-  const own = effect.shader.uniforms(values, ctx);
-  for (const [name, value] of Object.entries(own)) {
-    if (Array.isArray(value)) {
-      for (let i = 0; i < value.length; i++) u[name][i] = value[i];
-    } else {
-      u[name] = value;
+  const lista = Array.isArray(filtros) ? filtros : [filtros];
+  const passes = passesOf(effect);
+  lista.forEach((filter, i) => {
+    const pass = passes[i];
+    if (!pass) return;
+    const u = (filter.resources as any).fxUniforms.uniforms;
+    u.uResolution[0] = ctx.width;
+    u.uResolution[1] = ctx.height;
+    u.uTime = ctx.time;
+    // Cada passe tem a SUA funcao de uniforms: e assim que o passe horizontal e
+    // o vertical de um blur separavel se distinguem, sem inventar um "indice do
+    // passe" que o autor do efeito teria de interpretar.
+    const own = pass.uniforms(values, ctx);
+    for (const [name, value] of Object.entries(own)) {
+      if (Array.isArray(value)) {
+        for (let k = 0; k < value.length; k++) u[name][k] = value[k];
+      } else {
+        u[name] = value;
+      }
     }
-  }
+  });
 }
 
 /** Test seam: drop the compiled programs (used by the verify script). */

--- a/effects/adapters/three.ts
+++ b/effects/adapters/three.ts
@@ -17,11 +17,16 @@ const VERTEX = `varying vec2 vUv;
 void main() { vUv = uv; gl_Position = vec4(position.xy, 0.0, 1.0); }`;
 
 
+// Um material por INSTANCIA, pelo mesmo motivo do lado Pixi: com escopo por
+// camada o uso natural e o MESMO efeito em duas camadas com valores diferentes,
+// e um material unico faria a segunda sobrescrever os uniforms da primeira.
+// Compilar nao vira custo: o three cacheia o programa pelo codigo do shader,
+// entao dois materiais com o mesmo fragment dividem um programa so.
 const cache = new Map<string, THREE.ShaderMaterial>();
 
-/** The material for this effect's pass, compiled once and reused. */
-export function threeMaterialFor(effect: Effect): THREE.ShaderMaterial {
-  const hit = cache.get(effect.meta.id);
+/** O material do passe desta INSTANCIA de efeito. */
+export function threeMaterialFor(effect: Effect, instanceId = effect.meta.id): THREE.ShaderMaterial {
+  const hit = cache.get(instanceId);
   if (hit) return hit;
 
   const uniforms: Record<string, THREE.IUniform> = {
@@ -45,7 +50,7 @@ export function threeMaterialFor(effect: Effect): THREE.ShaderMaterial {
     vertexShader: VERTEX,
     fragmentShader: threeFragment(effect),
   });
-  cache.set(effect.meta.id, material);
+  cache.set(instanceId, material);
   return material;
 }
 

--- a/effects/adapters/three.ts
+++ b/effects/adapters/three.ts
@@ -11,7 +11,7 @@
 // so a pixel coordinate is just p / uResolution. No padding to undo, unlike Pixi.
 import * as THREE from 'three';
 import type { Effect, EffectContext } from '@/lib/types';
-import { threeFragment } from './glsl';
+import { passesOf, threeFragment } from './glsl';
 
 const VERTEX = `varying vec2 vUv;
 void main() { vUv = uv; gl_Position = vec4(position.xy, 0.0, 1.0); }`;
@@ -22,36 +22,43 @@ void main() { vUv = uv; gl_Position = vec4(position.xy, 0.0, 1.0); }`;
 // e um material unico faria a segunda sobrescrever os uniforms da primeira.
 // Compilar nao vira custo: o three cacheia o programa pelo codigo do shader,
 // entao dois materiais com o mesmo fragment dividem um programa so.
-const cache = new Map<string, THREE.ShaderMaterial>();
+const cache = new Map<string, THREE.ShaderMaterial[]>();
 
-/** O material do passe desta INSTANCIA de efeito. */
-export function threeMaterialFor(effect: Effect, instanceId = effect.meta.id): THREE.ShaderMaterial {
+/** Um material por PASSE desta instancia, na ordem em que rodam. */
+export function threeMaterialsFor(effect: Effect, instanceId = effect.meta.id): THREE.ShaderMaterial[] {
   const hit = cache.get(instanceId);
   if (hit) return hit;
 
-  const uniforms: Record<string, THREE.IUniform> = {
-    map: { value: null },
-    uResolution: { value: new THREE.Vector2(1, 1) },
-    uTime: { value: 0 },
-  };
-  for (const [name, type] of Object.entries(effect.shader.uniformTypes ?? {})) {
-    uniforms[name] = {
-      value: type === 'float' ? 0
-        : type === 'vec2' ? new THREE.Vector2()
-        : type === 'vec3' ? new THREE.Vector3()
-        : new THREE.Vector4(),
+  const materiais = passesOf(effect).map((pass) => {
+    const uniforms: Record<string, THREE.IUniform> = {
+      map: { value: null },
+      uResolution: { value: new THREE.Vector2(1, 1) },
+      uTime: { value: 0 },
     };
-  }
-
-  const material = new THREE.ShaderMaterial({
-    depthTest: false,
-    depthWrite: false,
-    uniforms,
-    vertexShader: VERTEX,
-    fragmentShader: threeFragment(effect),
+    for (const [name, type] of Object.entries(pass.uniformTypes ?? {})) {
+      uniforms[name] = {
+        value: type === 'float' ? 0
+          : type === 'vec2' ? new THREE.Vector2()
+          : type === 'vec3' ? new THREE.Vector3()
+          : new THREE.Vector4(),
+      };
+    }
+    return new THREE.ShaderMaterial({
+      depthTest: false,
+      depthWrite: false,
+      uniforms,
+      vertexShader: VERTEX,
+      fragmentShader: threeFragment(effect, pass),
+    });
   });
-  cache.set(instanceId, material);
-  return material;
+
+  cache.set(instanceId, materiais);
+  return materiais;
+}
+
+/** Atalho para quem so precisa do primeiro passe. */
+export function threeMaterialFor(effect: Effect, instanceId = effect.meta.id): THREE.ShaderMaterial {
+  return threeMaterialsFor(effect, instanceId)[0];
 }
 
 /** Push this frame's control values into the material. No recompilation. */
@@ -60,11 +67,16 @@ export function applyThreeUniforms(
   effect: Effect,
   values: Record<string, any>,
   ctx: EffectContext,
+  passIndex = 0,
 ): void {
+  const pass = passesOf(effect)[passIndex];
+  if (!pass) return;
   const u = material.uniforms;
   (u.uResolution.value as THREE.Vector2).set(ctx.width, ctx.height);
   u.uTime.value = ctx.time;
-  const own = effect.shader.uniforms(values, ctx);
+  // Cada passe tem a SUA funcao de uniforms — e assim que o horizontal e o
+  // vertical de um blur separavel se distinguem.
+  const own = pass.uniforms(values, ctx);
   for (const [name, value] of Object.entries(own)) {
     const slot = u[name];
     if (!slot) continue;
@@ -74,6 +86,6 @@ export function applyThreeUniforms(
 }
 
 export function disposeThreeMaterials(): void {
-  cache.forEach((m) => m.dispose());
+  cache.forEach((lista) => lista.forEach((m) => m.dispose()));
   cache.clear();
 }

--- a/effects/bloom.ts
+++ b/effects/bloom.ts
@@ -1,0 +1,79 @@
+import type { Effect } from '@/lib/types';
+
+// Bloom: o que passa do limiar transborda e ilumina a vizinhanca.
+//
+// PASSE UNICO, E ISSO E UMA ESCOLHA. O caminho classico e separavel — borra o
+// passe claro em X, depois em Y, e soma ao ORIGINAL. O problema esta nesse
+// "soma ao original": o ultimo passe precisa ler a entrada da CADEIA, e nao a
+// saida do passe anterior. Isso exige um protocolo novo (uma textura guardada e
+// entregue aos passes seguintes) que teria de existir e ser provado nos dois
+// engines, com um agravante do lado Pixi: as texturas intermediarias do
+// filterManager sao recicladas de um pool, entao guardar a referencia da
+// entrada e ler depois pode entregar um buffer que ja virou outra coisa.
+//
+// Um kernel esparso resolve o mesmo problema sem nada disso: as amostras sao
+// tomadas em ANEIS ao redor do pixel, e como bloom e por definicao um brilho
+// suave e espalhado, a esparsidade nao aparece — o que apareceria num blur de
+// detalhe fino se dissolve aqui. E `fxSample(p)` continua sendo o original,
+// porque nao ha passe anterior nenhum. A soma sai de graca.
+//
+// Custo medido em amostras por pixel: 4 aneis x 8 direcoes + o centro = 33,
+// contra 2 x 13 = 26 do separavel de dois passes. Um terco a mais de amostras
+// em troca de nao inventar protocolo — e o separavel ainda precisaria do passe
+// de combinacao por cima.
+//
+// O LIMIAR usa luminancia Rec.709, a mesma do modo mono do Halftone. Bloom
+// segue brilho percebido: um amarelo saturado transborda antes de um azul de
+// mesmo valor numerico, e e assim que a lente se comporta.
+const ANEIS = 4;
+const DIRECOES = 8;
+
+export const bloom: Effect = {
+  meta: { id: 'bloom', name: 'Bloom', defaultScope: 'scene' },
+  controls: [
+    { key: 'threshold', label: 'Threshold', type: 'slider', min: 0, max: 100, step: 1, default: 65, unit: '%' },
+    { key: 'radius', label: 'Radius', type: 'slider', min: 1, max: 60, step: 1, default: 22, unit: 'px' },
+    { key: 'intensity', label: 'Intensity', type: 'slider', min: 0, max: 200, step: 1, default: 70, unit: '%' },
+  ],
+  shader: {
+    uniformTypes: { uThreshold: 'float', uRadius: 'float', uIntensity: 'float' },
+    uniforms: (v) => ({
+      uThreshold: Math.max(0, Math.min(1, Number(v.threshold ?? 65) / 100)),
+      uRadius: Math.max(1, Number(v.radius ?? 22)),
+      uIntensity: Math.max(0, Number(v.intensity ?? 70) / 100),
+    }),
+    fragment: `
+// O que passa do limiar, e SO o excedente: subtrair o limiar em vez de deixar
+// passar o pixel inteiro e o que evita o degrau visivel na borda do brilho.
+vec3 fx_excedente(vec3 c) {
+  float luma = dot(c, vec3(0.2126, 0.7152, 0.0722));
+  float acima = max(0.0, luma - uThreshold);
+  // divide pelo que sobra da escala, para o limiar em 0 nao virar identidade
+  float k = acima / max(0.0001, 1.0 - uThreshold);
+  return c * k;
+}
+
+vec4 fxMain(vec2 p) {
+  vec4 base = fxSample(p);
+  vec3 brilho = vec3(0.0);
+  float peso = 0.0;
+  for (int anel = 1; anel <= ${ANEIS}; anel++) {
+    float r = (float(anel) / float(${ANEIS})) * uRadius;
+    // peso gaussiano pelo raio do anel, como num blur de verdade
+    float sigma = max(0.0001, uRadius * 0.5);
+    float w = exp(-(r * r) / (2.0 * sigma * sigma));
+    for (int dir = 0; dir < ${DIRECOES}; dir++) {
+      // Meio passo de rotacao por anel, para os aneis nao alinharem as amostras
+      // no mesmo raio e desenharem uma estrela.
+      float a = (float(dir) + float(anel) * 0.5) * (6.2831853 / float(${DIRECOES}));
+      vec2 off = vec2(cos(a), sin(a)) * r;
+      brilho += fx_excedente(fxSample(p + off).rgb) * w;
+      peso += w;
+    }
+  }
+  brilho /= max(0.0001, peso);
+  // Aditivo, nao mistura: bloom SOMA luz. Misturar apagaria a imagem embaixo.
+  return vec4(base.rgb + brilho * uIntensity, base.a);
+}`,
+  },
+};

--- a/effects/blur.ts
+++ b/effects/blur.ts
@@ -1,0 +1,60 @@
+import type { Effect, EffectShader } from '@/lib/types';
+
+// Blur gaussiano, SEPARAVEL: um passe horizontal e um vertical.
+//
+// Um gaussiano 2D e o produto de dois gaussianos 1D, entao borrar em X e depois
+// em Y da exatamente o mesmo resultado que um kernel 2D — e custa muito menos.
+// Um raio r num passe unico pede (2r+1)^2 amostras por pixel; separado pede
+// 2*(2r+1). A 20px de raio isso e 1681 contra 82, vinte vezes menos trabalho, e
+// e por isso que este efeito precisou do contrato de multiplos passes.
+//
+// TAPS FIXOS, RAIO VARIAVEL. O laco tem contagem constante (GLSL ES 1.00 nem
+// aceita laco com limite vindo de uniform) e o espacamento entre amostras cresce
+// com o raio. A um raio grande as amostras ficam esparsas, entao o peso e
+// normalizado pela soma REAL acumulada — sem isso a imagem escurece conforme o
+// raio sobe, porque a cauda do gaussiano que ficou de fora nao entra na conta.
+//
+// O peso e calculado no shader em vez de vir numa tabela de uniforms: sao 13
+// exponenciais por pixel contra 13 uniforms para manter em sincronia entre os
+// dois passes e os dois engines. A conta e mais barata que o risco.
+const TAPS = 6; // de cada lado; 13 amostras no total por passe
+
+// Os dois passes sao o MESMO shader com uma direcao diferente. Escrever duas
+// vezes seria duas oportunidades de divergir.
+const corpo = `
+vec4 fxMain(vec2 p) {
+  if (uRadius < 0.5) return fxSample(p);
+  vec4 soma = fxSample(p);
+  float peso = 1.0;
+  float sigma = max(0.0001, uRadius * 0.5);
+  for (int i = 1; i <= ${TAPS}; i++) {
+    float d = (float(i) / float(${TAPS})) * uRadius;
+    float w = exp(-(d * d) / (2.0 * sigma * sigma));
+    soma += fxSample(p + uDir * d) * w;
+    soma += fxSample(p - uDir * d) * w;
+    peso += 2.0 * w;
+  }
+  return soma / peso;
+}`;
+
+function passe(direcao: [number, number]): EffectShader {
+  return {
+    uniformTypes: { uRadius: 'float', uDir: 'vec2' },
+    uniforms: (v) => ({
+      uRadius: Math.max(0, Number(v.radius ?? 8)),
+      uDir: direcao,
+    }),
+    fragment: corpo,
+  };
+}
+
+export const blur: Effect = {
+  // Nasce no quadro todo: desfocar a cena inteira, fundo incluido, e o que um
+  // blur de cena faz. Quem quiser so os cards troca no seletor.
+  meta: { id: 'blur', name: 'Blur', defaultScope: 'scene' },
+  controls: [
+    { key: 'radius', label: 'Radius', type: 'slider', min: 0, max: 40, step: 1, default: 8, unit: 'px' },
+  ],
+  shader: passe([1, 0]),
+  passes: [passe([0, 1])],
+};

--- a/effects/index.ts
+++ b/effects/index.ts
@@ -1,20 +1,30 @@
 import type { Effect } from '@/lib/types';
+import { bloom } from './bloom';
+import { blur } from './blur';
 import { grain } from './grain';
 import { halftone } from './halftone';
 import { pixelate } from './pixelate';
 import { posterize } from './posterize';
 import { rgbSplit } from './rgbSplit';
 import { scanlines } from './scanlines';
+import { tiltShift } from './tiltShift';
 import { vignette } from './vignette';
 import { wave } from './wave';
 
 // Insertion order is the order the panel offers them, grouped by what a person
-// is looking for rather than alphabetically: first the two that set a whole
+// is looking for rather than alphabetically: first the ones that set a whole
 // frame's mood, then the four that are a deliberate printed/broadcast look,
 // then the one that distorts geometry.
+//
+// Blur, Bloom e Tilt-shift entram junto de grao e vinheta porque sao da mesma
+// familia: efeitos de LENTE — o que a camera faz com a cena, e nao um
+// tratamento aplicado por cima dela.
 export const effects: Record<string, Effect> = {
   [grain.meta.id]: grain,
   [vignette.meta.id]: vignette,
+  [blur.meta.id]: blur,
+  [bloom.meta.id]: bloom,
+  [tiltShift.meta.id]: tiltShift,
   [halftone.meta.id]: halftone,
   [posterize.meta.id]: posterize,
   [scanlines.meta.id]: scanlines,

--- a/effects/tiltShift.ts
+++ b/effects/tiltShift.ts
@@ -1,0 +1,76 @@
+import type { Effect, EffectShader } from '@/lib/types';
+
+// Tilt-shift: uma FAIXA em foco, o resto borrado, com a transicao suave.
+//
+// E o mesmo blur separavel do effects/blur.ts com o raio modulado pela
+// distancia ate a faixa de foco. Nao herda o codigo de la de proposito: o raio
+// aqui varia POR PIXEL, e um blur cujo raio muda a cada pixel nao e o mesmo
+// shader com um uniform diferente — o laco tem de calcular o raio antes de
+// amostrar.
+//
+// A faixa e horizontal e medida em fracao da ALTURA, que e como a lente de
+// verdade se comporta: o plano de foco e paralelo ao chao, e o que decide se um
+// ponto esta nele e a altura dele no quadro.
+//
+// A rampa usa smoothstep entre a borda da faixa e a borda mais a transicao. Um
+// corte duro entre nitido e borrado denuncia o truque na hora; e justamente a
+// rampa que faz o olho ler "profundidade de campo" em vez de "mascara".
+const TAPS = 6;
+
+const corpo = `
+float fx_desfoque(vec2 p) {
+  // distancia ate a faixa, em pixels, 0 dentro dela
+  float centro = uFocus * uResolution.y;
+  float meia = max(1.0, uBand * uResolution.y * 0.5);
+  float d = abs(p.y - centro) - meia;
+  if (d <= 0.0) return 0.0;
+  float rampa = max(1.0, uFeather * uResolution.y);
+  return uRadius * smoothstep(0.0, rampa, d);
+}
+
+vec4 fxMain(vec2 p) {
+  float raio = fx_desfoque(p);
+  if (raio < 0.5) return fxSample(p);
+  vec4 soma = fxSample(p);
+  float peso = 1.0;
+  float sigma = max(0.0001, raio * 0.5);
+  for (int i = 1; i <= ${TAPS}; i++) {
+    float d = (float(i) / float(${TAPS})) * raio;
+    float w = exp(-(d * d) / (2.0 * sigma * sigma));
+    soma += fxSample(p + uDir * d) * w;
+    soma += fxSample(p - uDir * d) * w;
+    peso += 2.0 * w;
+  }
+  return soma / peso;
+}`;
+
+function passe(direcao: [number, number]): EffectShader {
+  return {
+    uniformTypes: {
+      uRadius: 'float', uFocus: 'float', uBand: 'float', uFeather: 'float', uDir: 'vec2',
+    },
+    uniforms: (v) => ({
+      uRadius: Math.max(0, Number(v.radius ?? 14)),
+      // 0 = topo, 1 = base. Metade e o centro do quadro.
+      uFocus: Math.max(0, Math.min(1, Number(v.focus ?? 50) / 100)),
+      uBand: Math.max(0, Math.min(1, Number(v.band ?? 25) / 100)),
+      // Nunca exatamente zero: smoothstep com as duas bordas iguais e indefinido,
+      // e o mesmo cuidado que o Vignette ja precisou ter na sua rampa.
+      uFeather: Math.max(0.001, Number(v.feather ?? 12) / 100),
+      uDir: direcao,
+    }),
+    fragment: corpo,
+  };
+}
+
+export const tiltShift: Effect = {
+  meta: { id: 'tilt-shift', name: 'Tilt-shift', defaultScope: 'scene' },
+  controls: [
+    { key: 'radius', label: 'Radius', type: 'slider', min: 0, max: 40, step: 1, default: 14, unit: 'px' },
+    { key: 'focus', label: 'Focus', type: 'slider', min: 0, max: 100, step: 1, default: 50, unit: '%' },
+    { key: 'band', label: 'Band', type: 'slider', min: 0, max: 100, step: 1, default: 25, unit: '%' },
+    { key: 'feather', label: 'Feather', type: 'slider', min: 0, max: 60, step: 1, default: 12, unit: '%' },
+  ],
+  shader: passe([1, 0]),
+  passes: [passe([0, 1])],
+};

--- a/effects/wave.ts
+++ b/effects/wave.ts
@@ -19,8 +19,15 @@ import type { Effect } from '@/lib/types';
 // Out-of-frame samples come back transparent instead of clamped: clamping
 // smears the edge pixel into a band along the border wherever the wave reaches
 // past the canvas.
+// Nasce em 'artwork', nao no quadro todo. O Wave desloca a COORDENADA de
+// amostragem, e num quadro ja composto isso arrasta o fundo junto: sobre um
+// fundo chapado o efeito nem aparece la (deslocar cor uniforme nao muda nada) e
+// o unico resultado visivel e a borda, onde a amostra sai do quadro e volta
+// transparente, abrindo uma faixa vazia na lateral da cena. Sobre os cards, o
+// mesmo deslocamento e exatamente o que se quer ver ondular. O seletor de
+// escopo permite voltar para 'scene'; isto e so onde o efeito comeca.
 export const wave: Effect = {
-  meta: { id: 'wave', name: 'Wave' },
+  meta: { id: 'wave', name: 'Wave', defaultScope: 'artwork' },
   controls: [
     { key: 'amount', label: 'Amount', type: 'slider', min: 0, max: 120, step: 1, default: 18, unit: 'px' },
     { key: 'freq', label: 'Frequency', type: 'slider', min: 1, max: 20, step: 1, default: 3 },

--- a/lib/crop.ts
+++ b/lib/crop.ts
@@ -1,11 +1,20 @@
 import type { Template } from '@/lib/types';
 
 // Focal point for cover-fit cropping, both axes 0..1 (0.5/0.5 = centre).
-export interface CropFocus { x: number; y: number }
+export interface CropFocus { x: number; y: number; zoom?: number }
 
 export const DEFAULT_FOCUS: CropFocus = { x: 0.5, y: 0.5 };
 
 const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+
+export const MAX_CROP_ZOOM = 5;
+export function normalizeCrop(focus?: CropFocus | null): Required<CropFocus> {
+  return {
+    x: Number.isFinite(focus?.x) ? clamp01(focus!.x) : 0.5,
+    y: Number.isFinite(focus?.y) ? clamp01(focus!.y) : 0.5,
+    zoom: Number.isFinite(focus?.zoom) ? Math.max(1, Math.min(MAX_CROP_ZOOM, focus!.zoom!)) : 1,
+  };
+}
 
 // User-selectable card shapes (the scene-level crop aspect). 'auto' defers to
 // the template's declared cardAspect (or the 4:5 default).
@@ -69,10 +78,12 @@ export function cardAspectFor(
 // anchored by the focal point — like CSS object-fit: cover + object-position.
 // Images never stretch; the excess on the longer axis is cropped away.
 export function coverCrop(tw: number, th: number, aspect: number, focus?: CropFocus | null) {
-  const f = focus ?? DEFAULT_FOCUS;
+  const f = normalizeCrop(focus);
   let fw = tw;
   let fh = tw / aspect;
   if (fh > th) { fh = th; fw = th * aspect; }
+  fw /= f.zoom;
+  fh /= f.zoom;
   return {
     fx: (tw - fw) * clamp01(f.x),
     fy: (th - fh) * clamp01(f.y),
@@ -83,6 +94,14 @@ export function coverCrop(tw: number, th: number, aspect: number, focus?: CropFo
 
 // Cache key for a cropped texture (shared by both renderers).
 export function cropKey(url: string, aspect: number, focus?: CropFocus | null) {
-  const f = focus ?? DEFAULT_FOCUS;
-  return `${url}|${aspect.toFixed(4)}|${f.x}|${f.y}`;
+  const f = normalizeCrop(focus);
+  return `${url}|${aspect.toFixed(4)}|${f.x}|${f.y}|${f.zoom}`;
+}
+
+// Source-pixel selection shared by direct manipulation and the renderers.
+export function cropFromRect(tw: number, th: number, aspect: number, fx: number, fy: number, width: number): Required<CropFocus> {
+  const base = coverCrop(tw, th, aspect);
+  const zoom = Math.max(1, Math.min(MAX_CROP_ZOOM, base.fw / Math.max(Number.EPSILON, width)));
+  const fw = base.fw / zoom, fh = base.fh / zoom;
+  return normalizeCrop({ x: tw > fw ? fx / (tw - fw) : 0.5, y: th > fh ? fy / (th - fh) : 0.5, zoom });
 }

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -7,7 +7,7 @@ import { useSceneStore, type SceneState } from '@/store/useSceneStore';
 import { resolveEasing } from '@/lib/easing';
 import { assetIndexForSlot, clamp } from '@/lib/motion';
 import { resolveTrackTime, trackAssetIndices, type MotionTrack } from '@/lib/tracks';
-import { cardAspectFor, coverCrop, cropKey } from '@/lib/crop';
+import { cardAspectFor, coverCrop, cropKey, type CropFocus } from '@/lib/crop';
 import { advanceVideoForExport, createCardVideo, isVideoSource, prepareVideoForSequentialExport, useVideoProxies, whenVideoReady } from '@/lib/videoTexture';
 import { BASE_PATH, IS_STATIC_EXPORT } from '@/lib/paths';
 import { advancedRasterSize, gradientRasterMaxEdge, gradientSignature, normalizeGradientSpec, paintGradientCanvas } from '@/lib/gradient';
@@ -233,7 +233,7 @@ export class SceneRenderer {
 
   // Cover-fit a loaded texture into the template's card shape: a cropped view
   // (no stretch) anchored at the asset's focal point. Cached per url/aspect/focus.
-  private croppedView(url: string, base: PIXI.Texture, aspect: number, crop?: { x: number; y: number }): PIXI.Texture {
+  private croppedView(url: string, base: PIXI.Texture, aspect: number, crop?: CropFocus): PIXI.Texture {
     const key = cropKey(url, aspect, crop);
     const hit = this.croppedCache.get(key);
     if (hit) return hit;
@@ -292,7 +292,7 @@ export class SceneRenderer {
     const pool = indices.map((i) => s.assets[i]).filter(Boolean);
 
     const assetSig = (repeat ? 'R|' : '') + 'A' + aspect.toFixed(4) + '|' +
-      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + (a.crop ? a.crop.x + ',' + a.crop.y : 'c')).join('|');
+      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + cropKey(a.url, aspect, a.crop)).join('|');
 
     if (count === rt.countSig && assetSig === rt.assetSig) return;
     rt.countSig = count;
@@ -328,7 +328,7 @@ export class SceneRenderer {
       let asset = pool[assetIndexForSlot(i, pool.length, repeat)];
       if (!asset && pool.length > 0) asset = pool[i % pool.length];
       const binding = asset
-        ? `${asset.id}|${asset.url}|${aspect.toFixed(4)}|${asset.crop?.x ?? 0.5},${asset.crop?.y ?? 0.5}`
+        ? `${asset.id}|${cropKey(asset.url, aspect, asset.crop)}`
         : `placeholder|${i}`;
       const bindingChanged = slot.bindKey !== binding;
       slot.bindKey = binding;

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -2,7 +2,7 @@ import * as PIXI from 'pixi.js';
 import type { LayerTransform } from '@/lib/types';
 import { getTemplate, layerCountFor } from '@/templates';
 import { getEffect } from '@/effects';
-import { applyPixiUniforms, pixiFilterFor } from '@/effects/adapters/pixi';
+import { applyPixiUniforms, dropPixiFilters, pixiFilterFor } from '@/effects/adapters/pixi';
 import { useSceneStore, type SceneState } from '@/store/useSceneStore';
 import { resolveEasing } from '@/lib/easing';
 import { assetIndexForSlot, clamp } from '@/lib/motion';
@@ -504,22 +504,66 @@ export class SceneRenderer {
   // floats. The old code lumped the two together and rebuilt filters whenever
   // any VALUE changed, which under the old contract cost nothing and under this
   // one would recompile a shader on every pixel of a dragged slider.
+  // O ESCOPO decide em qual container o filtro entra:
+  //   'scene'       `content`, que tem o fundo dentro (addChild(bg, ..., motion))
+  //   'artwork'     `motion`, so os cards — o fundo passa intacto
+  //   'track:<id>'  o container daquela camada
+  //
+  // `filterArea` e obrigatorio nos alvos que nao sao `content`. Sem ela o Pixi
+  // usa os limites do container, e ai `uInputSize` passa a descrever aquele
+  // retangulo em vez do quadro — um efeito medido a partir do centro (vinheta)
+  // se centraria no aglomerado de cards, e nao no canvas. A area e LOCAL ao
+  // container, e `motion` esta transladado para o centro, entao o retangulo
+  // comeca em -w/2,-h/2.
+  private targetFor(scope: string | undefined): PIXI.Container | null {
+    if (!scope || scope === 'scene') return this.content;
+    if (scope === 'artwork') return this.motion;
+    if (scope.startsWith('track:')) {
+      return this.trackRTs.get(scope.slice(6))?.container ?? null;
+    }
+    return this.content;
+  }
+
   private syncEffects(frame: number) {
     const s = useSceneStore.getState();
     const active = s.effects.filter((e) => e.enabled);
 
-    const sig = active.map((e) => e.instanceId + ':' + e.effectId).join('|');
+    // O escopo entra na assinatura: mudar de alvo troca a lista dos DOIS
+    // containers envolvidos, e sem isso a mudanca so apareceria no proximo
+    // add/remove.
+    const sig = active.map((e) => e.instanceId + ':' + e.effectId + '@' + (e.scope ?? 'scene')).join('|');
     if (sig !== this.lastFxSig) {
       this.lastFxSig = sig;
-      const filters: PIXI.Filter[] = [];
+      const porAlvo = new Map<PIXI.Container, PIXI.Filter[]>();
       for (const e of active) {
         const def = getEffect(e.effectId);
         if (!def) continue;
+        const alvo = this.targetFor(e.scope);
+        if (!alvo) continue;   // camada removida: o efeito fica sem alvo, e sem efeito
         try {
-          filters.push(pixiFilterFor(def));
+          const lista = porAlvo.get(alvo) ?? [];
+          lista.push(pixiFilterFor(def, e.instanceId));
+          porAlvo.set(alvo, lista);
         } catch { /* a shader that will not compile must not take the scene down */ }
       }
-      this.content.filters = filters.length ? filters : [];
+      // Limpar TODOS os alvos possiveis antes de aplicar: um efeito que saiu de
+      // 'artwork' para 'scene' deixaria o filtro velho pendurado em `motion`.
+      const alvos: PIXI.Container[] = [this.content, this.motion];
+      for (const rt of this.trackRTs.values()) alvos.push(rt.container);
+      for (const alvo of alvos) {
+        const lista = porAlvo.get(alvo) ?? [];
+        alvo.filters = lista.length ? lista : [];
+      }
+      // Instancias que sairam da cena nao precisam segurar filtro.
+      dropPixiFilters(new Set(active.map((e) => e.instanceId)));
+    }
+
+    // A area de filtro acompanha o canvas, e e reavaliada todo frame porque uma
+    // camada pode ter acabado de nascer.
+    const area = new PIXI.Rectangle(-s.width / 2, -s.height / 2, s.width, s.height);
+    if (this.motion.filters && (this.motion.filters as PIXI.Filter[]).length) this.motion.filterArea = area;
+    for (const rt of this.trackRTs.values()) {
+      if (rt.container.filters && (rt.container.filters as PIXI.Filter[]).length) rt.container.filterArea = area;
     }
 
     // Time comes from the FRAME, never from the clock: an animated effect has to
@@ -530,7 +574,7 @@ export class SceneRenderer {
       const def = getEffect(e.effectId);
       if (!def) continue;
       try {
-        applyPixiUniforms(pixiFilterFor(def), def, e.values, ctx);
+        applyPixiUniforms(pixiFilterFor(def, e.instanceId), def, e.values, ctx);
       } catch { /* a bad uniform must not take the scene down either */ }
     }
   }

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -2,7 +2,7 @@ import * as PIXI from 'pixi.js';
 import type { LayerTransform } from '@/lib/types';
 import { getTemplate, layerCountFor } from '@/templates';
 import { getEffect } from '@/effects';
-import { applyPixiUniforms, dropPixiFilters, pixiFilterFor } from '@/effects/adapters/pixi';
+import { applyPixiUniforms, dropPixiFilters, pixiFiltersFor } from '@/effects/adapters/pixi';
 import { useSceneStore, type SceneState } from '@/store/useSceneStore';
 import { resolveEasing } from '@/lib/easing';
 import { assetIndexForSlot, clamp } from '@/lib/motion';
@@ -542,7 +542,10 @@ export class SceneRenderer {
         if (!alvo) continue;   // camada removida: o efeito fica sem alvo, e sem efeito
         try {
           const lista = porAlvo.get(alvo) ?? [];
-          lista.push(pixiFilterFor(def, e.instanceId));
+          // Um efeito pode ser mais de um passe (blur separavel). O Pixi
+          // encadeia uma lista de filtros sozinho, entao os passes entram em
+          // sequencia na mesma lista.
+          lista.push(...pixiFiltersFor(def, e.instanceId));
           porAlvo.set(alvo, lista);
         } catch { /* a shader that will not compile must not take the scene down */ }
       }
@@ -574,7 +577,7 @@ export class SceneRenderer {
       const def = getEffect(e.effectId);
       if (!def) continue;
       try {
-        applyPixiUniforms(pixiFilterFor(def, e.instanceId), def, e.values, ctx);
+        applyPixiUniforms(pixiFiltersFor(def, e.instanceId), def, e.values, ctx);
       } catch { /* a bad uniform must not take the scene down either */ }
     }
   }

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -3,7 +3,7 @@ import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeom
 import { getTemplate, layerCountFor } from '@/templates';
 import { useSceneStore } from '@/store/useSceneStore';
 import { getEffect } from '@/effects';
-import { applyThreeUniforms, disposeThreeMaterials, threeMaterialFor } from '@/effects/adapters/three';
+import { applyThreeUniforms, disposeThreeMaterials, threeMaterialsFor } from '@/effects/adapters/three';
 import { resolveEasing } from '@/lib/easing';
 import { assetIndexForSlot, clamp, lerp } from '@/lib/motion';
 import { loadImage } from '@/lib/textureLoad';
@@ -1198,14 +1198,19 @@ export class SceneRenderer3D implements IRenderer {
           const def = getEffect(active.effectId);
           if (!def) continue;
           try {
-            const material = threeMaterialFor(def, active.instanceId);
-            applyThreeUniforms(material, def, active.values, fxCtx);
-            material.uniforms.map.value = de.texture;
-            this.fxQuad.material = material;
-            this.renderer.setRenderTarget(para);
-            this.renderer.clear(true, false, false);
-            this.renderer.render(this.fxScene, this.composeCam);
-            [de, para] = [para, de];
+            // Um efeito pode ter varios passes (blur separavel); cada passe e um
+            // giro a mais do mesmo ping-pong.
+            const materiais = threeMaterialsFor(def, active.instanceId);
+            for (let i = 0; i < materiais.length; i++) {
+              const material = materiais[i];
+              applyThreeUniforms(material, def, active.values, fxCtx, i);
+              material.uniforms.map.value = de.texture;
+              this.fxQuad.material = material;
+              this.renderer.setRenderTarget(para);
+              this.renderer.clear(true, false, false);
+              this.renderer.render(this.fxScene, this.composeCam);
+              [de, para] = [para, de];
+            }
           } catch { /* a shader that will not compile must not take the scene down */ }
         }
         return de;

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -93,6 +93,9 @@ export class SceneRenderer3D implements IRenderer {
   private safeLine: THREE.LineLoop | null = null;
   private composeA!: THREE.WebGLRenderTarget;
   private composeB!: THREE.WebGLRenderTarget;
+  // So nascem quando ha efeito fora de 'scene' (ver ensureBackgroundTarget).
+  private bgTarget: THREE.WebGLRenderTarget | null = null;
+  private layerScratch: THREE.WebGLRenderTarget | null = null;
   private composeScene = new THREE.Scene();
   private composeCam = new THREE.OrthographicCamera(-1, 1, 1, -1, -1, 1);
   private composeQuad!: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
@@ -152,6 +155,8 @@ export class SceneRenderer3D implements IRenderer {
     const rw = Math.max(1, Math.round(width * resolution));
     const rh = Math.max(1, Math.round(height * resolution));
     this.composeA?.setSize(rw, rh);
+    this.bgTarget?.setSize(rw, rh);
+    this.layerScratch?.setSize(rw, rh);
     this.composeB?.setSize(rw, rh);
     this.trackRTs.forEach((rt) => rt.target.setSize(rw, rh));
     this.camera.aspect = width / height;
@@ -198,6 +203,18 @@ export class SceneRenderer3D implements IRenderer {
     camera.updateProjectionMatrix();
   }
 
+  // Alvos que so existem quando alguem usa escopo fora de 'scene'. Uma cena sem
+  // efeito de arte ou de camada nao paga por eles.
+  private ensureBackgroundTarget(): THREE.WebGLRenderTarget {
+    if (!this.bgTarget) this.bgTarget = this.makeTarget(false);
+    return this.bgTarget;
+  }
+
+  private ensureLayerScratch(): THREE.WebGLRenderTarget {
+    if (!this.layerScratch) this.layerScratch = this.makeTarget(false);
+    return this.layerScratch;
+  }
+
   private makeTarget(depthBuffer: boolean) {
     const target = new THREE.WebGLRenderTarget(
       Math.max(1, Math.round(this.width * this.resolution)),
@@ -228,6 +245,10 @@ export class SceneRenderer3D implements IRenderer {
         layerMap: { value: null },
         opacity: { value: 1 },
         blendMode: { value: 0 },
+        // A camada chega com alpha PRE-MULTIPLICADO (0, o caso das tracks) ou
+        // DIRETO (1, o acumulador de arte, que ja saiu deste mesmo shader).
+        // Dividir por alpha o que ja e direto estoura a cor nas bordas do card.
+        layerIsStraight: { value: 0 },
       },
       vertexShader: `varying vec2 vUv; void main(){ vUv=uv; gl_Position=vec4(position.xy,0.0,1.0); }`,
       fragmentShader: `
@@ -235,12 +256,15 @@ export class SceneRenderer3D implements IRenderer {
         uniform sampler2D layerMap;
         uniform float opacity;
         uniform int blendMode;
+        uniform int layerIsStraight;
         varying vec2 vUv;
         void main(){
           vec4 base = texture2D(baseMap, vUv);
           vec4 layer = texture2D(layerMap, vUv);
           float a = clamp(layer.a * opacity, 0.0, 1.0);
-          vec3 straight = layer.a > 0.00001 ? layer.rgb / layer.a : vec3(0.0);
+          vec3 straight = layerIsStraight == 1
+            ? layer.rgb
+            : (layer.a > 0.00001 ? layer.rgb / layer.a : vec3(0.0));
           vec3 blend = straight;
           if (blendMode == 1) blend = min(vec3(1.0), base.rgb + straight);
           else if (blendMode == 2) blend = vec3(1.0) - (vec3(1.0) - base.rgb) * (vec3(1.0) - straight);
@@ -1109,18 +1133,84 @@ export class SceneRenderer3D implements IRenderer {
       if (!this.ready || this.destroyed || !this.renderer) return;
       const s = useSceneStore.getState();
 
-      // The accumulator begins with the scene background.
       const rawAlpha = s.background.alpha ?? 100;
       const alphaPct = (rawAlpha > 0 && rawAlpha <= 1) ? rawAlpha * 100 : rawAlpha;
       const bgAlpha = Math.max(0, Math.min(1, alphaPct / 100));
 
-      this.renderer.setRenderTarget(this.composeA);
-      this.renderer.setClearColor(new THREE.Color(s.background.color), bgAlpha);
-      this.renderer.clear(true, true, true);
-      this.renderer.render(this.scene, this.camera);
+      // O resolution entregue ao shader e o do ALVO, nao o da cena: no export a
+      // cadeia inteira roda supersampled, e um efeito medido em pixels de cena
+      // sairia proporcionalmente mais fino no quadro exportado do que na tela.
+      const fxCtx = {
+        width: this.width * this.resolution,
+        height: this.height * this.resolution,
+        time: frame / Math.max(1, s.fps),
+      };
+      const ativos = s.effects.filter((e) => e.enabled && getEffect(e.effectId));
+      const escopoDe = (e: { scope?: string }) => e.scope ?? 'scene';
+      const daCena = ativos.filter((e) => escopoDe(e) === 'scene');
+      const daArte = ativos.filter((e) => escopoDe(e) === 'artwork');
+      const porCamada = new Map<string, typeof ativos>();
+      for (const e of ativos) {
+        const esc = escopoDe(e);
+        if (!esc.startsWith('track:')) continue;
+        const id = esc.slice(6);
+        porCamada.set(id, [...(porCamada.get(id) ?? []), e]);
+      }
+
+      // Um efeito de 'artwork' ou de camada exige que a arte seja composta SEM o
+      // fundo, para o fundo passar intacto. Isso custa um alvo a mais e um
+      // passe de composicao no fim, entao so acontece quando alguem pediu: sem
+      // efeito fora de 'scene', o caminho e exatamente o de antes, com o fundo
+      // entrando direto no acumulador.
+      const separarFundo = daArte.length > 0 || porCamada.size > 0;
 
       let read = this.composeA;
       let write = this.composeB;
+
+      if (separarFundo) {
+        const fundo = this.ensureBackgroundTarget();
+        this.renderer.setRenderTarget(fundo);
+        this.renderer.setClearColor(new THREE.Color(s.background.color), bgAlpha);
+        this.renderer.clear(true, true, true);
+        this.renderer.render(this.scene, this.camera);
+        // O acumulador comeca VAZIO: so a arte entra nele.
+        this.renderer.setRenderTarget(this.composeA);
+        this.renderer.setClearColor(0x000000, 0);
+        this.renderer.clear(true, true, true);
+      } else {
+        // The accumulator begins with the scene background.
+        this.renderer.setRenderTarget(this.composeA);
+        this.renderer.setClearColor(new THREE.Color(s.background.color), bgAlpha);
+        this.renderer.clear(true, true, true);
+        this.renderer.render(this.scene, this.camera);
+      }
+
+      // Uma cadeia de passes sobre um par de alvos, devolvendo o que ficou com o
+      // resultado. Um so lugar para a mecanica, usada pelos tres escopos.
+      const rodarPasses = (
+        lista: typeof ativos,
+        entrada: THREE.WebGLRenderTarget,
+        rascunho: THREE.WebGLRenderTarget,
+      ): THREE.WebGLRenderTarget => {
+        let de = entrada;
+        let para = rascunho;
+        for (const active of lista) {
+          const def = getEffect(active.effectId);
+          if (!def) continue;
+          try {
+            const material = threeMaterialFor(def, active.instanceId);
+            applyThreeUniforms(material, def, active.values, fxCtx);
+            material.uniforms.map.value = de.texture;
+            this.fxQuad.material = material;
+            this.renderer.setRenderTarget(para);
+            this.renderer.clear(true, false, false);
+            this.renderer.render(this.fxScene, this.composeCam);
+            [de, para] = [para, de];
+          } catch { /* a shader that will not compile must not take the scene down */ }
+        }
+        return de;
+      };
+
       const composeMaterial = this.composeQuad.material;
       s.tracks.forEach((track) => {
         const rt = this.trackRTs.get(track.id);
@@ -1132,9 +1222,16 @@ export class SceneRenderer3D implements IRenderer {
         this.renderer.clear(true, true, true);
         this.renderer.render(rt.scene, rt.camera);
 
+        // Efeitos DESTA camada, antes de ela entrar na composicao: e o que faz
+        // um escopo de camada ser de camada e nao do quadro.
+        let camada = rt.target;
+        const daCamada = porCamada.get(track.id);
+        if (daCamada?.length) camada = rodarPasses(daCamada, rt.target, this.ensureLayerScratch());
+
         composeMaterial.uniforms.baseMap.value = read.texture;
-        composeMaterial.uniforms.layerMap.value = rt.target.texture;
+        composeMaterial.uniforms.layerMap.value = camada.texture;
         composeMaterial.uniforms.opacity.value = rt.opacity;
+        composeMaterial.uniforms.layerIsStraight.value = 0;
         composeMaterial.uniforms.blendMode.value = rt.blend === 'add' ? 1
           : rt.blend === 'screen' ? 2
           : rt.blend === 'multiply' ? 3 : 0;
@@ -1144,36 +1241,29 @@ export class SceneRenderer3D implements IRenderer {
         [read, write] = [write, read];
       });
 
-      // Effects, as further passes on the SAME ping-pong the tracks just used.
-      // Until now this pass looked pixelate up by id and folded it into the output
-      // quad, so the other effects in effects/ simply did not exist for the webgl
-      // presets. Each active effect is now a pass, applied in the order the panel
-      // lists them — the same order the 2D path gives PIXI.Container.filters.
-      //
-      // The resolution handed to the shader is the RENDER TARGET's, not the
-      // scene's: during export the whole chain runs supersampled, and an effect
-      // measured in scene pixels would come out proportionally finer in the
-      // exported frame than on screen.
-      const fxCtx = {
-        width: this.width * this.resolution,
-        height: this.height * this.resolution,
-        time: frame / Math.max(1, s.fps),
-      };
-      for (const active of s.effects) {
-        if (!active.enabled) continue;
-        const def = getEffect(active.effectId);
-        if (!def) continue;
-        try {
-          const material = threeMaterialFor(def);
-          applyThreeUniforms(material, def, active.values, fxCtx);
-          material.uniforms.map.value = read.texture;
-          this.fxQuad.material = material;
-          this.renderer.setRenderTarget(write);
-          this.renderer.clear(true, false, false);
-          this.renderer.render(this.fxScene, this.composeCam);
-          [read, write] = [write, read];
-        } catch { /* a shader that will not compile must not take the scene down */ }
+      if (separarFundo) {
+        // Efeitos da ARTE, com o acumulador ainda sem fundo.
+        read = rodarPasses(daArte, read, write);
+        write = read === this.composeA ? this.composeB : this.composeA;
+        // Agora sim a arte por cima do fundo. `layerIsStraight` porque o
+        // acumulador ja saiu do compose com alpha DIRETO — dividir por alpha de
+        // novo estouraria a cor das bordas dos cards.
+        composeMaterial.uniforms.baseMap.value = this.ensureBackgroundTarget().texture;
+        composeMaterial.uniforms.layerMap.value = read.texture;
+        composeMaterial.uniforms.opacity.value = 1;
+        composeMaterial.uniforms.blendMode.value = 0;
+        composeMaterial.uniforms.layerIsStraight.value = 1;
+        this.renderer.setRenderTarget(write);
+        this.renderer.clear(true, false, false);
+        this.renderer.render(this.composeScene, this.composeCam);
+        [read, write] = [write, read];
+        composeMaterial.uniforms.layerIsStraight.value = 0;
       }
+
+      // Efeitos da CENA, sobre o quadro composto — fundo incluido. Na ordem em
+      // que o painel os lista, a mesma ordem que o caminho 2D da a
+      // PIXI.Container.filters.
+      read = rodarPasses(daCena, read, write);
 
       this.outputQuad.material.uniforms.map.value = read.texture;
       this.renderer.setRenderTarget(null);
@@ -1228,6 +1318,8 @@ export class SceneRenderer3D implements IRenderer {
     this.backgroundTex?.dispose();
     this.backgroundGeneration++;
     this.composeA?.dispose();
+    this.bgTarget?.dispose();
+    this.layerScratch?.dispose();
     this.composeB?.dispose();
     this.composeQuad?.geometry.dispose();
     this.composeQuad?.material.dispose();

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -7,7 +7,7 @@ import { applyThreeUniforms, disposeThreeMaterials, threeMaterialFor } from '@/e
 import { resolveEasing } from '@/lib/easing';
 import { assetIndexForSlot, clamp, lerp } from '@/lib/motion';
 import { loadImage } from '@/lib/textureLoad';
-import { cardAspectFor, coverCrop, cropKey } from '@/lib/crop';
+import { cardAspectFor, coverCrop, cropKey, type CropFocus } from '@/lib/crop';
 import { advanceVideoForExport, createCardVideo, isVideoSource, prepareVideoForSequentialExport, useVideoProxies } from '@/lib/videoTexture';
 import { BASE_PATH, IS_STATIC_EXPORT } from '@/lib/paths';
 import type { IRenderer } from '@/lib/rendererTypes';
@@ -283,7 +283,7 @@ export class SceneRenderer3D implements IRenderer {
 
   // Cover-fit via UV window (repeat/offset) on a clone sharing the decoded
   // image — mirrors the Pixi renderer's frame-cropped texture views.
-  private croppedView(url: string, base: THREE.Texture, aspect: number, crop?: { x: number; y: number }): { tex: THREE.Texture; fw: number; fh: number } {
+  private croppedView(url: string, base: THREE.Texture, aspect: number, crop?: CropFocus): { tex: THREE.Texture; fw: number; fh: number } {
     const img = base.image as HTMLImageElement;
     const { fx, fy, fw, fh } = coverCrop(img.width, img.height, aspect, crop);
     const key = cropKey(url, aspect, crop);
@@ -387,7 +387,7 @@ export class SceneRenderer3D implements IRenderer {
       { width: s.width, height: s.height, cardAspect: aspect });
     const pool = trackAssetIndices(track, s.assets).map((i) => s.assets[i]).filter(Boolean);
     const assetSig = (repeat ? 'R|' : '') + 'A' + aspect.toFixed(4) + '|' +
-      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + (a.crop ? a.crop.x + ',' + a.crop.y : 'c')).join('|');
+      pool.map((a) => a.id + ':' + a.url + ':' + a.visible + ':' + cropKey(a.url, aspect, a.crop)).join('|');
     if (!rt.r3fManaged && r3fManaged) {
       // Entering the R3F-managed Box from another WebGL template keeps the
       // same renderer and track runtime. Remove the previous native meshes
@@ -492,7 +492,7 @@ export class SceneRenderer3D implements IRenderer {
       let asset = pool[assetIndexForSlot(i, pool.length, repeat)];
       if (!asset && pool.length > 0) asset = pool[i % pool.length];
       const binding = asset
-        ? `${asset.id}|${asset.url}|${aspect.toFixed(4)}|${asset.crop?.x ?? 0.5},${asset.crop?.y ?? 0.5}`
+        ? `${asset.id}|${cropKey(asset.url, aspect, asset.crop)}`
         : `placeholder|${i}`;
       const bindingChanged = slot.bindKey !== binding;
       slot.bindKey = binding;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -247,4 +247,13 @@ export interface Effect {
   };
   controls: ControlDef[];
   shader: EffectShader;
+  // Passes ADICIONAIS, rodados em ordem depois de `shader`, cada um lendo a
+  // saida do anterior. Existe para o blur gaussiano, que so e linear se for
+  // SEPARAVEL: um passe horizontal e um vertical. Um blur de raio r feito num
+  // passe unico custa (2r+1)^2 amostras; separado custa 2*(2r+1) — a 20px de
+  // raio, 1681 contra 82.
+  //
+  // `shader` continua sendo o primeiro passe, entao todo efeito de passe unico
+  // segue valendo sem mudar nada.
+  passes?: EffectShader[];
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -226,8 +226,25 @@ export interface EffectShader {
   uniforms: (values: Record<string, any>, ctx: EffectContext) => Record<string, number | number[]>;
 }
 
+// Onde um efeito age. Guardado como string na cena para sobreviver a
+// serializacao; ausente significa 'scene', que e como toda cena salva antes
+// deste campo se comporta.
+//
+//   'scene'       o quadro composto inteiro, FUNDO INCLUIDO
+//   'artwork'     so os cards; o fundo da cena passa intacto
+//   'track:<id>'  so uma camada
+export type EffectScope = 'scene' | 'artwork' | `track:${string}`;
+
 export interface Effect {
-  meta: { id: string; name: string };
+  meta: {
+    id: string;
+    name: string;
+    // Onde este efeito entra ao ser adicionado. Grao, vinheta e scanlines sao
+    // efeitos de CAMERA e pertencem ao quadro todo. O Wave desloca geometria: no
+    // quadro todo ele arrasta o fundo junto e abre borda vazia, sem ganhar nada,
+    // entao nasce em 'artwork'. E so o ponto de partida — o usuario troca depois.
+    defaultScope?: EffectScope;
+  };
   controls: ControlDef[];
   shader: EffectShader;
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Motion Studio — an open-source factory for quick videos and GIFs.",
   "main": "index.js",
   "scripts": {
-    "test": "node scripts/verify-tilt.cjs && node scripts/verify-catalogue.cjs && node scripts/verify-contexts.cjs && node scripts/verify-reference.cjs && node scripts/verify-effects.cjs && node scripts/verify-gradients.cjs && node scripts/verify-gated-sections.cjs && node scripts/verify-docs-routes.cjs",
+    "test": "node scripts/verify-tilt.cjs && node scripts/verify-catalogue.cjs && node scripts/verify-contexts.cjs && node scripts/verify-reference.cjs && node scripts/verify-effects.cjs && node scripts/verify-gradients.cjs && node scripts/verify-gated-sections.cjs && node scripts/verify-docs-routes.cjs && node scripts/verify-crop.cjs",
     "dev": "next dev",
     "dev:network": "next dev -H 0.0.0.0",
     "build": "next build",

--- a/scripts/_probe_effect_scope.cjs
+++ b/scripts/_probe_effect_scope.cjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// O escopo do efeito muda o que ele alcanca?
+//
+// O Wave desloca a coordenada de amostragem. No quadro composto ele arrasta o
+// FUNDO junto, e como a amostra sai do quadro e volta transparente, aparece uma
+// faixa vazia na borda da cena. Sobre a arte, o fundo tem de sair intacto.
+//
+// A medida e a BORDA, nao a impressao: quantos pixels das colunas extremas
+// deixaram de ser a cor do fundo. Com escopo 'scene' esse numero tem de subir;
+// com 'artwork' tem de ficar no chao. Mede tambem quantos pixels do quadro
+// inteiro sao exatamente a cor de fundo, que e o "o fundo passou intacto?".
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const EFEITO = process.argv[3] || 'Wave';
+
+const CASOS = [
+  { nome: '2D (Pixi)', preset: null },
+  { nome: 'webgl (three)', preset: { rotulo: 'Ring Stream', grupo: 'Orbit 3D' } },
+];
+
+const MEDIR = function () {
+  const c = document.querySelector('canvas.stage-canvas');
+  if (!c || !c.width) return null;
+  const o = document.createElement('canvas');
+  o.width = c.width; o.height = c.height;
+  const g = o.getContext('2d'); g.drawImage(c, 0, 0);
+  const d = g.getImageData(0, 0, c.width, c.height).data;
+  const hist = new Map();
+  for (let i = 0; i < d.length; i += 4) {
+    const k = d[i] + ',' + d[i + 1] + ',' + d[i + 2];
+    hist.set(k, (hist.get(k) || 0) + 1);
+  }
+  let fundo = [0, 0, 0], max = 0;
+  for (const [k, n] of hist) if (n > max) { max = n; fundo = k.split(',').map(Number); }
+  const igualAoFundo = (i) => Math.abs(d[i] - fundo[0]) + Math.abs(d[i + 1] - fundo[1]) + Math.abs(d[i + 2] - fundo[2]) < 12;
+  // colunas extremas: 6 px de cada lado, onde a faixa vazia do wave aparece
+  let bordaTotal = 0, bordaQuebrada = 0;
+  for (let y = 0; y < c.height; y++) {
+    for (const x of [0, 1, 2, 3, 4, 5, c.width - 6, c.width - 5, c.width - 4, c.width - 3, c.width - 2, c.width - 1]) {
+      const i = (y * c.width + x) * 4;
+      bordaTotal++;
+      if (!igualAoFundo(i)) bordaQuebrada++;
+    }
+  }
+  let pixelsDeFundo = 0;
+  for (let i = 0; i < d.length; i += 4) if (igualAoFundo(i)) pixelsDeFundo++;
+  return { fundo: fundo.join(','), pixelsDeFundo, bordaQuebrada, bordaTotal };
+};
+
+const semear = function () {
+  const scene = {
+    activeTemplateId: 'arc-01',
+    tracks: [{ id: 't0', templateId: 'arc-01' }],
+    width: 810, height: 1080, fps: 30, duration: 8,
+    background: { source: 'color', color: '#1a1a1a', gradient: false, color2: '#1a1a1a', imageUrl: null, blur: 28 },
+    effects: [],
+  };
+  localStorage.setItem('motion-welcome-seen', '1');
+  localStorage.setItem('motion-tour-seen', '1');
+  localStorage.setItem('motion-scene-v1', JSON.stringify(scene));
+  localStorage.setItem('motion-project-fx', JSON.stringify(scene));
+  localStorage.setItem('motion-projects-v1', JSON.stringify({
+    activeId: 'fx', projects: [{ id: 'fx', name: 'Escopo', createdAt: 1, updatedAt: 2, mode: '2d' }],
+  }));
+};
+
+const escolher = async function (rotulo, grupo) {
+  document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+  const achar = () => Array.from(document.querySelectorAll('.tpl-card'))
+    .find((el) => { const l = el.querySelector('.tpl-card-label'); return l && l.textContent.trim() === rotulo; });
+  if (!achar()) {
+    const linha = Array.from(document.querySelectorAll('.tpl-item'))
+      .find((el) => (el.textContent || '').trim().startsWith(grupo));
+    if (!linha) return 'grupo nao achado';
+    linha.click();
+    await new Promise((r) => setTimeout(r, 900));
+  }
+  const card = achar();
+  if (!card) return 'preset nao apareceu';
+  (card.querySelector('.tpl-card-label') || card).click();
+  await new Promise((r) => setTimeout(r, 3000));
+  return 'ok';
+};
+
+const adicionar = async function (nome) {
+  const sel = Array.from(document.querySelectorAll('select'))
+    .find((s) => Array.from(s.options).some((o) => o.textContent.trim() === nome));
+  if (!sel) return 'sem select';
+  sel.value = Array.from(sel.options).find((o) => o.textContent.trim() === nome).value;
+  sel.dispatchEvent(new Event('change', { bubbles: true }));
+  await new Promise((r) => setTimeout(r, 150));
+  Array.from(document.querySelectorAll('button')).find((b) => b.textContent.trim() === 'Add').click();
+  await new Promise((r) => setTimeout(r, 1500));
+  const card = Array.from(document.querySelectorAll('.effect-card'))
+    .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === nome; });
+  if (!card) return 'card nao apareceu';
+  const escopo = card.querySelector('.effect-scope-row select');
+  return 'escopo inicial: ' + (escopo ? escopo.value : 'SEM SELETOR');
+};
+
+const trocarEscopo = async function (nome, valor) {
+  const card = Array.from(document.querySelectorAll('.effect-card'))
+    .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === nome; });
+  const sel = card && card.querySelector('.effect-scope-row select');
+  if (!sel) return 'sem seletor';
+  const opt = Array.from(sel.options).find((o) => o.value === valor || o.value.startsWith(valor));
+  if (!opt) return 'sem opcao ' + valor + ' (tem: ' + Array.from(sel.options).map((o) => o.value).join(',') + ')';
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value').set;
+  setter.call(sel, opt.value);
+  sel.dispatchEvent(new Event('change', { bubbles: true }));
+  await new Promise((r) => setTimeout(r, 1200));
+  return opt.value;
+};
+
+(async () => {
+  for (const caso of CASOS) {
+    console.log('');
+    console.log('=== ' + caso.nome + ' — ' + EFEITO + ' ===');
+    const b = await puppeteer.launch({
+      executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+      args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+    });
+    const p = await b.newPage();
+    p.on('pageerror', (e) => console.log('  [pageerror]', String(e).slice(0, 180)));
+    await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+    await p.evaluate(semear);
+    await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+    await p.evaluate(() => {
+      document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+    });
+    if (caso.preset) console.log('  preset ', await p.evaluate(escolher, caso.preset.rotulo, caso.preset.grupo));
+    const pintou = await p.waitForFunction(
+      function (fn) { const m = new Function('return (' + fn + ')()')(); return !!m && m.pixelsDeFundo > 50000; },
+      { timeout: 60000, polling: 700 }, MEDIR.toString(),
+    ).then(() => true).catch(() => false);
+    if (!pintou) { console.log('  palco nao pintou'); await b.close(); continue; }
+    console.log('  sem efeito     ', JSON.stringify(await p.evaluate(MEDIR)));
+    console.log('  add            ', await p.evaluate(adicionar, EFEITO));
+    // pausa: as tres leituras tem de sair do mesmo frame
+    await p.evaluate(async () => {
+      const btn = document.querySelector('.play-btn');
+      if (btn && btn.getAttribute('title') === 'Pause') { btn.click(); await new Promise((r) => setTimeout(r, 600)); }
+    });
+    for (const alvo of ['artwork', 'scene', 'track:']) {
+      const aplicado = await p.evaluate(trocarEscopo, EFEITO, alvo);
+      console.log('  ' + String(alvo).padEnd(9) + ' -> ' + String(aplicado).padEnd(14) + JSON.stringify(await p.evaluate(MEDIR)));
+    }
+    await b.close();
+  }
+})();

--- a/scripts/verify-crop.cjs
+++ b/scripts/verify-crop.cjs
@@ -1,0 +1,31 @@
+// Crop geometry must stay identical in the editor, Pixi and Three texture views.
+require('sucrase/register');
+const assert = require('node:assert/strict');
+const { coverCrop, cropKey, cropFromRect, normalizeCrop, cardAspectFor } = require('../lib/crop');
+const near = (a, b) => assert.ok(Math.abs(a - b) < 1e-7, `${a} != ${b}`);
+assert.deepEqual(coverCrop(1200, 800, 1), { fx: 200, fy: 0, fw: 800, fh: 800 });
+assert.deepEqual(coverCrop(1200, 800, 1, { x: 1, y: 0 }), { fx: 400, fy: 0, fw: 800, fh: 800 });
+assert.deepEqual(coverCrop(1200, 800, 1, { x: .5, y: .5, zoom: 2 }), { fx: 400, fy: 200, fw: 400, fh: 400 });
+assert.deepEqual(normalizeCrop({ x: NaN, y: Infinity, zoom: NaN }), { x: .5, y: .5, zoom: 1 });
+assert.deepEqual(normalizeCrop({ x: -2, y: 8, zoom: 90 }), { x: 0, y: 1, zoom: 5 });
+assert.equal(cropKey('a', 1), cropKey('a', 1, { x: .5, y: .5, zoom: 1 }));
+assert.notEqual(cropKey('a', 1), cropKey('a', 1, { x: .5, y: .5, zoom: 2 }));
+assert.equal(cardAspectFor({ cardAspect: 'canvas' }, 1920, 1080, '1:1'), 1920 / 1080);
+let cases = 0;
+for (const [w, h] of [[1200, 800], [800, 1200], [1000, 1000], [1, 1]]) {
+  for (const aspect of [.1, 9/16, .8, 1, 16/9, 10]) {
+    for (const zoom of [1, 1.01, 2, 5]) {
+      for (const x of [0, .27, .5, 1]) for (const y of [0, .63, 1]) {
+        const r = coverCrop(w, h, aspect, {x, y, zoom});
+        near(r.fw / r.fh, aspect);
+        assert.ok(r.fx >= 0 && r.fy >= 0 && r.fx + r.fw <= w + 1e-7 && r.fy + r.fh <= h + 1e-7);
+        {
+          const roundtrip = coverCrop(w, h, aspect, cropFromRect(w, h, aspect, r.fx, r.fy, r.fw));
+          for (const key of ['fx', 'fy', 'fw', 'fh']) near(roundtrip[key], r[key]);
+        }
+        cases++;
+      }
+    }
+  }
+}
+console.log(`Crop: ${cases} geometry cases passed; legacy crops, zoom, bounds and cache invalidation passed.`);

--- a/scripts/verify-effects-gl.cjs
+++ b/scripts/verify-effects-gl.cjs
@@ -41,7 +41,7 @@ Module._resolveFilename = function (request, parent, isMain, options) {
 };
 
 const { effects, effectDefaults } = require('../effects');
-const { pixiFragment, threeFragment } = require('../effects/adapters/glsl');
+const { passesOf, pixiFragment, threeFragment } = require('../effects/adapters/glsl');
 
 const CHROME = [
   'C:/Program Files/Google/Chrome/Application/chrome.exe',
@@ -69,6 +69,12 @@ for (const [id, fx] of Object.entries(effects)) {
       // Cabecalho de ES 3.00 na frente: o vertex compartilhado deste teste e
       // 300 es, e misturar versoes nao linka.
       .replace(/^/, ["#version 300 es", "precision highp float;", "out vec4 fx_out;", ""].join(String.fromCharCode(10))),
+    // TODOS os passes, para o compilador ver cada um. Um efeito separavel tem o
+    // segundo passe fora de `shader`, e sem isto ele nunca chegaria a GPU — que
+    // e exatamente onde `sample`, palavra reservada em GLSL ES 3.00, apareceu da
+    // primeira vez, com a suite estrutural verde ao lado.
+    fragmentosDosPasses: passesOf(fx).map((p) => pixiFragment(fx, p)),
+    uniformsDosPasses: passesOf(fx).map((p) => p.uniforms(d, { width: 256, height: 256, time: 0 })),
     u0: fx.shader.uniforms(d, { width: 256, height: 256, time: 0 }),
     u1: fx.shader.uniforms(d, { width: 256, height: 256, time: 1 }),
     // Os valores dos CONTROLES vao junto: o esperado de um teste tem de vir da
@@ -140,6 +146,14 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
       // faixa branca de 8px no meio, para o split ter uma borda para deslocar
       faixa: makeTex((x) => (Math.abs(x - W / 2) < 4 ? [255, 255, 255] : [0, 0, 0])),
       ruido: makeTex((x, y) => { const i = y * W + x; return [(i*37)%256, (i*91)%256, (i*17)%256]; }),
+      // Ruido que varia nos DOIS eixos. O `ruido` acima nao serve para medir um
+      // blur vertical: com i = y*W + x e W = 256, andar uma linha soma 256 a i,
+      // e (i*37)%256 volta ao mesmo valor — a textura e constante em Y, e o
+      // teste do segundo passe media zero contra zero e "passava" por acidente.
+      ruido2d: makeTex((x, y) => {
+        const h = (x * 73856093) ^ (y * 19349663);
+        return [(h >>> 3) % 256, (h >>> 11) % 256, (h >>> 19) % 256];
+      }),
       // degrade horizontal liso: revela banding (posterize) e a trama (halftone)
       degrade: makeTex((x) => { const v = Math.round((x / (W - 1)) * 255); return [v, v, v]; }),
       // O MESMO degrade, mas em espaco LINEAR — que e o que o three recebe de
@@ -351,6 +365,97 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
       r.medidas.pixelate = { desvio_intra_bloco: +dv.toFixed(3), desvio_original: +desvio(run(fx.pixelate.fragment, { uSize: [1, 1] }, TEX.ruido)).toFixed(3) };
       if (dv > 0.5) r.falhas.push(`pixelate: os blocos de ${N}px nao ficaram uniformes (desvio ${dv.toFixed(2)})`);
     } catch (e) { r.falhas.push('pixelate: ' + String(e.message).slice(0, 160)); }
+
+    // ---- TODO PASSE TEM DE COMPILAR ----
+    //
+    // Um efeito separavel tem o segundo passe fora de `shader`, e as medidas
+    // acima so tocam o primeiro. Sem isto, um erro de GLSL no passe vertical de
+    // um blur passaria verde nas duas suites — que foi exatamente o que
+    // aconteceu com `sample`, palavra reservada em GLSL ES 3.00, quando so a
+    // suite estrutural existia.
+    let passesCompilados = 0;
+    for (const [id, e] of Object.entries(fx)) {
+      const lista = e.fragmentosDosPasses || [];
+      for (let i = 0; i < lista.length; i++) {
+        try {
+          run(lista[i], e.uniformsDosPasses[i] || {}, TEX.degrade);
+          passesCompilados++;
+        } catch (err) {
+          r.falhas.push(id + ': passe ' + (i + 1) + '/' + lista.length + ' nao compilou — ' + String(err.message).slice(0, 140));
+        }
+      }
+    }
+    r.medidas['passes'] = { compilados: passesCompilados, efeitos: Object.keys(fx).length };
+
+    // ---- BLUR: o desvio local tem de CAIR, e o passe 2 tem de participar ----
+    //
+    // Rodar so o passe horizontal deixa a variacao VERTICAL intacta. Medir os
+    // dois desvios separadamente e o que distingue "borrou" de "borrou nos dois
+    // eixos" — um blur separavel com o segundo passe morto passaria num teste de
+    // desvio global.
+    try {
+      const desvioEixo = (px, dx, dy) => {
+        let soma = 0, n = 0;
+        for (let y = 4; y < H - 4; y += 3) for (let x = 4; x < W - 4; x += 3) {
+          const a = px[((y) * W + x) * 4];
+          const b = px[((y + dy) * W + (x + dx)) * 4];
+          soma += Math.abs(a - b); n++;
+        }
+        return soma / n;
+      };
+      const original = run(fx.blur.fragmentosDosPasses[0], { ...fx.blur.uniformsDosPasses[0], uRadius: 0 }, TEX.ruido2d);
+      // passe 1 sobre o ruido, depois passe 2 sobre a saida do 1 nao e possivel
+      // aqui (o harness desenha para o canvas), entao mede-se cada passe sobre o
+      // ruido: o horizontal tem de derrubar a variacao em X, o vertical em Y.
+      const h = run(fx.blur.fragmentosDosPasses[0], fx.blur.uniformsDosPasses[0], TEX.ruido2d);
+      const v = run(fx.blur.fragmentosDosPasses[1], fx.blur.uniformsDosPasses[1], TEX.ruido2d);
+      const m = {
+        original_x: +desvioEixo(original, 1, 0).toFixed(1),
+        horizontal_x: +desvioEixo(h, 1, 0).toFixed(1),
+        original_y: +desvioEixo(original, 0, 1).toFixed(1),
+        vertical_y: +desvioEixo(v, 0, 1).toFixed(1),
+      };
+      r.medidas.blur = m;
+      if (m.horizontal_x >= m.original_x * 0.6) r.falhas.push('blur: o passe horizontal nao derrubou a variacao em X (' + m.original_x + ' -> ' + m.horizontal_x + ')');
+      if (m.vertical_y >= m.original_y * 0.6) r.falhas.push('blur: o passe vertical nao derrubou a variacao em Y (' + m.original_y + ' -> ' + m.vertical_y + ') — o segundo passe pode estar inerte');
+    } catch (e) { r.falhas.push('blur: ' + String(e.message).slice(0, 160)); }
+
+    // ---- TILT-SHIFT: a faixa em foco tem de ficar mais nitida que as pontas ----
+    try {
+      const nitidez = (px, y0, y1) => {
+        let soma = 0, n = 0;
+        for (let y = y0; y < y1; y++) for (let x = 4; x < W - 4; x += 2) {
+          soma += Math.abs(px[(y * W + x) * 4] - px[(y * W + x + 1) * 4]); n++;
+        }
+        return soma / n;
+      };
+      const t = run(fx['tilt-shift'].fragmentosDosPasses[0], fx['tilt-shift'].uniformsDosPasses[0], TEX.ruido2d);
+      const meio = nitidez(t, (H >> 1) - 12, (H >> 1) + 12);
+      const topo = nitidez(t, 4, 28);
+      r.medidas['tilt-shift'] = { faixaEmFoco: +meio.toFixed(1), foraDaFaixa: +topo.toFixed(1) };
+      if (meio <= topo * 1.5) r.falhas.push('tilt-shift: a faixa de foco nao esta mais nitida que as pontas (' + meio.toFixed(1) + ' vs ' + topo.toFixed(1) + ')');
+    } catch (e) { r.falhas.push('tilt-shift: ' + String(e.message).slice(0, 160)); }
+
+    // ---- BLOOM: so o que passa do limiar transborda, e ele SOMA luz ----
+    try {
+      const linha = (px, x) => px[((H >> 1) * W + x) * 4];
+      // A ENERGIA numa faixa ao lado, nao um pixel: o bloom espalha pouca luz
+      // por muitos pixels, entao um ponto isolado mede quase nada e o teste
+      // viraria uma questao de escolher bem o ponto. Somar a banda mede o que o
+      // efeito realmente entrega.
+      const energia = (px, x0, x1) => {
+        let soma = 0;
+        for (let y = 0; y < H; y++) for (let x = x0; x < x1; x++) soma += px[(y * W + x) * 4];
+        return soma;
+      };
+      const b = run(fx.bloom.fragment, fx.bloom.u0, TEX.faixa);
+      const sem = run(fx.bloom.fragment, { ...fx.bloom.u0, uIntensity: 0 }, TEX.faixa);
+      const x0 = (W >> 1) + 6, x1 = (W >> 1) + 30;
+      const com = energia(b, x0, x1), base = energia(sem, x0, x1);
+      r.medidas.bloom = { energiaVizinha_com: com, energiaVizinha_sem: base, centro: linha(b, W >> 1) };
+      if (com <= base) r.falhas.push('bloom: o brilho nao transbordou para o lado da faixa (' + base + ' -> ' + com + ')');
+      if (linha(b, W >> 1) < 250) r.falhas.push('bloom: o centro da faixa branca escureceu (' + linha(b, W >> 1) + ') — bloom SOMA, nao mistura');
+    } catch (e) { r.falhas.push('bloom: ' + String(e.message).slice(0, 160)); }
 
     // ---- PARIDADE ENTRE ENGINES ----
     //

--- a/scripts/verify-effects.cjs
+++ b/scripts/verify-effects.cjs
@@ -53,6 +53,15 @@ for (const effect of effectList) {
   check(Array.isArray(effect.controls), id, 'controls nao e uma lista');
   check(!!effect.shader?.fragment, id, 'shader.fragment ausente');
   check(typeof effect.shader?.uniforms === 'function', id, 'shader.uniforms nao e funcao');
+
+  // O escopo em que o efeito NASCE. So faz sentido declarar 'scene' ou
+  // 'artwork': um id de camada nao existe na hora em que o efeito e escrito, e
+  // guardar `track:` aqui daria um efeito que nasce apontando para uma camada
+  // de outra cena — sem alvo, ele simplesmente nao pinta.
+  const escopo = effect.meta?.defaultScope;
+  check(escopo === undefined || escopo === 'scene' || escopo === 'artwork', id,
+    `meta.defaultScope invalido (${escopo}) — use 'scene', 'artwork', ou nada`);
+
   if (!effect.shader?.fragment) continue;
 
   // ---- the fragment itself ----

--- a/scripts/verify-effects.cjs
+++ b/scripts/verify-effects.cjs
@@ -64,42 +64,53 @@ for (const effect of effectList) {
 
   if (!effect.shader?.fragment) continue;
 
+  // Um efeito pode ter mais de um PASSE (blur separavel: um horizontal, um
+  // vertical). Verificar so `shader` deixaria o segundo passe sem rede —
+  // controle morto, uniform declarado e nunca escrito, nome reservado
+  // redeclarado: nada disso apareceria. Cada passe passa pelas MESMAS
+  // checagens, e a contagem de asserçoes sobe junto.
+  const passes = [effect.shader, ...(effect.passes ?? [])];
+  for (const pass of passes) {
+  check(!!pass?.fragment && typeof pass?.uniforms === 'function', id,
+    'um passe esta sem fragment ou sem uniforms()');
+  if (!pass?.fragment) continue;
+
   // ---- the fragment itself ----
-  check(/vec4\s+fxMain\s*\(\s*vec2/.test(effect.shader.fragment), id,
+  check(/vec4\s+fxMain\s*\(\s*vec2/.test(pass.fragment), id,
     'o fragment precisa definir `vec4 fxMain(vec2 p)` — e o ponto de entrada que os dois adaptadores chamam');
-  check(!/<<<<<<<|>>>>>>>/.test(effect.shader.fragment), id, 'marcador de conflito no shader');
+  check(!/<<<<<<<|>>>>>>>/.test(pass.fragment), id, 'marcador de conflito no shader');
 
   // Redeclaring an injected name is a compile error the adapters cannot catch.
   for (const name of RESERVED) {
     if (name === 'fxMain') continue;
-    const declared = new RegExp(`\\b(uniform|varying|in|out)\\s+\\w+\\s+${name}\\b`).test(effect.shader.fragment)
-      || new RegExp(`\\bvec4\\s+${name}\\s*\\(`).test(effect.shader.fragment);
+    const declared = new RegExp(`\\b(uniform|varying|in|out)\\s+\\w+\\s+${name}\\b`).test(pass.fragment)
+      || new RegExp(`\\bvec4\\s+${name}\\s*\\(`).test(pass.fragment);
     check(!declared, id, `redeclara \`${name}\`, que o adaptador ja injeta`);
   }
 
   // ---- assembly, in both engines ----
   for (const [engine, build] of [['pixi', pixiFragment], ['three', threeFragment]]) {
     let src = '';
-    try { src = build(effect); } catch (e) { fail(id, `${engine}: montagem lancou ${e.message}`); continue; }
-    check(src.includes(effect.shader.fragment), id, `${engine}: o corpo do efeito nao entrou no fragment montado`);
+    try { src = build(effect, pass); } catch (e) { fail(id, `${engine}: montagem lancou ${e.message}`); continue; }
+    check(src.includes(pass.fragment), id, `${engine}: o corpo do efeito nao entrou no fragment montado`);
     check(src.includes('fxSample'), id, `${engine}: helper fxSample ausente`);
     const opens = (src.match(/\{/g) || []).length, closes = (src.match(/\}/g) || []).length;
     check(opens === closes, id, `${engine}: chaves desbalanceadas (${opens} abrem, ${closes} fecham)`);
   }
 
   // ---- controls <-> uniforms ----
-  const declaredTypes = effect.shader.uniformTypes ?? {};
+  const declaredTypes = pass.uniformTypes ?? {};
   const WIDTH = { float: 1, vec2: 2, vec3: 3, vec4: 4 };
   for (const [name, type] of Object.entries(declaredTypes)) {
     check(!!WIDTH[type], id, `uniform \`${name}\` tem tipo desconhecido \`${type}\``);
     check(/^u[A-Z]/.test(name), id, `uniform \`${name}\` deveria comecar com u maiusculo (uSize, uAmount)`);
-    check(effect.shader.fragment.includes(name), id, `uniform \`${name}\` e declarado mas o shader nunca o le`);
+    check(pass.fragment.includes(name), id, `uniform \`${name}\` e declarado mas o shader nunca o le`);
   }
 
   const defaults = effectDefaults(id);
   for (const ctx of SIZES) {
     let produced;
-    try { produced = effect.shader.uniforms(defaults, ctx); }
+    try { produced = pass.uniforms(defaults, ctx); }
     catch (e) { fail(id, `uniforms() lancou em ${ctx.width}x${ctx.height}: ${e.message}`); continue; }
 
     check(!!produced && typeof produced === 'object', id, 'uniforms() nao devolveu um objeto');
@@ -126,7 +137,7 @@ for (const effect of effectList) {
   const probe = { ...defaults };
   const reached = new Set();
   for (const control of effect.controls) {
-    const before = JSON.stringify(effect.shader.uniforms(probe, SIZES[0]));
+    const before = JSON.stringify(pass.uniforms(probe, SIZES[0]));
     const bumped = { ...probe };
     const v = probe[control.key];
     bumped[control.key] = typeof v === 'number'
@@ -134,13 +145,14 @@ for (const effect of effectList) {
       : typeof v === 'boolean' ? !v
       : Array.isArray(control.options) ? control.options.find((o) => o !== v) ?? v
       : v;
-    const after = JSON.stringify(effect.shader.uniforms(bumped, SIZES[0]));
+    const after = JSON.stringify(pass.uniforms(bumped, SIZES[0]));
     if (before !== after) reached.add(control.key);
   }
   for (const control of effect.controls) {
     check(reached.has(control.key), id,
       `o controle \`${control.key}\` nao muda uniform nenhum — botao morto no painel`);
   }
+  } // fim do passe
 }
 
 if (failures.length) {

--- a/store/useSceneStore.ts
+++ b/store/useSceneStore.ts
@@ -3,6 +3,7 @@ import { defaultsFor, easingFor, templates } from '@/templates';
 import { carouselReferenceDurations } from '@/templates/carousel';
 import type { EasingSpec } from '@/lib/easing';
 import type { CropFocus } from '@/lib/crop';
+import type { EffectScope } from '@/lib/types';
 import { DEMO_ASSETS, demoSourceForSlot, isDemoAssetSource } from '@/lib/demoAssets';
 import { idbPut, idbGet, idbDelete } from '@/lib/assetDb';
 import { DEFAULT_TRACK_TRANSFORM, TRACK_END, type BlendMode, type MotionTrack } from '@/lib/tracks';
@@ -45,6 +46,9 @@ export interface ActiveEffect {
   effectId: string;
   enabled: boolean;
   values: Record<string, any>;
+  // Opcional de proposito: cena salva antes deste campo nao tem `scope`, e le
+  // como 'scene' — exatamente o comportamento que ela tinha.
+  scope?: EffectScope;
 }
 
 export interface BackgroundSettings {
@@ -190,11 +194,12 @@ export interface SceneState {
   loadFavorites: () => void;
   toggleFavorite: (templateId: string) => void;
 
-  addEffect: (effectId: string, values: Record<string, any>) => void;
+  addEffect: (effectId: string, values: Record<string, any>, scope?: EffectScope) => void;
   removeEffect: (instanceId: string) => void;
   toggleEffect: (instanceId: string) => void;
   reorderEffects: (from: number, to: number) => void;
   setEffectValue: (instanceId: string, key: string, val: any) => void;
+  setEffectScope: (instanceId: string, scope: EffectScope) => void;
 
   get totalFrames(): number;
 }
@@ -930,11 +935,11 @@ export const useSceneStore = create<SceneState>((set, get) => ({
       return { favoriteTemplateIds: next };
     }),
 
-  addEffect: (effectId, values) =>
+  addEffect: (effectId, values, scope) =>
     set((s) => ({
       effects: [
         ...s.effects,
-        { instanceId: nid('fx'), effectId, enabled: true, values: { ...values } },
+        { instanceId: nid('fx'), effectId, enabled: true, values: { ...values }, scope: scope ?? 'scene' },
       ],
     })),
   removeEffect: (instanceId) =>
@@ -958,6 +963,12 @@ export const useSceneStore = create<SceneState>((set, get) => ({
         e.instanceId === instanceId
           ? { ...e, values: { ...e.values, [key]: val } }
           : e
+      ),
+    })),
+  setEffectScope: (instanceId, scope) =>
+    set((s) => ({
+      effects: s.effects.map((e) =>
+        e.instanceId === instanceId ? { ...e, scope } : e
       ),
     })),
 


### PR DESCRIPTION
Two things, both measured on the stage in both engines.

## 1. Effect scope

An effect always acted on the whole composed frame, background included. For grain and vignette that is right — they are camera effects. For Wave it is wrong: it displaces the SAMPLING COORDINATE, and over a flat background that displacement is invisible (moving a uniform colour changes nothing). The only visible result was the edge, where the sample leaves the frame and comes back transparent, opening an empty band down the side of the scene.

`ActiveEffect.scope` now decides the reach:

| scope | Pixi | three |
|---|---|---|
| `scene` (absent reads as this) | `content.filters`, background inside | passes after composition |
| `artwork` | `motion.filters`, cards only | artwork composed without the background, passes, then over it |
| `track:<id>` | that layer's container | passes on the track target before compositing |

The field is optional, so a scene saved before this renders exactly as it did. An **Applies to** selector lives in the effect card and lists the layers by name. `meta.defaultScope` says where an effect is born, and Wave is born in `artwork`.

Two things that were not obvious:

- `filterArea` became mandatory on targets other than `content`. Without it Pixi uses the container bounds, so `uInputSize` describes that rectangle instead of the frame — a vignette would centre on the cluster of cards rather than on the canvas. The area is local, and `motion` is translated to the centre, so the rectangle starts at -w/2,-h/2.
- The final compose pass needed `layerIsStraight`: tracks arrive premultiplied and the artwork accumulator has already come out of that same shader with straight alpha. Dividing by alpha twice blows out the colour on card edges.

Both adapters now hand out a filter/material per INSTANCE, with the program still compiled once per effect. The cache used to be keyed by effect id, so two instances shared one uniform block and the last writer won. With one scope that went unnoticed; with per-layer scope the natural use is the same effect on two layers with different values.

Measured with the timeline paused, counting edge pixels that stopped being the background colour (out of 12960):

| | 2D (Pixi) | webgl (three) |
|---|---|---|
| no effect | 4539 | 3787 |
| Wave in `artwork` | 2853 | 2775 |
| Wave in `scene` | **8637** | **8393** |
| Wave in `track:t0` | 2853 | 2610 |

## 2. Multi-pass, and three new effects

A Gaussian blur is only linear if it is SEPARABLE — one horizontal pass, one vertical. Radius r in a single pass costs (2r+1)^2 samples per pixel; separated it costs 2*(2r+1). At 20px that is 1681 against 82.

`Effect.passes` are the additional passes, run in order after `shader`, each reading the previous one's output. `shader` is still the first pass, so every single-pass effect keeps working untouched. Each pass has its own `uniforms()` — that is how the horizontal and the vertical tell each other apart, without inventing a "pass index" the effect author would have to interpret. In Pixi an N-pass effect becomes N filters in sequence, because `container.filters = [a, b]` already chains. In three each pass is one more turn of the ping-pong that was already there.

- **Blur** — separable Gaussian, 13 taps per pass, weights normalised by the REAL accumulated sum. Without that the image darkens as the radius grows, because the tail left outside never enters the total.
- **Tilt-shift** — the same blur with the radius modulated per pixel by the distance to the focus band. It deliberately does not reuse Blur's code: a radius that varies per pixel is not the same shader with a different uniform. The ramp is a smoothstep — a hard cut between sharp and blurred gives the trick away immediately.
- **Bloom** — SINGLE PASS, and that is a choice explained in the file. The classic separable path has to add to the ORIGINAL in the last pass, meaning it reads the CHAIN's input rather than the previous pass's output. That would need a new protocol in both engines, with an extra hazard on the Pixi side: the filterManager's intermediate textures come from a recycled pool, so holding the input reference and reading it later can hand back a buffer that has become something else. A sparse ring kernel solves it with none of that, and `fxSample(p)` is still the original because there is no previous pass.

## Verification

Both suites now look at EVERY pass. Without that, a GLSL error in a vertical pass would pass green in both — which is exactly what happened with `sample`, a reserved word in GLSL ES 3.00, back when only the structural suite existed. Mutation confirmed: deleting `uDir` from Blur's second pass fails the suite.

| Measurement (GPU) | Result |
|---|---|
| Passes compiled | 13, across 11 effects |
| Blur, variation in X | 122.2 -> 20.8 (horizontal pass) |
| Blur, variation in Y | 46.5 -> 9.8 (vertical pass) |
| Tilt-shift sharpness | 121.9 in the band against 40 outside |
| Bloom, neighbouring energy | 0 -> 79616, centre intact at 255 |
| Cross-engine parity | blur 0.08, tilt-shift 0.19, bloom 0.55 (of 255) |

Two fixes to the instrument itself, which was measuring the wrong thing:

- the harness noise texture does not vary in Y. With i = y*W + x and W = 256, moving one row adds 256 to i, and (i*37)%256 returns the same value — the texture is constant vertically, so the second-pass test compared zero against zero and "passed" by accident. Replaced with a hash over both axes.
- bloom was measured at a single pixel 20px from the stripe, where it delivers 2 out of 255. It now sums the ENERGY over a band: the effect spreads a little light over many pixels, and a single point turns the test into a question of picking the right point.

`tsc` clean, all suites green on top of current main (effects 914 assertions, was 505), 24 measurements on GPU, `next build` compiles.

This branch replaces the two commits that were left stranded on `feat/effects-halftone-posterize-scanlines-wave` after #81 merged; they are cherry-picked onto current main with no conflicts.
