### PR TITLE
Feat/liquid glass lens

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -89,6 +89,45 @@ notice below travels inside the shipped bundle, in the library's own files:
 
 
 ================================================================================
+VENDORED SOURCE — liquid-glass-carousel
+================================================================================
+
+The lens maths in effects/liquidGlass.ts is adapted from the `discLens` shader
+in liquid-glass-carousel:
+
+    https://github.com/Yousuf-developer/liquid-glass-carousel
+
+It is not a dependency. The code was copied and modified, so it carries its own
+licence header in that file as well as this notice.
+
+    MIT License
+
+    Copyright (c) 2026 Yousuf Soomro
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+Only the shader was taken. That project's carousel — its scroll and drag
+handling and its GSAP timelines — is not used here, and its demo images are
+explicitly outside its own MIT grant.
+
+
+================================================================================
 FONTS AND ASSETS
 ================================================================================
 

--- a/effects/adapters/glsl.ts
+++ b/effects/adapters/glsl.ts
@@ -46,8 +46,38 @@ vec3 fx_toLinear(vec3 c) {
   return mix(c / 12.92, pow((max(c, vec3(0.0)) + 0.055) / 1.055, vec3(2.4)), step(0.04045, c));
 }`;
 
-// Os helpers de espaco de cor tambem sao injetados, entao tambem sao reservados.
-RESERVED.push('fx_toSrgb', 'fx_toLinear');
+// AREA DE APLICACAO: onde no quadro o efeito age.
+//
+// Um efeito de lente aplicado ao quadro inteiro borra os CARDS, que sao o
+// assunto da cena — o resultado e uma imagem uniformemente mole em vez de uma
+// imagem com foco. Blur, Bloom, Tilt-shift e Liquid Glass ganharam este
+// controle porque os quatro tinham o mesmo defeito, e resolver quatro vezes
+// seriam quatro chances de divergir.
+//
+// A mascara sai de DUAS linhas, e as duas formas caem dela:
+//   n = |p - centro| / (tamanho/2)   0 no centro, 1 nas bordas
+//   max(n.x, n.y)   distancia de Chebyshev: um ANEL retangular    (bordas)
+//   length(n)/raiz2 distancia radial: forte nos CANTOS            (cantos)
+//
+// `band` e o quanto o efeito entra para dentro, e o smoothstep da a rampa: um
+// corte duro entre borrado e nitido desenha uma moldura visivel, que e um
+// defeito diferente do que se estava consertando.
+//
+// 0 = quadro inteiro (mascara 1.0 em todo lugar), 1 = bordas, 2 = cantos.
+// Qualquer outro valor devolve 1.0, para um efeito poder ter modo proprio — o
+// Tilt-shift usa 3 para a sua faixa de foco horizontal.
+const AREA_HELPERS = `
+float fx_areaMask(vec2 p, float area, float band) {
+  if (area < 0.5 || area > 2.5) return 1.0;
+  vec2 n = abs(p - uResolution * 0.5) / max(uResolution * 0.5, vec2(1.0));
+  float m = (area < 1.5) ? max(n.x, n.y) : length(n) * 0.70710678;
+  float b = clamp(band, 0.001, 1.0);
+  return smoothstep(1.0 - b, 1.0, m);
+}`;
+
+// Os helpers de espaco de cor e de area tambem sao injetados, entao tambem sao
+// reservados.
+RESERVED.push('fx_toSrgb', 'fx_toLinear', 'fx_areaMask');
 
 
 function declarations(pass: EffectShader): string {
@@ -75,6 +105,7 @@ ${declarations(pass)}
 vec2 fx_toPixels(vec2 uv) { return uv * uInputSize.xy + uInputSize.zw; }
 vec2 fx_toUv(vec2 p)      { return (p - uInputSize.zw) / uInputSize.xy; }
 vec4 fxSample(vec2 p)     { return texture(uTexture, fx_toUv(p)); }
+${AREA_HELPERS}
 
 ${pass.fragment}
 
@@ -100,6 +131,7 @@ vec4 fxSample(vec2 p) {
   vec4 c = texture2D(map, p / uResolution);
   return vec4(fx_toSrgb(c.rgb), c.a);
 }
+${AREA_HELPERS}
 
 ${pass.fragment}
 

--- a/effects/area.ts
+++ b/effects/area.ts
@@ -1,0 +1,43 @@
+import type { ControlDef } from '@/lib/types';
+
+// Onde no quadro um efeito de lente age.
+//
+// Compartilhado por Blur, Bloom, Tilt-shift e Liquid Glass. Os quatro nasceram
+// de tela cheia e os quatro tinham o mesmo defeito: aplicados por cima de tudo,
+// borram os CARDS, que sao o assunto da cena — o resultado e uma imagem
+// uniformemente mole em vez de uma imagem com foco.
+//
+// Um lugar so para os dois controles e para a tabela de codigos, porque quatro
+// copias sao quatro chances de o painel dizer "Corners" e o shader entender
+// outra coisa. A matematica da mascara vive em `fx_areaMask`, injetada pelo
+// montador de GLSL nos dois engines (effects/adapters/glsl.ts).
+
+/** Painel -> uniform. A ordem tem de casar com `fx_areaMask`. */
+export const AREA_CODE: Record<string, number> = {
+  'Full frame': 0,
+  Edges: 1,
+  Corners: 2,
+};
+
+export const AREA_OPTIONS = ['Corners', 'Edges', 'Full frame'];
+
+/** As duas linhas que todo efeito de lente ganha, iguais em todos. */
+export const AREA_CONTROLS: ControlDef[] = [
+  { key: 'area', label: 'Applies at', type: 'pills', options: AREA_OPTIONS, default: 'Edges' },
+  {
+    key: 'reach', label: 'Reach', type: 'slider', min: 2, max: 100, step: 1, default: 35, unit: '%',
+    // Sem alcance nao ha o que ajustar: em 'Full frame' a mascara e 1 em todo
+    // lugar e este slider nao move nada — um controle visivel que nao faz nada
+    // e pior do que um controle ausente.
+    visibleWhen: { key: 'area', not: 'Full frame' },
+  },
+];
+
+/** Os uniforms correspondentes, para o efeito nao reescrever a conversao. */
+export const areaUniforms = (v: Record<string, any>) => ({
+  uArea: AREA_CODE[String(v.area ?? 'Edges')] ?? 1,
+  uBand: Math.max(0, Math.min(1, Number(v.reach ?? 35) / 100)),
+});
+
+/** Os tipos, para o efeito nao reescrever isso tambem. */
+export const AREA_UNIFORM_TYPES = { uArea: 'float', uBand: 'float' } as const;

--- a/effects/bloom.ts
+++ b/effects/bloom.ts
@@ -30,7 +30,10 @@ const ANEIS = 4;
 const DIRECOES = 8;
 
 export const bloom: Effect = {
-  meta: { id: 'bloom', name: 'Bloom', defaultScope: 'scene' },
+  // Nasce em 'artwork': age sobre os CARDS, e o fundo da cena passa intacto.
+  // Aplicado ao fundo tambem, um efeito de lente amassa a cena inteira e o
+  // assunto se perde junto. Quem quiser o fundo troca no seletor de escopo.
+  meta: { id: 'bloom', name: 'Bloom', defaultScope: 'artwork' },
   controls: [
     { key: 'threshold', label: 'Threshold', type: 'slider', min: 0, max: 100, step: 1, default: 65, unit: '%' },
     { key: 'radius', label: 'Radius', type: 'slider', min: 1, max: 60, step: 1, default: 22, unit: 'px' },

--- a/effects/bloom.ts
+++ b/effects/bloom.ts
@@ -1,4 +1,5 @@
 import type { Effect } from '@/lib/types';
+import { AREA_CONTROLS, AREA_UNIFORM_TYPES, areaUniforms } from './area';
 
 // Bloom: o que passa do limiar transborda e ilumina a vizinhanca.
 //
@@ -34,13 +35,15 @@ export const bloom: Effect = {
     { key: 'threshold', label: 'Threshold', type: 'slider', min: 0, max: 100, step: 1, default: 65, unit: '%' },
     { key: 'radius', label: 'Radius', type: 'slider', min: 1, max: 60, step: 1, default: 22, unit: 'px' },
     { key: 'intensity', label: 'Intensity', type: 'slider', min: 0, max: 200, step: 1, default: 70, unit: '%' },
+    ...AREA_CONTROLS,
   ],
   shader: {
-    uniformTypes: { uThreshold: 'float', uRadius: 'float', uIntensity: 'float' },
+    uniformTypes: { uThreshold: 'float', uRadius: 'float', uIntensity: 'float', ...AREA_UNIFORM_TYPES },
     uniforms: (v) => ({
       uThreshold: Math.max(0, Math.min(1, Number(v.threshold ?? 65) / 100)),
       uRadius: Math.max(1, Number(v.radius ?? 22)),
       uIntensity: Math.max(0, Number(v.intensity ?? 70) / 100),
+      ...areaUniforms(v),
     }),
     fragment: `
 // O que passa do limiar, e SO o excedente: subtrair o limiar em vez de deixar
@@ -72,8 +75,13 @@ vec4 fxMain(vec2 p) {
     }
   }
   brilho /= max(0.0001, peso);
+  // A area modula a INTENSIDADE, nao o raio: o bloom segue colhendo luz de todo
+  // vizinho claro — inclusive dos cards no meio — e so a DEPOSITA onde a
+  // mascara deixa. Modular o raio faria o brilho encolher em vez de recuar, o
+  // que le como bloom fraco e nao como bloom nas bordas.
+  float area = fx_areaMask(p, uArea, uBand);
   // Aditivo, nao mistura: bloom SOMA luz. Misturar apagaria a imagem embaixo.
