### PR TITLE
Fix folder icon closed state and animate opening

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -457,6 +457,75 @@ input[type=range] {
 }
 
 /* ============================================================
+   FOLDER GLYPH — the Projects icon opens when its section is active
+   (components/EditorIcons.tsx → ProjectsIcon)
+
+   Clicking Projects makes the rail item `.active`, and that is what opens the
+   folder: the front panel tips out about its own bottom-left corner, the one
+   the reference clip holds fixed. Plus the little squash on the way in,
+   borrowed from the reference — anticipation, so the panel does not just
+   appear.
+
+   Anywhere without an `.active` ancestor (ProjectDock, the mobile header) the
+   panel sits at identity, on the closed folder, and the glyph is the plain
+   closed folder it has always been.
+   ============================================================ */
+.folder-glyph {
+  --dur: 380ms;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  overflow: visible;
+}
+
+/* plain (unmasked) back is what renders almost all the time; the masked copy
+   only takes over while the panel is actually open. See EditorIcons.tsx. */
+.folder-glyph .folder-back-masked { visibility: hidden; }
+.rail-item.active .folder-glyph .folder-back-plain { visibility: hidden; }
+.rail-item.active .folder-glyph .folder-back-masked { visibility: visible; }
+
+.folder-glyph .folder-front {
+  transform-box: fill-box;
+  /* the corner the reference holds fixed through the whole opening */
+  transform-origin: left bottom;
+  /* Hidden when closed, and NOT transitioned in either direction: a
+     transition only reaches its final value if it runs, and when it does not
+     (a backgrounded tab, a dropped frame, a remount mid-flight) the computed
+     value stays pinned where it came FROM. That left the tipped panel painted
+     over the closed folder. `visibility` on top of opacity because it cannot
+     paint under any compositing path, and unlike `display: none` it keeps the
+     element in the layout so the transform still transitions. */
+  visibility: hidden;
+  opacity: 0;
+  transition: transform var(--dur) cubic-bezier(.4, 0, .2, 1);
+}
+
+.rail-item.active .folder-glyph .folder-front {
+  /* ORDER MATTERS: this way round the skew acts on the already-shortened
+     panel, which puts the right edge at x19.1 instead of x21.0 — the only one
+     of the two that fits the 20-unit box. */
+  transform: skewX(-18deg) scaleY(.56);
+  visibility: visible;
+  opacity: 1;
+  transition: transform var(--dur) cubic-bezier(.4, 0, .2, 1);
+}
+
+/* the squash is the reference's "pinch": the folder takes a breath before the
+   panel swings out. Runs on activation only. */
+.rail-item.active .folder-glyph { animation: folder-pinch var(--dur) cubic-bezier(.4, 0, .2, 1); }
+
+@keyframes folder-pinch {
+  0%   { transform: scaleY(1)    scaleX(1);    }
+  25%  { transform: scaleY(.92)  scaleX(1.03); }
+  60%  { transform: scaleY(1.02) scaleX(.99);  }
+  100% { transform: scaleY(1)    scaleX(1);    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .folder-glyph .folder-front { transition-duration: 1ms; }
+  .rail-item.active .folder-glyph { animation: none; }
+}
+
+/* ============================================================
    THEME GLYPH — the sun/moon toggle, one shape that morphs
    (components/EditorIcons.tsx → ThemeGlyph)
 

--- a/components/EditorIcons.tsx
+++ b/components/EditorIcons.tsx
@@ -67,8 +67,92 @@ export function AddIcon(props: EditorIconProps) {
   return <svg {...iconProps(props)}><path d="M10 3v14M3 10h14"/></svg>;
 }
 
-export function ProjectsIcon(props: EditorIconProps) {
-  return <svg {...iconProps(props)}><path d="M3 17V4h5.5l2 2H17v11Z"/></svg>;
+// The folder opens when its section is active. Transcribed from the
+// system-outline folder animation by measuring its frames over a 20-unit grid.
+//
+//  · The front panel TIPS about its own bottom-left corner, which stays fixed
+//    through the whole opening. It does not slide and it does not grow.
+//  · ORDER of the transform is load-bearing. `scaleY() skewX()` skews the
+//    ORIGINAL height and the top edge travels 11*tan(t); `skewX() scaleY()`
+//    skews the already-shortened panel and it travels 11*sy*tan(t). Measured,
+//    the same numbers put the right edge at x21.0 one way and x19.1 the other,
+//    and only the second fits the 20-unit box.
+//  · The reference's front panel is OPAQUE — it hides the back's right side
+//    and floor below it. So the back is the whole folder and the `cover` mask
+//    cuts it where the front covers it. That mask's content carries
+//    `folder-front`, so one rule drives the panel and its cutout together.
+//    It is STROKED as well as filled: cut to the fill alone and the cut lands
+//    on the centreline of the panel's stroke, leaving the outer half of the
+//    back's to add to it.
+//  · The `lip` mask subtracts the tab's region from the panel's top edge, or
+//    the closed state carries a seam across the tab. It starts at x3.2 —
+//    measured as the only position that neither leaves a parasite pixel in the
+//    tab's gap nor eats the panel's own left stroke.
+//
+// `non-scaling-stroke` keeps the panel's weight equal to the back's: the open
+// transform scales Y, which would otherwise thin its horizontal edges. The
+// width is given in screen px, scaled from `size`, so it matches at 13, 18
+// and 20.
+const FOLDER_BACK = 'M3 17V4h5.5l2 2H17v11Z';
+const FOLDER_FRONT = 'M3 6h14v11H3Z';
+
+export function ProjectsIcon({ size = 20, ...rest }: EditorIconProps) {
+  const uid = useId();
+  const lip = `folder-lip-${uid}`;
+  const cover = `folder-cover-${uid}`;
+  return <svg {...iconProps({ size, ...rest })} className="folder-glyph">
+    <defs>
+      {/* the panel's top edge, cut where the tab sits over it */}
+      <mask id={lip} maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+        <rect x="0" y="0" width="20" height="20" fill="#fff"/>
+        <rect x="3.2" y="3.2" width="7.3" height="5.3" fill="#000"/>
+      </mask>
+      {/* the back, cut where the panel covers it */}
+      <mask id={cover} maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+        <rect x="0" y="0" width="20" height="20" fill="#fff"/>
+        <path
+          className="folder-front"
+          d={FOLDER_FRONT}
+          fill="#000"
+          stroke="#000"
+          vectorEffect="non-scaling-stroke"
+          strokeWidth={1.5 * size / 20}
+          strokeMiterlimit={1.5}
+        />
+        {/* the stroke above widens the cut upwards too, into the tab. The
+            panel never reaches above y6, so giving this corner back costs
+            nothing. */}
+        <rect x="0" y="0" width="11.3" height="6" fill="#fff"/>
+      </mask>
+    </defs>
+    {/* Two copies of the back, switched by `visibility` rather than by the
+        mask alone. A mask forces its content onto a separate rasterised
+        buffer before compositing, and a browser is free to sample that buffer
+        at whatever resolution it likes — closed, the cut is a no-op (nothing
+        painted into the mask, so nothing is removed), but the back is still
+        going through that extra buffer for no reason, and an independently
+        rasterised layer's edges are not guaranteed to land on the exact same
+        sub-pixel grid as a directly painted path. Closed is the state every
+        rail item is in almost all the time, so it gets the plain path with no
+        mask in its render path at all — zero chance of a masking artefact —
+        and the masked copy exists purely for when the panel is open. */}
+    <path className="folder-back-plain" d={FOLDER_BACK}/>
+    <g className="folder-back-masked" mask={`url(#${cover})`}>
+      <path d={FOLDER_BACK}/>
+    </g>
+    <g mask={`url(#${lip})`}>
+      {/* miterlimit 1.5 bevels the tipped panel's 72-degree bottom-left
+          corner, whose miter would spit a spur out past the box, and keeps the
+          miter on the closed state's 90-degree corners. */}
+      <path
+        className="folder-front"
+        d={FOLDER_FRONT}
+        vectorEffect="non-scaling-stroke"
+        strokeWidth={1.5 * size / 20}
+        strokeMiterlimit={1.5}
+      />
+    </g>
+  </svg>;
 }
 
 // A featured card with two more receding behind it — which is literally what


### PR DESCRIPTION
## Summary
- Animate the Projects folder when its rail item is active.
- Render the original unmasked folder when closed and hide every open-state element immediately, preventing leftover strokes.
- Keep consistent stroke weight and support reduced motion.
- Scope this PR to EditorIcons.tsx and globals.css; exclude generated and unrelated changes.

## Validation
- TypeScript and npm test passed during preparation.
- git diff --cached --check passed.
- Approved visual design preserved; no additional redesign.