-  return vec4(base.rgb + brilho * uIntensity, base.a);
+  return vec4(base.rgb + brilho * uIntensity * area, base.a);
 }`,
   },
 };

--- a/effects/blur.ts
+++ b/effects/blur.ts
@@ -57,7 +57,10 @@ function passe(direcao: [number, number]): EffectShader {
 }
 
 export const blur: Effect = {
-  meta: { id: 'blur', name: 'Blur', defaultScope: 'scene' },
+  // Nasce em 'artwork': age sobre os CARDS, e o fundo da cena passa intacto.
+  // Aplicado ao fundo tambem, um efeito de lente amassa a cena inteira e o
+  // assunto se perde junto. Quem quiser o fundo troca no seletor de escopo.
+  meta: { id: 'blur', name: 'Blur', defaultScope: 'artwork' },
   controls: [
     { key: 'radius', label: 'Radius', type: 'slider', min: 0, max: 40, step: 1, default: 8, unit: 'px' },
     // Nasce em 'Edges', nao em 'Full frame'. O default certo e o que serve na

--- a/effects/blur.ts
+++ b/effects/blur.ts
@@ -1,4 +1,5 @@
 import type { Effect, EffectShader } from '@/lib/types';
+import { AREA_CONTROLS, AREA_UNIFORM_TYPES, areaUniforms } from './area';
 
 // Blur gaussiano, SEPARAVEL: um passe horizontal e um vertical.
 //
@@ -23,12 +24,17 @@ const TAPS = 6; // de cada lado; 13 amostras no total por passe
 // vezes seria duas oportunidades de divergir.
 const corpo = `
 vec4 fxMain(vec2 p) {
-  if (uRadius < 0.5) return fxSample(p);
+  // O raio e MODULADO pela area. No meio do quadro a mascara vale 0, a funcao
+  // devolve o pixel intacto e nem entra no laco — e o que separa "desfocar as
+  // bordas" de "desfocar tudo". Aplicado ao quadro inteiro, o blur come os
+  // cards, que sao justamente o assunto da cena.
+  float raio = uRadius * fx_areaMask(p, uArea, uBand);
+  if (raio < 0.5) return fxSample(p);
   vec4 soma = fxSample(p);
   float peso = 1.0;
-  float sigma = max(0.0001, uRadius * 0.5);
+  float sigma = max(0.0001, raio * 0.5);
   for (int i = 1; i <= ${TAPS}; i++) {
-    float d = (float(i) / float(${TAPS})) * uRadius;
+    float d = (float(i) / float(${TAPS})) * raio;
     float w = exp(-(d * d) / (2.0 * sigma * sigma));
     soma += fxSample(p + uDir * d) * w;
     soma += fxSample(p - uDir * d) * w;
@@ -39,21 +45,25 @@ vec4 fxMain(vec2 p) {
 
 function passe(direcao: [number, number]): EffectShader {
   return {
-    uniformTypes: { uRadius: 'float', uDir: 'vec2' },
+    uniformTypes: { uRadius: 'float', uDir: 'vec2', ...AREA_UNIFORM_TYPES },
     uniforms: (v) => ({
       uRadius: Math.max(0, Number(v.radius ?? 8)),
       uDir: direcao,
+      ...areaUniforms(v),
     }),
+    fixedUniforms: ['uDir'],
     fragment: corpo,
   };
 }
 
 export const blur: Effect = {
-  // Nasce no quadro todo: desfocar a cena inteira, fundo incluido, e o que um
-  // blur de cena faz. Quem quiser so os cards troca no seletor.
   meta: { id: 'blur', name: 'Blur', defaultScope: 'scene' },
   controls: [
     { key: 'radius', label: 'Radius', type: 'slider', min: 0, max: 40, step: 1, default: 8, unit: 'px' },
+    // Nasce em 'Edges', nao em 'Full frame'. O default certo e o que serve na
+    // maioria dos casos, e desfocar o quadro inteiro raramente e o que se quer
+    // numa cena cujo assunto esta no meio.
+    ...AREA_CONTROLS,
   ],
   shader: passe([1, 0]),
   passes: [passe([0, 1])],

--- a/effects/index.ts
+++ b/effects/index.ts
@@ -3,6 +3,7 @@ import { bloom } from './bloom';
 import { blur } from './blur';
 import { grain } from './grain';
 import { halftone } from './halftone';
+import { liquidGlass } from './liquidGlass';
 import { pixelate } from './pixelate';
 import { posterize } from './posterize';
 import { rgbSplit } from './rgbSplit';
@@ -25,6 +26,7 @@ export const effects: Record<string, Effect> = {
   [blur.meta.id]: blur,
   [bloom.meta.id]: bloom,
   [tiltShift.meta.id]: tiltShift,
+  [liquidGlass.meta.id]: liquidGlass,
   [halftone.meta.id]: halftone,
   [posterize.meta.id]: posterize,
   [scanlines.meta.id]: scanlines,

--- a/effects/liquidGlass.ts
+++ b/effects/liquidGlass.ts
@@ -1,0 +1,259 @@
+import type { Effect } from '@/lib/types';
+
+// Liquid Glass: uma lente de vidro sobre o quadro — refracao, dispersao
+// cromatica na borda, brilho central, anel e uma ondulacao fluida no aro.
+//
+// ---------------------------------------------------------------------------
+// ORIGEM E LICENCA
+//
+// A matematica da lente vem do `discLens` de github.com/Yousuf-developer/
+// liquid-glass-carousel, sob licenca MIT:
+//
+//   MIT License
+//   Copyright (c) 2026 Yousuf Soomro
+//
+//   Permission is hereby granted, free of charge, to any person obtaining a
+//   copy of this software and associated documentation files (the "Software"),
+//   to deal in the Software without restriction, including without limitation
+//   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//   and/or sell copies of the Software, and to permit persons to whom the
+//   Software is furnished to do so, subject to the following conditions:
+//
+//   The above copyright notice and this permission notice shall be included in
+//   all copies or substantial portions of the Software.
+//
+//   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//   DEALINGS IN THE SOFTWARE.
+//
+// Registrado tambem no NOTICE, que e parte dos termos da Apache-2.0 deste
+// projeto e nao cortesia.
+// ---------------------------------------------------------------------------
+//
+// O QUE MUDOU NA ADAPTACAO, e por que:
+//
+// - `texture2D(uTex, uv)` virou `fxSample(p)`. O contrato daqui entrega pixels
+//   e resolve o espaco de cor e o padding do Pixi por dentro; amostrar a
+//   textura direto quebraria os dois.
+// - A vinheta do original saiu. Este projeto ja tem um efeito Vignette, e dois
+//   caminhos para a mesma coisa divergem com o tempo — quem quiser as duas
+//   coisas empilha os dois efeitos.
+// - O centro vem de um `xypad` em PIXELS a partir do centro do quadro, em vez
+//   de UV. E a unidade que todo controle daqui usa, e um pad em UV mudaria de
+//   significado a cada proporcao de canvas.
+// - Um controle `glow` unico governa o nova e o anel, que no original sao tres
+//   uniforms interdependentes (`uGlow`, `uWhiteGlow`, `uBlueRing`) — trinta
+//   botoes num painel de efeito nao ajudam ninguem a chegar num resultado.
+// - O laco de dispersao mantem `MAX_SAMPLES` constante com `break`, porque
+//   GLSL ES 1.00 (o alvo do three) nao aceita limite de laco vindo de uniform.
+//
+// O ALPHA e o do que estava embaixo: a lente REFRATA o que existe, nao inventa
+// opacidade. Sobre um fundo transparente nao ha o que refratar e o brilho nao
+// aparece no export — o que e coerente, mas vale saber antes de exportar PNG
+// com fundo vazio.
+const MAX_SAMPLES = 16;
+
+export const liquidGlass: Effect = {
+  // Lente: e o que a camera faz com a cena, entao nasce no quadro todo.
+  meta: { id: 'liquid-glass', name: 'Liquid Glass', defaultScope: 'scene' },
+  controls: [
+    // Pixels a partir do centro do quadro. `max` e o alcance do pad em cada
+    // eixo; 540 e meia altura do canvas de referencia, entao o pad cobre a cena.
+    { key: 'position', label: 'Position', type: 'xypad', max: 540, default: { x: 0, y: 0 } },
+    { key: 'size', label: 'Size', type: 'slider', min: 4, max: 80, step: 1, default: 26, unit: '%' },
+    { key: 'shape', label: 'Shape', type: 'pills', options: ['Circle', 'Square'], default: 'Circle' },
+    {
+      key: 'rounding', label: 'Rounding', type: 'slider', min: 0, max: 100, step: 1, default: 30, unit: '%',
+      visibleWhen: { key: 'shape', equals: 'Square' },
+    },
+    { key: 'refraction', label: 'Refraction', type: 'slider', min: 0, max: 100, step: 1, default: 45, unit: '%' },
+    { key: 'dispersion', label: 'Dispersion', type: 'slider', min: 0, max: 100, step: 1, default: 30, unit: '%' },
+    { key: 'ripple', label: 'Ripple', type: 'slider', min: 0, max: 100, step: 1, default: 18, unit: '%' },
+    { key: 'glow', label: 'Glow', type: 'slider', min: 0, max: 100, step: 1, default: 35, unit: '%' },
+    { key: 'ring', label: 'Ring', type: 'slider', min: 0, max: 100, step: 1, default: 40, unit: '%' },
+    { key: 'ringColor', label: 'Ring colour', type: 'color', default: '#009dff' },
+    { key: 'shimmer', label: 'Shimmer', type: 'slider', min: 0, max: 100, step: 1, default: 25, unit: '%', advanced: true },
+    { key: 'edgeBlur', label: 'Edge blur', type: 'slider', min: 0, max: 40, step: 1, default: 6, unit: 'px', advanced: true },
+    { key: 'rotation', label: 'Rotation', type: 'slider', min: -180, max: 180, step: 1, default: 0, unit: '°', advanced: true },
+  ],
+  shader: {
+    uniformTypes: {
+      uCenter: 'vec2',
+      uHalf: 'vec2',
+      uZoom: 'float',
+      uDispersion: 'float',
+      uRipple: 'float',
+      uGlow: 'float',
+      uRing: 'float',
+      uRingColor: 'vec3',
+      uShimmer: 'float',
+      uBlur: 'float',
+      uRotation: 'float',
+      uShape: 'float',
+      uRound: 'float',
+      uSamples: 'float',
+    },
+    uniforms: (v, ctx) => {
+      const pos = (v.position ?? { x: 0, y: 0 }) as { x: number; y: number };
+      // Meia-altura em pixels; o mesmo valor nos dois eixos mantem o circulo
+      // redondo na TELA, porque a distancia e medida em pixels e nao em UV.
+      const meia = (Math.max(4, Number(v.size ?? 26)) / 100) * ctx.height * 0.5;
+      const hex = String(v.ringColor ?? '#009dff').replace('#', '');
+      const n = parseInt(hex.length === 3 ? hex.split('').map((c) => c + c).join('') : hex, 16) || 0x009dff;
+      return {
+        uCenter: [ctx.width / 2 + Number(pos.x ?? 0), ctx.height / 2 + Number(pos.y ?? 0)],
+        uHalf: [meia, meia],
+        uZoom: Math.max(0, Number(v.refraction ?? 45)) / 100,
+        uDispersion: Math.max(0, Number(v.dispersion ?? 30)) / 100,
+        uRipple: Math.max(0, Number(v.ripple ?? 18)) / 100,
+        uGlow: Math.max(0, Number(v.glow ?? 35)) / 100,
+        uRing: Math.max(0, Number(v.ring ?? 40)) / 100,
+        uRingColor: [((n >> 16) & 0xff) / 255, ((n >> 8) & 0xff) / 255, (n & 0xff) / 255],
+        uShimmer: Math.max(0, Number(v.shimmer ?? 25)) / 100,
+        uBlur: Math.max(0, Number(v.edgeBlur ?? 6)),
+        uRotation: (Number(v.rotation ?? 0) * Math.PI) / 180,
+        uShape: v.shape === 'Square' ? 1 : 0,
+        uRound: Math.max(0, Math.min(1, Number(v.rounding ?? 30) / 100)),
+        // Constante por enquanto, mas passa pela mesma funcao: chumbar no shader
+        // esconderia o valor de quem for ler o efeito.
+        uSamples: MAX_SAMPLES,
+      };
+    },
+    fragment: `
+const int LG_MAX = ${MAX_SAMPLES};
+
+// distancia assinada de caixa arredondada (negativa dentro)
+float lg_sdRoundBox(vec2 p, vec2 b, float r) {
+  vec2 q = abs(p) - b + r;
+  return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
+}
+
+vec4 fxMain(vec2 p) {
+  vec4 base = fxSample(p);
+
+  // Local, em PIXELS, girado junto com a lente para que aro, anel e ondulacao
+  // girem como uma peca so.
+  vec2 d = p - uCenter;
+  float ca = cos(uRotation), sa = sin(uRotation);
+  vec2 q = mat2(ca, -sa, sa, ca) * d;
+
+  // 0 no centro .. 1 na borda
+  float nd = length(q / uHalf);
+  float maskND = nd;
+  if (uShape > 0.5) {
+    float corner = min(uHalf.x, uHalf.y) * uRound;
+    maskND = 1.0 + lg_sdRoundBox(q, uHalf, corner) / min(uHalf.x, uHalf.y);
+  }
+  // Fora da lente o quadro passa intacto — inclusive o alpha.
+  if (maskND > 1.0) return base;
+
+  float shapeND = clamp(maskND, 0.0, 1.0);
+  float rad = clamp(nd, 0.0, 1.0);
+  vec2 radialDir = normalize(d + vec2(1e-6));
+  vec2 tangentDir = vec2(-radialDir.y, radialDir.x);
+  float angle = atan(q.y, q.x);
+
+  // Puxada para dentro (a refracao) mais a ondulacao no aro. A ondulacao e duas
+  // senoides de frequencias diferentes: uma so daria um aro poligonal regular,
+  // que le como falha de geometria e nao como liquido.
+  float pull = uZoom * 0.30 * (rad * rad);
+  float rimStrength = smoothstep(0.578, 1.0, rad);
+  // Frequencias 2 e 1, como no original. Eu havia posto 3 e 7, que da um aro
+  // ocupado — bonito de perto e nervoso em movimento; duas ondas lentas
+  // desencontradas e o que le como liquido.
+  float fluid = sin(angle * 2.0) * 0.55 + sin(angle * 1.0) * 0.25;
+  float rPix = (uHalf.x + uHalf.y) * 0.5;
+  // As constantes abaixo sao FRACAO DO RAIO da lente, nao pixels absolutos.
+  // O original mede tudo em UV de altura de tela, entao converter so as
+  // coordenadas e manter os fatores deixou a ondulacao vinte vezes fraca. Em
+  // fracao do raio o efeito tambem fica igual em qualquer resolucao.
+  vec2 rimOff = tangentDir * fluid * rimStrength * rPix * uRipple * 1.8;
+  vec2 baseP = uCenter + d * (1.0 - pull) + rimOff;
+
+  // Dispersao cromatica: amostra ao longo de um pequeno deslocamento e pesa as
+  // amostras de vermelho a azul. O peso e normalizado POR CANAL — sem isso o
+  // aro clareia, porque a soma dos pesos nao e 1.
+  float rimMask = smoothstep(0.55, 1.0, rad);
+  // Tambem em fracao do raio: no original o desvio no aro vale ~5,6% do raio da
+  // lente, e 0.19 * 0.30 (o default) reproduz isso.
+  vec2 dispDir = radialDir * uDispersion * rPix * 0.19 * rimMask;
+  int N = int(uSamples);
+  if (N < 2) N = 2;
+  if (N > LG_MAX) N = LG_MAX;
+  vec3 col = vec3(0.0);
+  vec3 wsum = vec3(0.0);
+  for (int i = 0; i < LG_MAX; i++) {
+    if (i >= N) break;
+    float t = float(i) / float(N - 1);
+    vec3 s = fxSample(baseP + dispDir * (t - 0.5)).rgb;
+    vec3 w = vec3(
+      exp(-pow((t - 0.00) / 0.38, 2.0)),
+      exp(-pow((t - 0.50) / 0.38, 2.0)),
+      exp(-pow((t - 1.00) / 0.38, 2.0))
+    );
+    col += s * w;
+    wsum += w;
+  }
+  col /= max(wsum, vec3(0.001));
+
+  // Desfoque suave perto do aro, que e onde o vidro real perde definicao.
+  float blurFade = 1.0 - smoothstep(0.72, 0.98, rad);
+  if (uBlur > 0.01 && blurFade > 0.01) {
+    vec2 blurRad = vec2(uBlur) * blurFade;
+    vec3 bcol = vec3(0.0);
+    float btw = 0.0;
+    for (int a = 0; a < 6; a++) {
+      float ang = float(a) * 1.0471975;
+      for (int rr = 0; rr < 3; rr++) {
+        float k = 0.4 + float(rr) * 0.3;
+        vec2 o = vec2(cos(ang), sin(ang)) * blurRad * k;
+        float w = 1.0 - k * 0.38;
+        bcol += fxSample(baseP + o).rgb * w;
+        btw += w;
+      }
+    }
+    col = mix(bcol / btw, col, rimMask);
+  }
+
+  // Vidro escurece um pouco para o centro.
+  col *= mix(0.91, 1.0, smoothstep(0.0, 0.38, shapeND));
+
+  // Nova branca no centro, duas gaussianas: a estreita da o nucleo, a larga o
+  // halo. Uma so vira bolinha dura.
+  // Os fatores aqui saem das formulas do original com os defaults dele
+  // (glow 4.2, whiteGlow 0.24, novaSize 12): o nucleo soma 0,08 no centro, nao
+  // 0,5. A minha primeira versao somava 0,47 e estourava o meio da lente de
+  // branco — eu havia normalizado os controles para 0..1 sem refazer as
+  // constantes que dependiam da escala antiga.
+  float r2 = shapeND * shapeND * 0.25;
+  float gs = max(uGlow * 0.43, 0.004);
+  float nova = (exp(-r2 / gs) + exp(-r2 / (gs * 7.0)) * 0.18) * uGlow * 0.23;
+  col += vec3(nova);
+
+  // Anel colorido mais a aura em volta dele. O anel fica quase na borda
+  // (0.49 de 0.5) e e fino: mais para dentro ele le como bolha, nao como aro.
+  float dC = shapeND * 0.5;
+  float tR = 0.49;
+  float rW = 0.014;
+  float ring = exp(-pow((dC - tR) / rW, 2.0)) * uRing * 6.7;
+  // O cintilar anda com uTime, que vem do FRAME: o mesmo frame cintila igual em
+  // todo render, e o ciclo fecha no loop.
+  if (uShimmer > 0.001) {
+    ring *= sin(angle * 12.0 + uTime * uShimmer * 6.2831853) * 0.12 + 0.88;
+  }
+  float aura = exp(-pow((dC - tR) / (rW * 6.0), 2.0)) * 0.28 * uRing * 2.5;
+  col += uRingColor * (ring + aura);
+
+  // Linha clara na borda, o reflexo do canto do vidro.
+  col += vec3(exp(-pow((dC - 0.488) / 0.003, 2.0)) * uRing * 3.5);
+
+  // Queda suave no ultimo por cento, para o aro nao serrilhar.
+  float a = smoothstep(1.0, 0.93, maskND);
+  return vec4(mix(base.rgb, col, a), base.a);
+}`,
+  },
+};

--- a/effects/liquidGlass.ts
+++ b/effects/liquidGlass.ts
@@ -59,8 +59,11 @@ import { AREA_CODE, AREA_UNIFORM_TYPES } from './area';
 const MAX_SAMPLES = 16;
 
 export const liquidGlass: Effect = {
-  // Lente: e o que a camera faz com a cena, entao nasce no quadro todo.
-  meta: { id: 'liquid-glass', name: 'Liquid Glass', defaultScope: 'scene' },
+  // Nasce em 'artwork': o vidro age sobre os CARDS, e o fundo da cena passa
+  // intacto. Em 'scene' ele refrata o fundo tambem, e como o fundo costuma ser
+  // chapado, o unico resultado visivel ali e a moldura sobreposta a uma cor
+  // uniforme — custo sem ganho. Quem tiver fundo com imagem troca no seletor.
+  meta: { id: 'liquid-glass', name: 'Liquid Glass', defaultScope: 'artwork' },
   controls: [
     // O PRIMEIRO controle, porque e o que decide quais outros importam. Em
     // bordas ou cantos nao ha pad, tamanho nem forma para acertar: o alcance e
@@ -268,6 +271,20 @@ vec4 fxMain(vec2 p) {
     col = mix(bcol / btw, col, rimMask);
   }
 
+  // A LUZ do vidro sai proporcional ao que existe embaixo.
+  //
+  // Sem isto, num escopo de arte (onde o fundo nao entra e os pixels vazios tem
+  // alpha 0) o anel, a nova e a linha de reflexo saem com rgb > 0 e alpha 0 —
+  // e nessa convencao pre-multiplicada isso NAO e invisivel, e luz aditiva:
+  // compoe sobre o fundo da cena e desenha a moldura colorida exatamente onde
+  // se pediu que ela nao fosse. Medido: 14% dos pixels de fundo mudavam, contra
+  // 0,8% do Bloom, que sangra so o halo na beirada do card.
+  //
+  // Fisicamente tambem e o certo: vidro reflete e refrata a luz que existe.
+  // Sem card, sem luz. E em escopo de cena o fundo e opaco, entao base.a vale
+  // 1 e isto nao muda nada — uma linha serve os dois casos.
+  float luz = base.a;
+
   // Vidro escurece um pouco para o centro.
   col *= mix(0.91, 1.0, smoothstep(0.0, 0.38, shapeND));
 
@@ -284,7 +301,7 @@ vec4 fxMain(vec2 p) {
     float r2 = shapeND * shapeND * 0.25;
     float gs = max(uGlow * 0.43, 0.004);
     float nova = (exp(-r2 / gs) + exp(-r2 / (gs * 7.0)) * 0.18) * uGlow * 0.23;
-    col += vec3(nova);
+    col += vec3(nova) * luz;
   }
 
   // Anel colorido mais a aura em volta dele. O anel fica quase na borda
@@ -304,13 +321,13 @@ vec4 fxMain(vec2 p) {
   // no default antigo, o pico somava 1,62 em ciano — acima de 1,0, ou seja
   // estourado. O fator devolve o anel para a faixa visivel.
   float ganhoAnel = lente ? 1.0 : 0.3;
-  col += uRingColor * (ring + aura) * ganhoAnel;
+  col += uRingColor * (ring + aura) * ganhoAnel * luz;
 
   // Linha clara na borda, o reflexo do canto do vidro. No disco ela e um fio
   // curto num circulo; numa moldura ela corre pelo quadro inteiro e soma com a
   // aura do anel ao longo de tudo — no default aquilo virava letreiro de neon.
   // Um terco da intensidade no modo de borda devolve o reflexo sem o anuncio.
-  col += vec3(exp(-pow((dC - 0.488) / 0.003, 2.0)) * uRing * (lente ? 3.5 : 1.2));
+  col += vec3(exp(-pow((dC - 0.488) / 0.003, 2.0)) * uRing * (lente ? 3.5 : 1.2) * luz);
 
   // Quanto do vidro entra. No disco e 1 dentro com uma queda de 7% no aro, para
   // nao serrilhar; na faixa a propria mascara ja e a rampa, entao ela e a

--- a/effects/liquidGlass.ts
+++ b/effects/liquidGlass.ts
@@ -1,4 +1,5 @@
 import type { Effect } from '@/lib/types';
+import { AREA_CODE, AREA_UNIFORM_TYPES } from './area';
 
 // Liquid Glass: uma lente de vidro sobre o quadro — refracao, dispersao
 // cromatica na borda, brilho central, anel e uma ondulacao fluida no aro.
@@ -61,11 +62,28 @@ export const liquidGlass: Effect = {
   // Lente: e o que a camera faz com a cena, entao nasce no quadro todo.
   meta: { id: 'liquid-glass', name: 'Liquid Glass', defaultScope: 'scene' },
   controls: [
+    // O PRIMEIRO controle, porque e o que decide quais outros importam. Em
+    // bordas ou cantos nao ha pad, tamanho nem forma para acertar: o alcance e
+    // o unico numero, e era isso que estava faltando para o efeito ser usavel.
+    { key: 'area', label: 'Applies at', type: 'pills', options: ['Corners', 'Edges', 'Lens'], default: 'Edges' },
+    {
+      key: 'reach', label: 'Reach', type: 'slider', min: 2, max: 100, step: 1, default: 22, unit: '%',
+      visibleWhen: { key: 'area', not: 'Lens' },
+    },
     // Pixels a partir do centro do quadro. `max` e o alcance do pad em cada
     // eixo; 540 e meia altura do canvas de referencia, entao o pad cobre a cena.
-    { key: 'position', label: 'Position', type: 'xypad', max: 540, default: { x: 0, y: 0 } },
-    { key: 'size', label: 'Size', type: 'slider', min: 4, max: 80, step: 1, default: 26, unit: '%' },
-    { key: 'shape', label: 'Shape', type: 'pills', options: ['Circle', 'Square'], default: 'Circle' },
+    {
+      key: 'position', label: 'Position', type: 'xypad', max: 540, default: { x: 0, y: 0 },
+      visibleWhen: { key: 'area', equals: 'Lens' },
+    },
+    {
+      key: 'size', label: 'Size', type: 'slider', min: 4, max: 80, step: 1, default: 26, unit: '%',
+      visibleWhen: { key: 'area', equals: 'Lens' },
+    },
+    {
+      key: 'shape', label: 'Shape', type: 'pills', options: ['Circle', 'Square'], default: 'Circle',
+      visibleWhen: { key: 'area', equals: 'Lens' },
+    },
     {
       key: 'rounding', label: 'Rounding', type: 'slider', min: 0, max: 100, step: 1, default: 30, unit: '%',
       visibleWhen: { key: 'shape', equals: 'Square' },
@@ -74,7 +92,7 @@ export const liquidGlass: Effect = {
     { key: 'dispersion', label: 'Dispersion', type: 'slider', min: 0, max: 100, step: 1, default: 30, unit: '%' },
     { key: 'ripple', label: 'Ripple', type: 'slider', min: 0, max: 100, step: 1, default: 18, unit: '%' },
     { key: 'glow', label: 'Glow', type: 'slider', min: 0, max: 100, step: 1, default: 35, unit: '%' },
-    { key: 'ring', label: 'Ring', type: 'slider', min: 0, max: 100, step: 1, default: 40, unit: '%' },
+    { key: 'ring', label: 'Ring', type: 'slider', min: 0, max: 100, step: 1, default: 22, unit: '%' },
     { key: 'ringColor', label: 'Ring colour', type: 'color', default: '#009dff' },
     { key: 'shimmer', label: 'Shimmer', type: 'slider', min: 0, max: 100, step: 1, default: 25, unit: '%', advanced: true },
     { key: 'edgeBlur', label: 'Edge blur', type: 'slider', min: 0, max: 40, step: 1, default: 6, unit: 'px', advanced: true },
@@ -96,6 +114,7 @@ export const liquidGlass: Effect = {
       uShape: 'float',
       uRound: 'float',
       uSamples: 'float',
+      ...AREA_UNIFORM_TYPES,
     },
     uniforms: (v, ctx) => {
       const pos = (v.position ?? { x: 0, y: 0 }) as { x: number; y: number };
@@ -111,7 +130,7 @@ export const liquidGlass: Effect = {
         uDispersion: Math.max(0, Number(v.dispersion ?? 30)) / 100,
         uRipple: Math.max(0, Number(v.ripple ?? 18)) / 100,
         uGlow: Math.max(0, Number(v.glow ?? 35)) / 100,
-        uRing: Math.max(0, Number(v.ring ?? 40)) / 100,
+        uRing: Math.max(0, Number(v.ring ?? 22)) / 100,
         uRingColor: [((n >> 16) & 0xff) / 255, ((n >> 8) & 0xff) / 255, (n & 0xff) / 255],
         uShimmer: Math.max(0, Number(v.shimmer ?? 25)) / 100,
         uBlur: Math.max(0, Number(v.edgeBlur ?? 6)),
@@ -120,9 +139,14 @@ export const liquidGlass: Effect = {
         uRound: Math.max(0, Math.min(1, Number(v.rounding ?? 30) / 100)),
         // Constante por enquanto, mas passa pela mesma funcao: chumbar no shader
         // esconderia o valor de quem for ler o efeito.
-        uSamples: MAX_SAMPLES,
+          uSamples: MAX_SAMPLES,
+        // 'Lens' e modo proprio deste efeito e vai para 0; bordas e cantos
+        // reusam a tabela compartilhada, para painel e shader nao discordarem.
+        uArea: String(v.area ?? 'Edges') === 'Lens' ? 0 : (AREA_CODE[String(v.area ?? 'Edges')] ?? 1),
+        uBand: Math.max(0, Math.min(1, Number(v.reach ?? 22) / 100)),
       };
     },
+    fixedUniforms: ['uSamples'],
     fragment: `
 const int LG_MAX = ${MAX_SAMPLES};
 
@@ -135,24 +159,50 @@ float lg_sdRoundBox(vec2 p, vec2 b, float r) {
 vec4 fxMain(vec2 p) {
   vec4 base = fxSample(p);
 
-  // Local, em PIXELS, girado junto com a lente para que aro, anel e ondulacao
-  // girem como uma peca so.
-  vec2 d = p - uCenter;
+  // DOIS modos, e a diferenca entre eles e so como 'rad' e 'rPix' nascem.
+  //
+  //   Lens (uArea 0)    um disco que se posiciona: 'rad' sai da elipse
+  //   Edges / Corners   o vidro vive na FAIXA DA BORDA: 'rad' e a mascara de
+  //                     area, e nao ha o que posicionar
+  //
+  // O modo de borda existe porque o disco, aplicado por cima da cena, cobre os
+  // cards — e vidro em cima do assunto e o assunto que se perde. Na borda o
+  // vidro emoldura, o meio fica limpo, e nao ha pad nem tamanho para acertar:
+  // o alcance e o unico numero.
+  bool lente = uArea < 0.5;
+
+  vec2 centro = lente ? uCenter : uResolution * 0.5;
+  vec2 d = p - centro;
   float ca = cos(uRotation), sa = sin(uRotation);
   vec2 q = mat2(ca, -sa, sa, ca) * d;
 
-  // 0 no centro .. 1 na borda
-  float nd = length(q / uHalf);
-  float maskND = nd;
-  if (uShape > 0.5) {
-    float corner = min(uHalf.x, uHalf.y) * uRound;
-    maskND = 1.0 + lg_sdRoundBox(q, uHalf, corner) / min(uHalf.x, uHalf.y);
+  float rad;
+  float shapeND;
+  float rPix;
+  if (lente) {
+    // 0 no centro .. 1 na borda
+    float nd = length(q / uHalf);
+    float maskND = nd;
+    if (uShape > 0.5) {
+      float corner = min(uHalf.x, uHalf.y) * uRound;
+      maskND = 1.0 + lg_sdRoundBox(q, uHalf, corner) / min(uHalf.x, uHalf.y);
+    }
+    // Fora da lente o quadro passa intacto — inclusive o alpha.
+    if (maskND > 1.0) return base;
+    shapeND = clamp(maskND, 0.0, 1.0);
+    rad = clamp(nd, 0.0, 1.0);
+    rPix = (uHalf.x + uHalf.y) * 0.5;
+  } else {
+    // A mascara JA e "0 no limpo .. 1 na borda", que e a mesma orientacao do
+    // 'rad' do disco — entao todo o resto do shader vale sem mudanca.
+    rad = fx_areaMask(p, uArea, uBand);
+    if (rad <= 0.001) return base;
+    shapeND = rad;
+    // O raio caracteristico e a LARGURA DA FAIXA, nao o do quadro: e ele que
+    // dita a escala da ondulacao e da dispersao, e usar meio quadro faria uma
+    // faixa fina ondular com a amplitude de uma lente gigante.
+    rPix = uBand * min(uResolution.x, uResolution.y) * 0.5;
   }
-  // Fora da lente o quadro passa intacto — inclusive o alpha.
-  if (maskND > 1.0) return base;
-
-  float shapeND = clamp(maskND, 0.0, 1.0);
-  float rad = clamp(nd, 0.0, 1.0);
   vec2 radialDir = normalize(d + vec2(1e-6));
   vec2 tangentDir = vec2(-radialDir.y, radialDir.x);
   float angle = atan(q.y, q.x);
@@ -166,7 +216,6 @@ vec4 fxMain(vec2 p) {
   // ocupado — bonito de perto e nervoso em movimento; duas ondas lentas
   // desencontradas e o que le como liquido.
   float fluid = sin(angle * 2.0) * 0.55 + sin(angle * 1.0) * 0.25;
-  float rPix = (uHalf.x + uHalf.y) * 0.5;
   // As constantes abaixo sao FRACAO DO RAIO da lente, nao pixels absolutos.
   // O original mede tudo em UV de altura de tela, entao converter so as
   // coordenadas e manter os fatores deixou a ondulacao vinte vezes fraca. Em
@@ -229,10 +278,14 @@ vec4 fxMain(vec2 p) {
   // 0,5. A minha primeira versao somava 0,47 e estourava o meio da lente de
   // branco — eu havia normalizado os controles para 0..1 sem refazer as
   // constantes que dependiam da escala antiga.
-  float r2 = shapeND * shapeND * 0.25;
-  float gs = max(uGlow * 0.43, 0.004);
-  float nova = (exp(-r2 / gs) + exp(-r2 / (gs * 7.0)) * 0.18) * uGlow * 0.23;
-  col += vec3(nova);
+  // So no modo lente: uma nova precisa de um CENTRO, e uma faixa de borda nao
+  // tem um. Somada ali, ela viraria um clarao ao longo de toda a moldura.
+  if (lente) {
+    float r2 = shapeND * shapeND * 0.25;
+    float gs = max(uGlow * 0.43, 0.004);
+    float nova = (exp(-r2 / gs) + exp(-r2 / (gs * 7.0)) * 0.18) * uGlow * 0.23;
+    col += vec3(nova);
+  }
 
   // Anel colorido mais a aura em volta dele. O anel fica quase na borda
   // (0.49 de 0.5) e e fino: mais para dentro ele le como bolha, nao como aro.
@@ -246,13 +299,23 @@ vec4 fxMain(vec2 p) {
     ring *= sin(angle * 12.0 + uTime * uShimmer * 6.2831853) * 0.12 + 0.88;
   }
   float aura = exp(-pow((dC - tR) / (rW * 6.0), 2.0)) * 0.28 * uRing * 2.5;
-  col += uRingColor * (ring + aura);
+  // Mesma razao da linha de reflexo: num circulo curto o anel e um brilho de
+  // vidro, correndo pelo quadro inteiro ele SATURA e vira tubo de neon. Medido
+  // no default antigo, o pico somava 1,62 em ciano — acima de 1,0, ou seja
+  // estourado. O fator devolve o anel para a faixa visivel.
+  float ganhoAnel = lente ? 1.0 : 0.3;
+  col += uRingColor * (ring + aura) * ganhoAnel;
 
-  // Linha clara na borda, o reflexo do canto do vidro.
-  col += vec3(exp(-pow((dC - 0.488) / 0.003, 2.0)) * uRing * 3.5);
+  // Linha clara na borda, o reflexo do canto do vidro. No disco ela e um fio
+  // curto num circulo; numa moldura ela corre pelo quadro inteiro e soma com a
+  // aura do anel ao longo de tudo — no default aquilo virava letreiro de neon.
+  // Um terco da intensidade no modo de borda devolve o reflexo sem o anuncio.
+  col += vec3(exp(-pow((dC - 0.488) / 0.003, 2.0)) * uRing * (lente ? 3.5 : 1.2));
 
-  // Queda suave no ultimo por cento, para o aro nao serrilhar.
-  float a = smoothstep(1.0, 0.93, maskND);
+  // Quanto do vidro entra. No disco e 1 dentro com uma queda de 7% no aro, para
+  // nao serrilhar; na faixa a propria mascara ja e a rampa, entao ela e a
+  // opacidade — o vidro nasce do nada na borda interna e fecha na externa.
+  float a = lente ? smoothstep(1.0, 0.93, shapeND) : rad;
   return vec4(mix(base.rgb, col, a), base.a);
 }`,
   },

--- a/effects/tiltShift.ts
+++ b/effects/tiltShift.ts
@@ -1,4 +1,5 @@
 import type { Effect, EffectShader } from '@/lib/types';
+import { AREA_OPTIONS, AREA_UNIFORM_TYPES, areaUniforms } from './area';
 
 // Tilt-shift: uma FAIXA em foco, o resto borrado, com a transicao suave.
 //
@@ -18,18 +19,24 @@ import type { Effect, EffectShader } from '@/lib/types';
 const TAPS = 6;
 
 const corpo = `
-float fx_desfoque(vec2 p) {
-  // distancia ate a faixa, em pixels, 0 dentro dela
+// A faixa horizontal: 0 dentro dela, subindo para fora. E o modo 'Band', o
+// tilt-shift classico — plano de foco paralelo ao chao.
+float ts_faixa(vec2 p) {
   float centro = uFocus * uResolution.y;
-  float meia = max(1.0, uBand * uResolution.y * 0.5);
+  float meia = max(1.0, uBandY * uResolution.y * 0.5);
   float d = abs(p.y - centro) - meia;
   if (d <= 0.0) return 0.0;
   float rampa = max(1.0, uFeather * uResolution.y);
-  return uRadius * smoothstep(0.0, rampa, d);
+  return smoothstep(0.0, rampa, d);
 }
 
 vec4 fxMain(vec2 p) {
-  float raio = fx_desfoque(p);
+  // Faixa (codigo 3) usa a mascara propria; bordas e cantos usam a
+  // compartilhada. A faixa deixa o meio nitido e borra TOPO E BASE, o que numa
+  // cena de cards deitados ainda come metade deles — por isso ela deixou de ser
+  // o unico modo, e nao e mais o default.
+  float mascara = (uArea > 2.5) ? ts_faixa(p) : fx_areaMask(p, uArea, uBand);
+  float raio = uRadius * mascara;
   if (raio < 0.5) return fxSample(p);
   vec4 soma = fxSample(p);
   float peso = 1.0;
@@ -47,18 +54,26 @@ vec4 fxMain(vec2 p) {
 function passe(direcao: [number, number]): EffectShader {
   return {
     uniformTypes: {
-      uRadius: 'float', uFocus: 'float', uBand: 'float', uFeather: 'float', uDir: 'vec2',
+      uRadius: 'float', uFocus: 'float', uBandY: 'float', uFeather: 'float', uDir: 'vec2',
+      ...AREA_UNIFORM_TYPES,
     },
     uniforms: (v) => ({
       uRadius: Math.max(0, Number(v.radius ?? 14)),
       // 0 = topo, 1 = base. Metade e o centro do quadro.
       uFocus: Math.max(0, Math.min(1, Number(v.focus ?? 50) / 100)),
-      uBand: Math.max(0, Math.min(1, Number(v.band ?? 25) / 100)),
+      // `uBandY` e a faixa de foco; `uBand`, que vem da area compartilhada, e o
+      // alcance da mascara de borda. Nomes distintos porque sao duas coisas
+      // diferentes e o mesmo nome nos dois era um bug esperando acontecer.
+      uBandY: Math.max(0, Math.min(1, Number(v.band ?? 25) / 100)),
       // Nunca exatamente zero: smoothstep com as duas bordas iguais e indefinido,
       // e o mesmo cuidado que o Vignette ja precisou ter na sua rampa.
       uFeather: Math.max(0.001, Number(v.feather ?? 12) / 100),
       uDir: direcao,
+      ...areaUniforms(v),
+      // 'Band' nao esta na tabela compartilhada: e um modo so deste efeito.
+      uArea: String(v.area ?? 'Edges') === 'Band' ? 3 : areaUniforms(v).uArea,
     }),
+    fixedUniforms: ['uDir'],
     fragment: corpo,
   };
 }
@@ -67,9 +82,26 @@ export const tiltShift: Effect = {
   meta: { id: 'tilt-shift', name: 'Tilt-shift', defaultScope: 'scene' },
   controls: [
     { key: 'radius', label: 'Radius', type: 'slider', min: 0, max: 40, step: 1, default: 14, unit: 'px' },
-    { key: 'focus', label: 'Focus', type: 'slider', min: 0, max: 100, step: 1, default: 50, unit: '%' },
-    { key: 'band', label: 'Band', type: 'slider', min: 0, max: 100, step: 1, default: 25, unit: '%' },
-    { key: 'feather', label: 'Feather', type: 'slider', min: 0, max: 60, step: 1, default: 12, unit: '%' },
+    // A faixa horizontal virou UMA das areas em vez de a unica. Ela deixa o
+    // meio nitido e borra topo e base, o que numa cena de cards deitados ainda
+    // come metade deles; bordas e cantos protegem o assunto de verdade.
+    { key: 'area', label: 'Applies at', type: 'pills', options: [...AREA_OPTIONS, 'Band'], default: 'Edges' },
+    {
+      key: 'reach', label: 'Reach', type: 'slider', min: 2, max: 100, step: 1, default: 35, unit: '%',
+      visibleWhen: { key: 'area', not: 'Full frame' },
+    },
+    {
+      key: 'focus', label: 'Focus', type: 'slider', min: 0, max: 100, step: 1, default: 50, unit: '%',
+      visibleWhen: { key: 'area', equals: 'Band' },
+    },
+    {
+      key: 'band', label: 'Band', type: 'slider', min: 0, max: 100, step: 1, default: 25, unit: '%',
+      visibleWhen: { key: 'area', equals: 'Band' },
+    },
+    {
+      key: 'feather', label: 'Feather', type: 'slider', min: 0, max: 60, step: 1, default: 12, unit: '%',
+      visibleWhen: { key: 'area', equals: 'Band' },
+    },
   ],
   shader: passe([1, 0]),
   passes: [passe([0, 1])],

--- a/effects/tiltShift.ts
+++ b/effects/tiltShift.ts
@@ -79,7 +79,10 @@ function passe(direcao: [number, number]): EffectShader {
 }
 
 export const tiltShift: Effect = {
-  meta: { id: 'tilt-shift', name: 'Tilt-shift', defaultScope: 'scene' },
+  // Nasce em 'artwork': age sobre os CARDS, e o fundo da cena passa intacto.
+  // Aplicado ao fundo tambem, um efeito de lente amassa a cena inteira e o
+  // assunto se perde junto. Quem quiser o fundo troca no seletor de escopo.
+  meta: { id: 'tilt-shift', name: 'Tilt-shift', defaultScope: 'artwork' },
   controls: [
     { key: 'radius', label: 'Radius', type: 'slider', min: 0, max: 40, step: 1, default: 14, unit: 'px' },
     // A faixa horizontal virou UMA das areas em vez de a unica. Ela deixa o

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -249,6 +249,22 @@ export class SceneRenderer3D implements IRenderer {
         // DIRETO (1, o acumulador de arte, que ja saiu deste mesmo shader).
         // Dividir por alpha o que ja e direto estoura a cor nas bordas do card.
         layerIsStraight: { value: 0 },
+        // 1 = ignore `baseMap` e comece do VAZIO.
+        //
+        // Existe por causa de uma pegadinha do three com alvos MULTISAMPLED — e
+        // todos aqui sao, ver makeTarget. A textura de um alvo MSAA so e
+        // resolvida quando algo e DESENHADO nele; no caminho de arte separada o
+        // acumulador e apenas LIMPO e nunca desenhado, entao a sua textura
+        // seguia entregando o conteudo resolvido antes: o fundo OPACO dos
+        // frames em que a arte nao era separada. Com isso `base.a` valia 1 onde
+        // devia valer 0, o alpha da arte saia opaco no quadro inteiro, e a luz
+        // do Liquid Glass vazava para o fundo. Medido: 14% dos pixels de fundo
+        // mudavam no caminho webgl contra 1,2% no Pixi, com o MESMO shader — e
+        // foi essa assimetria entre os dois engines que denunciou.
+        //
+        // Nao ler a textura resolve na raiz, em vez de depender de um clear que
+        // o driver nao e obrigado a propagar para a textura.
+        baseEmpty: { value: 0 },
       },
       vertexShader: `varying vec2 vUv; void main(){ vUv=uv; gl_Position=vec4(position.xy,0.0,1.0); }`,
       fragmentShader: `
@@ -257,9 +273,10 @@ export class SceneRenderer3D implements IRenderer {
         uniform float opacity;
         uniform int blendMode;
         uniform int layerIsStraight;
+        uniform int baseEmpty;
         varying vec2 vUv;
         void main(){
-          vec4 base = texture2D(baseMap, vUv);
+          vec4 base = baseEmpty == 1 ? vec4(0.0) : texture2D(baseMap, vUv);
           vec4 layer = texture2D(layerMap, vUv);
           float a = clamp(layer.a * opacity, 0.0, 1.0);
           vec3 straight = layerIsStraight == 1
@@ -1217,6 +1234,11 @@ export class SceneRenderer3D implements IRenderer {
       };
 
       const composeMaterial = this.composeQuad.material;
+      // A primeira camada a compor no caminho separado nao tem base: o
+      // acumulador esta vazio, e a textura dele nao pode ser lida (ver
+      // `baseEmpty`). Depois da primeira, o acumulador ja recebeu um desenho e
+      // a textura vale.
+      let primeiraCamada = separarFundo;
       s.tracks.forEach((track) => {
         const rt = this.trackRTs.get(track.id);
         if (!rt?.active) return;
@@ -1237,6 +1259,8 @@ export class SceneRenderer3D implements IRenderer {
         composeMaterial.uniforms.layerMap.value = camada.texture;
         composeMaterial.uniforms.opacity.value = rt.opacity;
         composeMaterial.uniforms.layerIsStraight.value = 0;
+        composeMaterial.uniforms.baseEmpty.value = primeiraCamada ? 1 : 0;
+        primeiraCamada = false;
         composeMaterial.uniforms.blendMode.value = rt.blend === 'add' ? 1
           : rt.blend === 'screen' ? 2
           : rt.blend === 'multiply' ? 3 : 0;
@@ -1258,6 +1282,8 @@ export class SceneRenderer3D implements IRenderer {
         composeMaterial.uniforms.opacity.value = 1;
         composeMaterial.uniforms.blendMode.value = 0;
         composeMaterial.uniforms.layerIsStraight.value = 1;
+        // Aqui a base e o FUNDO, que foi desenhado de verdade — pode ser lida.
+        composeMaterial.uniforms.baseEmpty.value = 0;
         this.renderer.setRenderTarget(write);
         this.renderer.clear(true, false, false);
         this.renderer.render(this.composeScene, this.composeCam);

--- a/lib/renderer3d.ts
+++ b/lib/renderer3d.ts
@@ -318,7 +318,15 @@ export class SceneRenderer3D implements IRenderer {
 
     // The quad every effect pass renders through. Its material is swapped per
     // effect; the geometry and the scene are built once.
-    this.fxQuad = new THREE.Mesh(geometry.clone(), outputMaterial);
+    //
+    // Material PROPRIO, nao o do output. Nascia compartilhando a mesma
+    // instancia, e passava porque `renderFrame` troca a material antes de todo
+    // passe e `fxScene` nunca e desenhada sem efeito ativo. Mas as duas coisas
+    // que faziam isso funcionar sao invisiveis daqui, e uma delas e o
+    // `outputQuad.material.dispose()` do destroy, que soltaria a material que
+    // este quad ainda referencia. Uma copia custa nada e tira as duas
+    // dependencias implicitas.
+    this.fxQuad = new THREE.Mesh(geometry.clone(), outputMaterial.clone());
     this.fxScene.add(this.fxQuad);
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -224,6 +224,18 @@ export interface EffectShader {
   uniformTypes?: Record<string, 'float' | 'vec2' | 'vec3' | 'vec4'>;
   // Control values -> uniform values, once per frame.
   uniforms: (values: Record<string, any>, ctx: EffectContext) => Record<string, number | number[]>;
+  // Uniforms CONSTANTES por desenho, que nenhum controle move.
+  //
+  // A suite exige que todo uniform seja movido por algum controle, porque um
+  // uniform preso no default e um valor chumbado se passando por parametro — e
+  // isso aconteceu de verdade: o Bloom recebeu `uArea` sem os controles
+  // correspondentes e nascia restrito as bordas, sem como tirar.
+  //
+  // Alguns sao constantes de proposito. `uDir` e a DIRECAO do passe, e e o que
+  // distingue o horizontal do vertical num blur separavel. Declarar aqui e a
+  // forma de dizer isso: a excecao fica explicita e revisavel, em vez de o
+  // portao ser afrouxado para todo mundo.
+  fixedUniforms?: string[];
 }
 
 // Onde um efeito age. Guardado como string na cena para sobreviver a

--- a/scripts/_probe_artwork_area.cjs
+++ b/scripts/_probe_artwork_area.cjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+// Em escopo 'artwork', o efeito respeita o FUNDO e a AREA ao mesmo tempo?
+//
+// Duas perguntas que se cruzam, e por isso vale medir juntas:
+//
+//   1. o fundo da cena tem de sair intacto — e o que 'artwork' promete
+//   2. a faixa de borda tem de cair na borda do CANVAS
+//
+// A segunda nao e obvia. Em 'scene' o filtro do Pixi vive em `content`, que
+// cobre o quadro; em 'artwork' ele vive em `motion`, com `filterArea` propria, e
+// as coordenadas que o shader recebe passam pelo `uInputSize` daquela area. Se a
+// origem nao casar com a origem do canvas, a mascara de area anda junto e a
+// moldura aparece deslocada — sem que nada quebre nem apareca no console.
+//
+// A medida: pixels que MUDARAM em relacao a cena sem efeito, separados em
+// "estao na moldura externa" e "estao no miolo", mais quantos deles caem em cima
+// da cor do fundo.
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const EFEITO = process.argv[3] || 'Blur';
+
+const CASOS = [
+  { nome: '2D (Pixi)', preset: null },
+  { nome: 'webgl (three)', preset: { rotulo: 'Ring Stream', grupo: 'Orbit 3D' } },
+];
+
+// Lê o palco e guarda os bytes, para comparar dois estados do MESMO frame.
+const LER = function () {
+  const c = document.querySelector('canvas.stage-canvas');
+  if (!c || !c.width) return null;
+  const o = document.createElement('canvas');
+  o.width = c.width; o.height = c.height;
+  const g = o.getContext('2d'); g.drawImage(c, 0, 0);
+  const d = g.getImageData(0, 0, c.width, c.height).data;
+  return { w: c.width, h: c.height, px: Array.from(d) };
+};
+
+const semear = function () {
+  const scene = {
+    activeTemplateId: 'arc-01',
+    tracks: [{ id: 't0', templateId: 'arc-01' }],
+    width: 810, height: 1080, fps: 30, duration: 8,
+    background: { source: 'color', color: '#1a1a1a', gradient: false, color2: '#1a1a1a', imageUrl: null, blur: 28 },
+    effects: [],
+  };
+  localStorage.setItem('motion-welcome-seen', '1');
+  localStorage.setItem('motion-tour-seen', '1');
+  localStorage.setItem('motion-scene-v1', JSON.stringify(scene));
+  localStorage.setItem('motion-project-fx', JSON.stringify(scene));
+  localStorage.setItem('motion-projects-v1', JSON.stringify({
+    activeId: 'fx', projects: [{ id: 'fx', name: 'Artwork area', createdAt: 1, updatedAt: 2, mode: '2d' }],
+  }));
+};
+
+const escolher = async function (rotulo, grupo) {
+  document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+  const achar = () => Array.from(document.querySelectorAll('.tpl-card'))
+    .find((el) => { const l = el.querySelector('.tpl-card-label'); return l && l.textContent.trim() === rotulo; });
+  if (!achar()) {
+    const linha = Array.from(document.querySelectorAll('.tpl-item'))
+      .find((el) => (el.textContent || '').trim().startsWith(grupo));
+    if (!linha) return 'grupo nao achado';
+    linha.click();
+    await new Promise((r) => setTimeout(r, 900));
+  }
+  const card = achar();
+  if (!card) return 'preset nao apareceu';
+  (card.querySelector('.tpl-card-label') || card).click();
+  await new Promise((r) => setTimeout(r, 3000));
+  return 'ok';
+};
+
+const pausar = async function () {
+  const btn = document.querySelector('.play-btn');
+  if (btn && btn.getAttribute('title') === 'Pause') {
+    btn.click();
+    await new Promise((r) => setTimeout(r, 700));
+  }
+  return document.querySelector('.play-btn').getAttribute('title');
+};
+
+const adicionar = async function (nome) {
+  const sel = Array.from(document.querySelectorAll('select'))
+    .find((s) => Array.from(s.options).some((o) => o.textContent.trim() === nome));
+  if (!sel) return 'sem select';
+  sel.value = Array.from(sel.options).find((o) => o.textContent.trim() === nome).value;
+  sel.dispatchEvent(new Event('change', { bubbles: true }));
+  await new Promise((r) => setTimeout(r, 150));
+  Array.from(document.querySelectorAll('button')).find((b) => b.textContent.trim() === 'Add').click();
+  await new Promise((r) => setTimeout(r, 1600));
+  const card = Array.from(document.querySelectorAll('.effect-card'))
+    .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === nome; });
+  if (!card) return 'card nao apareceu';
+  const esc = card.querySelector('.effect-scope-row select');
+  return 'escopo=' + (esc ? esc.value : 'SEM SELETOR');
+};
+
+(async () => {
+  for (const caso of CASOS) {
+    console.log('');
+    console.log('=== ' + caso.nome + ' — ' + EFEITO + ' ===');
+    const b = await puppeteer.launch({
+      executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+      args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+    });
+    const p = await b.newPage();
+    p.on('pageerror', (e) => console.log('  [pageerror]', String(e).slice(0, 180)));
+    const vistos = new Set();
+    p.on('console', (m) => { const t = m.text(); if ((t.includes('[DIAG]') || t.includes('[ALPHA]')) && !vistos.has(t)) { vistos.add(t); console.log('  ' + t.slice(0, 200)); } });
+    await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+    await p.evaluate(semear);
+    await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+    await p.evaluate(() => {
+      document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+    });
+    if (caso.preset) console.log('  preset ', await p.evaluate(escolher, caso.preset.rotulo, caso.preset.grupo));
+    const pintou = await p.waitForFunction(
+      function (fn) { const m = new Function('return (' + fn + ')()')(); return !!m && m.w > 0; },
+      { timeout: 60000, polling: 700 }, LER.toString(),
+    ).then(() => true).catch(() => false);
+    if (!pintou) { console.log('  palco nao pintou'); await b.close(); continue; }
+
+    // PAUSA antes das duas leituras: sem isso a diferenca mistura pose com efeito.
+    console.log('  pausa  ', await p.evaluate(pausar));
+    const antes = await p.evaluate(LER);
+    console.log('  add    ', await p.evaluate(adicionar, EFEITO));
+    const depois = await p.evaluate(LER);
+    await b.close();
+
+    if (!antes || !depois || antes.w !== depois.w) { console.log('  leituras incompativeis'); continue; }
+    const { w, h } = antes;
+    // a cor do fundo, tirada de um canto do quadro SEM efeito
+    const fundo = [antes.px[0], antes.px[1], antes.px[2]];
+    const faixa = Math.round(Math.min(w, h) * 0.5 * 0.35); // o Reach default
+    let mudouMoldura = 0, mudouMiolo = 0, mudouSobreFundo = 0, totalFundo = 0;
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const i = (y * w + x) * 4;
+        const dif = Math.abs(antes.px[i] - depois.px[i])
+          + Math.abs(antes.px[i + 1] - depois.px[i + 1])
+          + Math.abs(antes.px[i + 2] - depois.px[i + 2]);
+        const eraFundo = Math.abs(antes.px[i] - fundo[0]) + Math.abs(antes.px[i + 1] - fundo[1]) + Math.abs(antes.px[i + 2] - fundo[2]) < 10;
+        if (eraFundo) totalFundo++;
+        if (dif < 8) continue;
+        const naMoldura = x < faixa || y < faixa || x >= w - faixa || y >= h - faixa;
+        if (naMoldura) mudouMoldura++; else mudouMiolo++;
+        if (eraFundo) mudouSobreFundo++;
+      }
+    }
+    const total = mudouMoldura + mudouMiolo;
+    console.log('  pixels mudados      ' + total
+      + '  (moldura ' + mudouMoldura + ', miolo ' + mudouMiolo + ')');
+    console.log('  na moldura          ' + (total ? ((mudouMoldura / total) * 100).toFixed(1) : '0') + '%');
+    console.log('  sobre o FUNDO       ' + mudouSobreFundo + ' de ' + totalFundo
+      + ' (' + (totalFundo ? ((mudouSobreFundo / totalFundo) * 100).toFixed(2) : '0') + '% do fundo)');
+
+    // A COR da contaminacao diz qual termo a causou, e "mudou" sozinho nao diz.
+    // Luz somada sai mais clara e puxada para a cor do anel; refracao sai com a
+    // cor de um card arrastado para ali, sem tendencia de brilho.
+    let dr = 0, dg = 0, db = 0, n = 0;
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const i = (y * w + x) * 4;
+        const eraFundo = Math.abs(antes.px[i] - fundo[0]) + Math.abs(antes.px[i + 1] - fundo[1]) + Math.abs(antes.px[i + 2] - fundo[2]) < 10;
+        if (!eraFundo) continue;
+        const dif = Math.abs(antes.px[i] - depois.px[i])
+          + Math.abs(antes.px[i + 1] - depois.px[i + 1])
+          + Math.abs(antes.px[i + 2] - depois.px[i + 2]);
+        if (dif < 8) continue;
+        dr += depois.px[i] - antes.px[i];
+        dg += depois.px[i + 1] - antes.px[i + 1];
+        db += depois.px[i + 2] - antes.px[i + 2];
+        n++;
+      }
+    }
+    if (n) {
+      console.log('  delta medio no fundo  R ' + (dr / n).toFixed(1)
+        + '  G ' + (dg / n).toFixed(1) + '  B ' + (db / n).toFixed(1)
+        + '   (positivo e claro = luz somada; misto = refracao)');
+    }
+
+    // PORTAO, nao so relatorio.
+    //
+    // 5% e o teto: o efeito age nos cards, e a borda macia de um card
+    // inevitavelmente sangra alguns pixels para o fundo — medido entre 0,4% e
+    // 3% nos quatro efeitos. Acima disso o efeito esta pintando o FUNDO, que e
+    // exatamente o que o escopo de arte promete nao fazer.
+    //
+    // O teto pegou um bug de verdade: no caminho webgl a luz do Liquid Glass
+    // vazava para 14% do fundo contra 1,2% no Pixi, com o MESMO shader — e foi
+    // a assimetria entre os engines que apontou a causa (textura de alvo MSAA
+    // nao resolvida; ver `baseEmpty` em lib/renderer3d.ts).
+    const pctFundo = totalFundo ? (mudouSobreFundo / totalFundo) * 100 : 0;
+    if (pctFundo > 5) {
+      console.log('  FALHOU: ' + pctFundo.toFixed(2) + '% do fundo mudou; em escopo de arte o teto e 5%');
+      process.exitCode = 1;
+    }
+    // E a area tem de valer tambem: um efeito que muda o quadro todo passaria
+    // no teste do fundo se o fundo fosse pequeno.
+    if (total && (mudouMoldura / total) * 100 < 85) {
+      console.log('  FALHOU: so ' + ((mudouMoldura / total) * 100).toFixed(1) + '% das mudancas caem na moldura');
+      process.exitCode = 1;
+    }
+  }
+})();

--- a/scripts/_probe_premultiplied.cjs
+++ b/scripts/_probe_premultiplied.cjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// O canvas do palco respeita a invariante de alpha PRE-MULTIPLICADO?
+//
+// O navegador compoe um canvas com alpha assumindo pre-multiplicado: cada canal
+// de cor ja tem de vir multiplicado pelo alpha, o que torna `rgb <= alpha` uma
+// invariante do formato. Um pixel com rgb 255 e alpha 128 e impossivel — e
+// quando aparece, o compositor clareia aquele pixel, porque trata 255 como "luz
+// que ja passou pelo alpha".
+//
+// Isto importa aqui porque o passe de saida do renderer 3D e um ShaderMaterial
+// com `transparent: true` que escreve `texture2D(map, uv)` direto: se o alvo
+// guarda alpha DIRETO, a saida sai fora da invariante.
+//
+// A cena e semeada com o FUNDO em alpha 40, que e o que faz o canvas ter alpha
+// parcial em area grande — sem isso o quadro e todo opaco e a invariante nao
+// tem como ser violada.
+//
+// Mede os dois engines de proposito: se um respeita e o outro nao, o defeito
+// esta no renderer e nao na cena. Foi essa assimetria que denunciou a textura
+// de alvo MSAA nao resolvida.
+const fs = require('fs');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+
+const CASOS = [
+  { nome: '2D (Pixi)', preset: null },
+  { nome: 'webgl (three)', preset: { rotulo: 'Ring Stream', grupo: 'Orbit 3D' } },
+];
+
+const MEDIR = function () {
+  const c = document.querySelector('canvas.stage-canvas');
+  if (!c || !c.width) return null;
+  const o = document.createElement('canvas');
+  o.width = c.width; o.height = c.height;
+  const g = o.getContext('2d');
+  // `alpha: true` e sem fundo pintado: o que se le e o alpha do proprio palco.
+  g.clearRect(0, 0, c.width, c.height);
+  g.drawImage(c, 0, 0);
+  const d = g.getImageData(0, 0, c.width, c.height).data;
+  let parciais = 0, fora = 0, piorExcesso = 0, opacos = 0, vazios = 0;
+  for (let i = 0; i < d.length; i += 4) {
+    const a = d[i + 3];
+    if (a >= 250) { opacos++; continue; }
+    if (a <= 4) { vazios++; continue; }
+    parciais++;
+    const rgbMax = Math.max(d[i], d[i + 1], d[i + 2]);
+    const excesso = rgbMax - a;
+    if (excesso > 8) { fora++; if (excesso > piorExcesso) piorExcesso = excesso; }
+  }
+  return { opacos, vazios, parciais, fora, piorExcesso };
+};
+
+const semear = function () {
+  const scene = {
+    activeTemplateId: 'arc-01',
+    tracks: [{ id: 't0', templateId: 'arc-01' }],
+    width: 810, height: 1080, fps: 30, duration: 8,
+    // alpha 40: o quadro passa a ter alpha parcial em area grande
+    background: { source: 'color', color: '#1a1a1a', alpha: 40, gradient: false, color2: '#1a1a1a', imageUrl: null, blur: 28 },
+    effects: [],
+  };
+  localStorage.setItem('motion-welcome-seen', '1');
+  localStorage.setItem('motion-tour-seen', '1');
+  localStorage.setItem('motion-scene-v1', JSON.stringify(scene));
+  localStorage.setItem('motion-project-fx', JSON.stringify(scene));
+  localStorage.setItem('motion-projects-v1', JSON.stringify({
+    activeId: 'fx', projects: [{ id: 'fx', name: 'Premultiplied', createdAt: 1, updatedAt: 2, mode: '2d' }],
+  }));
+};
+
+const escolher = async function (rotulo, grupo) {
+  document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+  const achar = () => Array.from(document.querySelectorAll('.tpl-card'))
+    .find((el) => { const l = el.querySelector('.tpl-card-label'); return l && l.textContent.trim() === rotulo; });
+  if (!achar()) {
+    const linha = Array.from(document.querySelectorAll('.tpl-item'))
+      .find((el) => (el.textContent || '').trim().startsWith(grupo));
+    if (!linha) return 'grupo nao achado';
+    linha.click();
+    await new Promise((r) => setTimeout(r, 900));
+  }
+  const card = achar();
+  if (!card) return 'preset nao apareceu';
+  (card.querySelector('.tpl-card-label') || card).click();
+  await new Promise((r) => setTimeout(r, 3000));
+  return 'ok';
+};
+
+(async () => {
+  for (const caso of CASOS) {
+    console.log('');
+    console.log('=== ' + caso.nome + ' ===');
+    const b = await puppeteer.launch({
+      executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+      args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+    });
+    const p = await b.newPage();
+    p.on('pageerror', (e) => console.log('  [pageerror]', String(e).slice(0, 180)));
+    await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+    await p.evaluate(semear);
+    await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+    await p.evaluate(() => {
+      document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+    });
+    if (caso.preset) console.log('  preset ', await p.evaluate(escolher, caso.preset.rotulo, caso.preset.grupo));
+    const ok = await p.waitForFunction(
+      function (fn) { const m = new Function('return (' + fn + ')()')(); return !!m && (m.parciais + m.opacos) > 20000; },
+      { timeout: 60000, polling: 700 }, MEDIR.toString(),
+    ).then(() => true).catch(() => false);
+    const m = await p.evaluate(MEDIR);
+    await b.close();
+    if (!ok) { console.log('  palco nao pintou:', JSON.stringify(m)); continue; }
+    console.log('  ' + JSON.stringify(m));
+    if (!m.parciais) {
+      console.log('  sem pixel de alpha parcial — a invariante nao pode ser testada nesta cena');
+      continue;
+    }
+    const pct = (m.fora / m.parciais) * 100;
+    console.log('  fora da invariante  ' + pct.toFixed(1) + '% dos parciais, pior excesso ' + m.piorExcesso + '/255');
+    if (pct > 5) {
+      console.log('  FALHOU: rgb > alpha em ' + pct.toFixed(1) + '% dos pixels parciais — o compositor clareia esses pixels');
+      process.exitCode = 1;
+    }
+  }
+})();

--- a/scripts/_shot_liquid_glass.cjs
+++ b/scripts/_shot_liquid_glass.cjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// A/B honesto do Posterize: MESMO frame, efeito desligado e ligado.
+//
+// As duas fotos anteriores estavam em frames diferentes — o palco continua
+// tocando — e diferenca de pose se confunde com diferenca de efeito. Aqui a
+// linha de tempo e PAUSADA antes das duas capturas, e o que muda entre elas e
+// so o olho do card do efeito.
+const fs = require('fs'), path = require('path');
+const puppeteer = require('puppeteer-core');
+const CHROME = ['C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe']
+  .find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+const U = process.argv[2] || 'http://localhost:3100';
+const NIVEIS = Number(process.argv[3] || 5);
+const OUT = path.resolve(__dirname, '..', '..', '_fx-shots');
+fs.mkdirSync(OUT, { recursive: true });
+
+const CASOS = [
+  { nome: '2d', preset: null },                                   // preset padrao (2D)
+  { nome: 'webgl', preset: { rotulo: 'Ring Stream', grupo: 'Orbit 3D' } },
+];
+
+const semear = function () {
+  const scene = {
+    activeTemplateId: 'arc-01',
+    tracks: [{ id: 't0', templateId: 'arc-01' }],
+    width: 810, height: 1080, fps: 30, duration: 8,
+    background: { source: 'color', color: '#1a1a1a', gradient: false, color2: '#1a1a1a', imageUrl: null, blur: 28 },
+    effects: [],
+  };
+  localStorage.setItem('motion-welcome-seen', '1');
+  localStorage.setItem('motion-tour-seen', '1');
+  localStorage.setItem('motion-scene-v1', JSON.stringify(scene));
+  localStorage.setItem('motion-project-fx', JSON.stringify(scene));
+  localStorage.setItem('motion-projects-v1', JSON.stringify({
+    activeId: 'fx', projects: [{ id: 'fx', name: 'AB posterize', createdAt: 1, updatedAt: 2, mode: '2d' }],
+  }));
+};
+
+const CONTEUDO = function () {
+  const c = document.querySelector('canvas.stage-canvas');
+  if (!c || !c.width) return null;
+  const o = document.createElement('canvas');
+  o.width = c.width; o.height = c.height;
+  const g = o.getContext('2d'); g.drawImage(c, 0, 0);
+  const d = g.getImageData(0, 0, c.width, c.height).data;
+  const hist = new Map();
+  for (let i = 0; i < d.length; i += 4) {
+    const k = d[i] + ',' + d[i + 1] + ',' + d[i + 2];
+    hist.set(k, (hist.get(k) || 0) + 1);
+  }
+  let fundo = [0, 0, 0], max = 0;
+  for (const [k, n] of hist) if (n > max) { max = n; fundo = k.split(',').map(Number); }
+  let conteudo = 0;
+  const set = new Set();
+  for (let i = 0; i < d.length; i += 4) {
+    set.add(d[i]);
+    const dist = Math.abs(d[i] - fundo[0]) + Math.abs(d[i + 1] - fundo[1]) + Math.abs(d[i + 2] - fundo[2]);
+    if (dist >= 24) conteudo++;
+  }
+  return { conteudo, fundo, niveis: set.size };
+};
+
+(async () => {
+  for (const caso of CASOS) {
+    console.log('');
+    console.log('=== ' + caso.nome + ' ===');
+    const b = await puppeteer.launch({
+      executablePath: CHROME, headless: process.env.HEADED ? false : 'new',
+      args: ['--enable-gpu'], defaultViewport: { width: 1600, height: 1000 },
+    });
+    const p = await b.newPage();
+    await p.goto(U + '/library', { waitUntil: 'domcontentloaded', timeout: 180000 });
+    await p.evaluate(semear);
+    await p.goto(U + '/library', { waitUntil: 'networkidle2', timeout: 180000 });
+    await p.evaluate(() => {
+      document.querySelectorAll('[role=dialog], .modal-backdrop').forEach((el) => { el.style.display = 'none'; });
+    });
+    if (caso.preset) {
+      await p.evaluate(async (rotulo, grupo) => {
+        const achar = () => Array.from(document.querySelectorAll('.tpl-card'))
+          .find((el) => { const l = el.querySelector('.tpl-card-label'); return l && l.textContent.trim() === rotulo; });
+        if (!achar()) {
+          const linha = Array.from(document.querySelectorAll('.tpl-item'))
+            .find((el) => (el.textContent || '').trim().startsWith(grupo));
+          if (linha) { linha.click(); await new Promise((r) => setTimeout(r, 900)); }
+        }
+        const card = achar();
+        if (card) { (card.querySelector('.tpl-card-label') || card).click(); await new Promise((r) => setTimeout(r, 3000)); }
+      }, caso.preset.rotulo, caso.preset.grupo);
+    }
+    await p.waitForFunction(
+      function (fn) { const m = new Function('return (' + fn + ')()')(); return !!m && m.conteudo > 20000; },
+      { timeout: 60000, polling: 700 }, CONTEUDO.toString(),
+    );
+
+    // adiciona o efeito, ajusta os niveis, e SO DEPOIS pausa
+    await p.evaluate(async () => {
+      const sel = Array.from(document.querySelectorAll('select'))
+        .find((s) => Array.from(s.options).some((o) => o.textContent.trim() === 'Liquid Glass'));
+      sel.value = Array.from(sel.options).find((o) => o.textContent.trim() === 'Liquid Glass').value;
+      sel.dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 150));
+      Array.from(document.querySelectorAll('button')).find((btn) => btn.textContent.trim() === 'Add').click();
+      await new Promise((r) => setTimeout(r, 1200));
+    });
+    const caixa = await p.evaluate(() => {
+      const card = Array.from(document.querySelectorAll('.effect-card'))
+        .find((c) => { const t = c.querySelector('.effect-title'); return t && t.textContent.trim() === 'Liquid Glass'; });
+      card.scrollIntoView({ block: 'center' });
+      const st = card.querySelector('.strack');
+      const r = st.getBoundingClientRect();
+      return { x: r.x, y: r.y, w: r.width, h: r.height };
+    });
+    await new Promise((r) => setTimeout(r, 400));
+
+    // pausa: sem isso as duas capturas caem em frames diferentes
+    const pausou = await p.evaluate(async () => {
+      const btn = document.querySelector('.play-btn');
+      if (!btn) return 'sem botao de play';
+      const antes = btn.getAttribute('title');
+      if (antes === 'Pause') { btn.click(); await new Promise((r) => setTimeout(r, 600)); }
+      return 'title agora: ' + document.querySelector('.play-btn').getAttribute('title');
+    });
+    console.log('  pausa  ', pausou);
+
+    const clip = await p.evaluate(() => {
+      const r = document.querySelector('canvas.stage-canvas').getBoundingClientRect();
+      return { x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) };
+    });
+
+    const olho = () => p.evaluate(async () => {
+      const card = Array.from(document.querySelectorAll('.effect-card'))
+        .find((c) => { const t2 = c.querySelector('.effect-title'); return t2 && t2.textContent.trim() === 'Liquid Glass'; });
+      card.querySelector('.icon-btn').click();
+      await new Promise((r) => setTimeout(r, 700));
+      return card.className;
+    });
+
+    console.log('  ligado ', JSON.stringify(await p.evaluate(CONTEUDO)));
+    await p.screenshot({ path: path.join(OUT, 'lg-' + caso.nome + '-ligado.png'), clip });
+    console.log('  olho   ', await olho());
+    console.log('  deslig ', JSON.stringify(await p.evaluate(CONTEUDO)));
+    await p.screenshot({ path: path.join(OUT, 'lg-' + caso.nome + '-desligado.png'), clip });
+    await b.close();
+  }
+  console.log('');
+  console.log('fotos em ' + OUT);
+})();

--- a/scripts/verify-effects-gl.cjs
+++ b/scripts/verify-effects-gl.cjs
@@ -97,10 +97,24 @@ for (const [id, fx] of Object.entries(effects)) {
   // Liquid Glass em duas posicoes. O deslocamento do pad resolve o SINAL de y
   // de uma vez: se o pad e o quadro discordarem, a lente anda para o lado
   // errado e nenhuma outra medida acusa isso.
+  // Os efeitos de lente, em 'Edges' e em 'Full frame'. E o par que prova a
+  // queixa que originou o controle: aplicado por cima de tudo, o efeito borra os
+  // cards; restrito as bordas, o meio do quadro tem de sair INTACTO.
+  for (const id of ['blur', 'bloom', 'tilt-shift', 'liquid-glass']) {
+    const fx = effects[id];
+    if (!fx.controls.some((c) => c.key === 'area')) continue;
+    const d = effectDefaults(id);
+    payload[id].areaBordas = passesOf(fx).map((p) => p.uniforms({ ...d, area: 'Edges', reach: 25 }, CTX));
+    payload[id].areaTudo = passesOf(fx).map((p) => p.uniforms({ ...d, area: 'Full frame' }, CTX));
+  }
+
   const lg = effectDefaults('liquid-glass');
-  const lgu = (extra) => effects['liquid-glass'].shader.uniforms({ ...lg, size: 30, ...extra }, CTX);
+  // Fixa 'Lens': o pad SO existe nesse modo. Com a area em 'Edges' (o default
+  // novo) o centro vem do quadro e ignorar o pad e o comportamento correto.
+  const lgu = (extra) => effects['liquid-glass'].shader.uniforms({ ...lg, area: 'Lens', size: 30, ...extra }, CTX);
   payload['liquid-glass'].uCentro = lgu({ position: { x: 0, y: 0 } });
   payload['liquid-glass'].uDireitaBaixo = lgu({ position: { x: 40, y: 24 } });
+  payload['tilt-shift'].uFaixa = effects['tilt-shift'].shader.uniforms({ ...effectDefaults('tilt-shift'), area: 'Band' }, CTX);
 }
 
 (async () => {
@@ -411,12 +425,14 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
         }
         return soma / n;
       };
-      const original = run(fx.blur.fragmentosDosPasses[0], { ...fx.blur.uniformsDosPasses[0], uRadius: 0 }, TEX.ruido2d);
+      // Fixa 'Full frame': este teste mede a SEPARABILIDADE do blur, e com a area
+      // em 'Edges' (o default novo) o miolo nem e tocado — mediria a mascara.
+      const original = run(fx.blur.fragmentosDosPasses[0], { ...fx.blur.areaTudo[0], uRadius: 0 }, TEX.ruido2d);
       // passe 1 sobre o ruido, depois passe 2 sobre a saida do 1 nao e possivel
       // aqui (o harness desenha para o canvas), entao mede-se cada passe sobre o
       // ruido: o horizontal tem de derrubar a variacao em X, o vertical em Y.
-      const h = run(fx.blur.fragmentosDosPasses[0], fx.blur.uniformsDosPasses[0], TEX.ruido2d);
-      const v = run(fx.blur.fragmentosDosPasses[1], fx.blur.uniformsDosPasses[1], TEX.ruido2d);
+      const h = run(fx.blur.fragmentosDosPasses[0], fx.blur.areaTudo[0], TEX.ruido2d);
+      const v = run(fx.blur.fragmentosDosPasses[1], fx.blur.areaTudo[1], TEX.ruido2d);
       const m = {
         original_x: +desvioEixo(original, 1, 0).toFixed(1),
         horizontal_x: +desvioEixo(h, 1, 0).toFixed(1),
@@ -437,7 +453,9 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
         }
         return soma / n;
       };
-      const t = run(fx['tilt-shift'].fragmentosDosPasses[0], fx['tilt-shift'].uniformsDosPasses[0], TEX.ruido2d);
+      // Fixa 'Band': e a faixa de foco que este teste mede, e ela deixou de ser o
+      // default quando a area entrou.
+      const t = run(fx['tilt-shift'].fragmentosDosPasses[0], fx['tilt-shift'].uFaixa, TEX.ruido2d);
       const meio = nitidez(t, (H >> 1) - 12, (H >> 1) + 12);
       const topo = nitidez(t, 4, 28);
       r.medidas['tilt-shift'] = { faixaEmFoco: +meio.toFixed(1), foraDaFaixa: +topo.toFixed(1) };
@@ -456,8 +474,11 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
         for (let y = 0; y < H; y++) for (let x = x0; x < x1; x++) soma += px[(y * W + x) * 4];
         return soma;
       };
-      const b = run(fx.bloom.fragment, fx.bloom.u0, TEX.faixa);
-      const sem = run(fx.bloom.fragment, { ...fx.bloom.u0, uIntensity: 0 }, TEX.faixa);
+      // Fixa Full frame: este teste mede o TRANSBORDO do bloom, e a faixa branca
+      // fica no meio do quadro — com a area em Edges (o default novo) a mascara
+      // apagaria justamente o que se quer medir.
+      const b = run(fx.bloom.fragment, fx.bloom.areaTudo[0], TEX.faixa);
+      const sem = run(fx.bloom.fragment, { ...fx.bloom.areaTudo[0], uIntensity: 0 }, TEX.faixa);
       const x0 = (W >> 1) + 6, x1 = (W >> 1) + 30;
       const com = energia(b, x0, x1), base = energia(sem, x0, x1);
       r.medidas.bloom = { energiaVizinha_com: com, energiaVizinha_sem: base, centro: linha(b, W >> 1) };
@@ -503,6 +524,67 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
       if (Math.abs((c1.x - c0.x) - 40) > 10) r.falhas.push('liquid-glass: o pad pediu +40 em x e a lente andou ' + (c1.x - c0.x).toFixed(1));
       if (Math.abs((c1.y - c0.y) - 24) > 10) r.falhas.push('liquid-glass: o pad pediu +24 em y e a lente andou ' + (c1.y - c0.y).toFixed(1) + ' — sinal de y invertido entre o pad e o quadro');
     } catch (e) { r.falhas.push('liquid-glass: ' + String(e.message).slice(0, 160)); }
+
+    // ---- AREA: 'Edges' tem de deixar o MEIO do quadro intacto ----
+    //
+    // A queixa que originou o controle: os efeitos de lente aplicavam por cima
+    // de tudo e borravam os cards, que ficam no meio. O teste e literalmente
+    // isso — comparar o miolo com a fonte e exigir zero diferenca, e comparar
+    // os cantos e exigir diferenca. Sem as duas metades, um efeito inerte
+    // passaria na primeira e um efeito de tela cheia passaria na segunda.
+    for (const id of ['blur', 'bloom', 'tilt-shift', 'liquid-glass']) {
+      const e = fx[id];
+      if (!e.areaBordas) continue;
+      try {
+        // fonte: o mesmo shader com a area em 'Edges' e alcance minimo — assim
+        // a comparacao e contra o proprio efeito desligado, nao contra outro
+        // shader, e um erro no wrapper nao se esconde na diferenca.
+        const nulo = { ...e.areaBordas[0], uBand: 0.0001 };
+        const fonte = run(e.fragmentosDosPasses[0], nulo, TEX.ruido2d);
+        const bordas = run(e.fragmentosDosPasses[0], e.areaBordas[0], TEX.ruido2d);
+        const tudo = run(e.fragmentosDosPasses[0], e.areaTudo[0], TEX.ruido2d);
+        const dif = (px, x0, y0, x1, y1) => {
+          let soma = 0, n = 0;
+          for (let y = y0; y < y1; y++) for (let x = x0; x < x1; x++) {
+            const i = (y * W + x) * 4;
+            soma += Math.abs(px[i] - fonte[i]) + Math.abs(px[i + 1] - fonte[i + 1]) + Math.abs(px[i + 2] - fonte[i + 2]);
+            n++;
+          }
+          return soma / Math.max(1, n);
+        };
+        const meio = [W / 2 - 24, H / 2 - 24, W / 2 + 24, H / 2 + 24];
+        const canto = [0, 0, 40, 40];
+        const m = {
+          bordas_meio: +dif(bordas, ...meio).toFixed(2),
+          bordas_canto: +dif(bordas, ...canto).toFixed(2),
+          tudo_meio: +dif(tudo, ...meio).toFixed(2),
+        };
+        r.medidas['area:' + id] = m;
+        if (m.bordas_meio > 1.5) r.falhas.push('area ' + id + ": em 'Edges' o meio do quadro mudou (" + m.bordas_meio + ') — o efeito nao esta respeitando a area');
+        if (m.bordas_canto < 3) r.falhas.push('area ' + id + ": em 'Edges' o canto nao mudou (" + m.bordas_canto + ') — o efeito ficou inerte em vez de restrito');
+        if (m.tudo_meio < 3) r.falhas.push('area ' + id + ": em 'Full frame' o meio deveria mudar (" + m.tudo_meio + ')');
+        // SATURACAO na moldura. Um brilho que num circulo curto le como reflexo
+        // de vidro, correndo pelo quadro inteiro, estoura e vira tubo de neon.
+        // Contar quantos pixels da moldura batem em 255 pega isso; olhar a
+        // imagem nao pega, porque neon tambem "parece de proposito".
+        // Sobre CINZA MEDIO, nao sobre o ruido: no ruido metade dos pixels ja
+        // nasce claro e qualquer soma satura, entao a medida diria mais sobre a
+        // textura do que sobre o efeito. Em 128 uniforme, saturar significa
+        // exatamente uma coisa — o efeito somou mais de 0,5 de luz.
+        const bordasCinza = run(e.fragmentosDosPasses[0], e.areaBordas[0], TEX.cinza);
+        let estourados = 0, borda = 0;
+        for (let y = 0; y < H; y++) for (let x = 0; x < W; x++) {
+          if (!(x < 6 || y < 6 || x > W - 7 || y > H - 7)) continue;
+          borda++;
+          const i = (y * W + x) * 4;
+          if (bordasCinza[i] >= 254 || bordasCinza[i + 1] >= 254 || bordasCinza[i + 2] >= 254) estourados++;
+        }
+        m.bordaEstourada = +((estourados / Math.max(1, borda)) * 100).toFixed(1);
+        if (m.bordaEstourada > 25) {
+          r.falhas.push('area ' + id + ': ' + m.bordaEstourada + '% da moldura saturou em 255 — o brilho estourou em vez de iluminar');
+        }
+      } catch (err) { r.falhas.push('area ' + id + ': ' + String(err.message).slice(0, 140)); }
+    }
 
     // ---- PARIDADE ENTRE ENGINES ----
     //

--- a/scripts/verify-effects-gl.cjs
+++ b/scripts/verify-effects-gl.cjs
@@ -93,6 +93,14 @@ for (const [id, fx] of Object.entries(effects)) {
   const d = effectDefaults('posterize');
   payload.posterize.uMix0 = effects.posterize.shader.uniforms({ ...d, mix: 0 }, CTX);
   payload.posterize.uMix50 = effects.posterize.shader.uniforms({ ...d, mix: 50 }, CTX);
+
+  // Liquid Glass em duas posicoes. O deslocamento do pad resolve o SINAL de y
+  // de uma vez: se o pad e o quadro discordarem, a lente anda para o lado
+  // errado e nenhuma outra medida acusa isso.
+  const lg = effectDefaults('liquid-glass');
+  const lgu = (extra) => effects['liquid-glass'].shader.uniforms({ ...lg, size: 30, ...extra }, CTX);
+  payload['liquid-glass'].uCentro = lgu({ position: { x: 0, y: 0 } });
+  payload['liquid-glass'].uDireitaBaixo = lgu({ position: { x: 40, y: 24 } });
 }
 
 (async () => {
@@ -456,6 +464,45 @@ void main(){ vTextureCoord = aPosition; gl_Position = vec4(aPosition*2.0-1.0, 0.
       if (com <= base) r.falhas.push('bloom: o brilho nao transbordou para o lado da faixa (' + base + ' -> ' + com + ')');
       if (linha(b, W >> 1) < 250) r.falhas.push('bloom: o centro da faixa branca escureceu (' + linha(b, W >> 1) + ') — bloom SOMA, nao mistura');
     } catch (e) { r.falhas.push('bloom: ' + String(e.message).slice(0, 160)); }
+
+    // ---- LIQUID GLASS: a lente e LOCAL, e anda com o pad ----
+    //
+    // Duas perguntas que compilar nao responde. Primeira: o efeito e local — o
+    // quadro fora da lente tem de sair identico a fonte, ou nao e uma lente, e
+    // um filtro de tela cheia. Segunda: o pad move a lente para o lado certo;
+    // com pad e quadro discordando no sinal de y, a lente anda para cima quando
+    // se pede para baixo e nenhuma outra medida acusa.
+    //
+    // Mede o CENTROIDE da diferenca contra a fonte, que e onde a lente esta.
+    try {
+      const fonte = run(fx['liquid-glass'].fragment, { ...fx['liquid-glass'].uCentro, uZoom: 0, uDispersion: 0, uRipple: 0, uGlow: 0, uRing: 0, uBlur: 0, uHalf: [0.001, 0.001] }, TEX.degrade);
+      const centroide = (px) => {
+        let sx = 0, sy = 0, peso = 0, mudados = 0;
+        for (let y = 0; y < H; y++) for (let x = 0; x < W; x++) {
+          const i = (y * W + x) * 4;
+          const dif = Math.abs(px[i] - fonte[i]) + Math.abs(px[i + 1] - fonte[i + 1]) + Math.abs(px[i + 2] - fonte[i + 2]);
+          if (dif < 6) continue;
+          mudados++;
+          sx += x * dif; sy += y * dif; peso += dif;
+        }
+        return { x: peso ? sx / peso : -1, y: peso ? sy / peso : -1, mudados };
+      };
+      const c0 = centroide(run(fx['liquid-glass'].fragment, fx['liquid-glass'].uCentro, TEX.degrade));
+      const c1 = centroide(run(fx['liquid-glass'].fragment, fx['liquid-glass'].uDireitaBaixo, TEX.degrade));
+      r.medidas['liquid-glass'] = {
+        centro: [Math.round(c0.x), Math.round(c0.y)], pixelsMudados: c0.mudados,
+        deslocada: [Math.round(c1.x), Math.round(c1.y)],
+        andou: [Math.round(c1.x - c0.x), Math.round(c1.y - c0.y)], pedido: [40, 24],
+      };
+      // A lente ocupa uma fracao do quadro: mudar tudo significa que ela nao
+      // recortou nada, e mudar quase nada significa que ela nao pintou.
+      const fracao = c0.mudados / (W * H);
+      if (fracao < 0.02) r.falhas.push('liquid-glass: a lente quase nao mudou pixel (' + (fracao * 100).toFixed(1) + '% do quadro)');
+      if (fracao > 0.35) r.falhas.push('liquid-glass: a lente vazou para fora do disco (' + (fracao * 100).toFixed(1) + '% do quadro mudou)');
+      // O centroide tem de ANDAR junto com o pad, com o sinal certo nos dois eixos.
+      if (Math.abs((c1.x - c0.x) - 40) > 10) r.falhas.push('liquid-glass: o pad pediu +40 em x e a lente andou ' + (c1.x - c0.x).toFixed(1));
+      if (Math.abs((c1.y - c0.y) - 24) > 10) r.falhas.push('liquid-glass: o pad pediu +24 em y e a lente andou ' + (c1.y - c0.y).toFixed(1) + ' — sinal de y invertido entre o pad e o quadro');
+    } catch (e) { r.falhas.push('liquid-glass: ' + String(e.message).slice(0, 160)); }
 
     // ---- PARIDADE ENTRE ENGINES ----
     //

--- a/scripts/verify-effects.cjs
+++ b/scripts/verify-effects.cjs
@@ -140,10 +140,22 @@ for (const effect of effectList) {
     const before = JSON.stringify(pass.uniforms(probe, SIZES[0]));
     const bumped = { ...probe };
     const v = probe[control.key];
+    // Cada TIPO de controle precisa da sua perturbacao. As tres primeiras
+    // linhas cobrem slider, toggle e pills, que era tudo o que existia num
+    // efeito. Objeto e cor entraram depois e caiam no `: v` do fim — o valor
+    // saia identico, os uniforms tambem, e o provador acusava um controle
+    // perfeitamente ligado como botao morto. Falso positivo, e o pior tipo:
+    // pressiona a pessoa a mexer no efeito para calar o teste.
     bumped[control.key] = typeof v === 'number'
       ? (control.max !== undefined && v >= control.max ? (control.min ?? 0) : v + (control.step ?? 1))
       : typeof v === 'boolean' ? !v
       : Array.isArray(control.options) ? control.options.find((o) => o !== v) ?? v
+      // xypad: {x,y}. Mexe nos DOIS eixos, senao um pad que so le `x` passaria.
+      : (v && typeof v === 'object' && 'x' in v && 'y' in v)
+        ? { x: Number(v.x) + 37, y: Number(v.y) - 23 }
+      // cor: troca por outra bem distante, para nao cair num arredondamento
+      : (typeof v === 'string' && /^#?[0-9a-f]{3,8}$/i.test(v))
+        ? (v.startsWith('#') ? '#0f8a3c' : '0f8a3c')
       : v;
     const after = JSON.stringify(pass.uniforms(bumped, SIZES[0]));
     if (before !== after) reached.add(control.key);

--- a/scripts/verify-effects.cjs
+++ b/scripts/verify-effects.cjs
@@ -164,6 +164,45 @@ for (const effect of effectList) {
     check(reached.has(control.key), id,
       `o controle \`${control.key}\` nao muda uniform nenhum — botao morto no painel`);
   }
+
+  // O ESPELHO do botao morto: um uniform que NENHUM controle move. Ele nao
+  // quebra nada, so fica preso no default para sempre — na pratica um valor
+  // chumbado se passando por parametro, e ninguem descobre porque a tela
+  // continua desenhando.
+  //
+  // Isto aconteceu de verdade: o Bloom recebeu `uArea`/`uBand` e ficou sem os
+  // controles correspondentes, entao o efeito nascia restrito as bordas e nao
+  // havia como tirar. As duas checagens juntas fecham o circulo — uma cobre
+  // controle sem uniform, a outra uniform sem controle.
+  const movidos = new Set();
+  for (const control of effect.controls) {
+    const antes = pass.uniforms(probe, SIZES[0]);
+    const alt = { ...probe };
+    const val = probe[control.key];
+    alt[control.key] = typeof val === 'number'
+      ? (control.max !== undefined && val >= control.max ? (control.min ?? 0) : val + (control.step ?? 1))
+      : typeof val === 'boolean' ? !val
+      : Array.isArray(control.options) ? control.options.find((o) => o !== val) ?? val
+      : (val && typeof val === 'object' && 'x' in val && 'y' in val)
+        ? { x: Number(val.x) + 37, y: Number(val.y) - 23 }
+      : (typeof val === 'string' && /^#?[0-9a-f]{3,8}$/i.test(val))
+        ? (val.startsWith('#') ? '#0f8a3c' : '0f8a3c')
+      : val;
+    const depois = pass.uniforms(alt, SIZES[0]);
+    for (const nome of Object.keys(declaredTypes)) {
+      if (JSON.stringify(antes[nome]) !== JSON.stringify(depois[nome])) movidos.add(nome);
+    }
+  }
+  // `fixedUniforms` e a excecao DECLARADA: constante por desenho, como a
+  // direcao do passe num blur separavel. Ter de declarar mantem o portao
+  // estrito — a alternativa era afrouxa-lo para todos.
+  const fixos = new Set(pass.fixedUniforms ?? []);
+  for (const nome of Object.keys(declaredTypes)) {
+    if (fixos.has(nome)) continue;
+    check(movidos.has(nome), id,
+      `o uniform \`${nome}\` nao e movido por controle nenhum — esta preso no default`
+      + ' (se e constante por desenho, declare em fixedUniforms)');
+  }
   } // fim do passe
 }
 


### PR DESCRIPTION
Stacked on #97 — it needs `meta.defaultScope` from that branch. Merge #97 first and this retargets to `main` cleanly.

## Where it comes from

The lens maths is the `discLens` shader from [liquid-glass-carousel](https://github.com/Yousuf-developer/liquid-glass-carousel), MIT. Checked at the source rather than assumed: the LICENSE is MIT and CREDITS.md states that the engine, the shader and the React wrapper are original and covered by it — only the demo images fall outside, and none of those came across. The copyright notice travels in two places, as this project's Apache-2.0 requires: a header in the effect file, and a new VENDORED SOURCE section in NOTICE.

**Only the shader was ported.** That project's carousel — infinite scroll, drag, focus mode — did not come, for two independent reasons: it is scroll-driven, whereas animation here is deterministic frame→pose for the export; and it depends on GSAP, whose licence bars a visual animation tool like this one.

## What changed in the adaptation

- `texture2D(uTex, uv)` became `fxSample(p)`, which handles colour space and Pixi's padding internally. Sampling the texture directly would break both.
- The original's vignette was dropped: there is already a Vignette effect here, and two paths to the same thing drift apart over time. Stack the two effects instead.
- The centre comes from an `xypad` in pixels from the frame centre. A pad in UV would change meaning with every canvas aspect.
- 30 uniforms became 13 controls. `uGlow`, `uWhiteGlow` and `uNovaSize` are interdependent in the original; one knob reaches a result, three do not.

## Three porting errors I made, and measured before committing

The original works in UV of screen height. I converted the coordinates to pixels without redoing the constants that depended on that scale:

- the white core added 0.47 at the centre against the original's 0.08 — six times too much, blowing out the middle of the lens. Rebuilt from the original's own formulas with its own defaults (glow 4.2, whiteGlow 0.24, novaSize 12).
- dispersion and rim ripple came out ~20x too weak. The constants are now a FRACTION OF THE LENS RADIUS, which also makes the effect identical at any resolution instead of depending on canvas size.
- the wave frequencies were 3 and 7, mine; the original uses 2 and 1. Seven waves give a busy rim in motion; two slow mismatched ones read as liquid.

## Measured

The first two questions are not answered by the shader compiling:

| Measurement | Result |
|---|---|
| Lens centre | [125,127] in a 256x256 frame (centre is 128,128) |
| Pixels changed | 4603 of 65536 — 7%, which is the disc area (pi*38.4^2) |
| Pad asked [+40,+24] | lens moved [39,24] — y sign correct on both axes |
| Cross-engine parity | mean 0.5 of 255 |

The position gate exists because an inverted y sign between the pad and the frame shows up in no other measurement: the lens simply travels up when you ask it to go down.

## A false positive fixed in the dead-control prober

It only knew how to perturb numbers, booleans and option lists. `xypad` (an `{x,y}` object) and `color` (a hex string) fell through to the final branch and came back identical, so no uniform moved and it reported two perfectly wired controls as dead buttons. That is the worst kind of false positive — it pressures you into changing the effect to silence the test. Mutation confirmed on both: genuinely ignoring `position` or `ringColor` fails the suite.

