### PR TITLE
fix(mockup): repaint the stage background when the gradient raster re…

### DIFF
--- a/three3d/mockup.ts
+++ b/three3d/mockup.ts
@@ -90,7 +90,9 @@ export function initMockup(
   // puts c1 at the BOTTOM, and the radial ends at 130% of the box.
   const bgCanvas = document.createElement('canvas');
   bgCanvas.width = bgCanvas.height = 2;
-  const bgTex = new THREE.CanvasTexture(bgCanvas);
+  let bgTexWidth = bgCanvas.width;
+  let bgTexHeight = bgCanvas.height;
+  let bgTex = new THREE.CanvasTexture(bgCanvas);
   bgTex.colorSpace = THREE.SRGBColorSpace;
   scene.background = bgTex;
   let bgKey = '';
@@ -112,6 +114,22 @@ export function initMockup(
       ctx.fillRect(0, 0, 2, 2);
     } else {
       paintGradientCanvas(bgCanvas, gradient, rw, rh, phase);
+    }
+    // The raster size is not constant: Basic linear/radial paint at 1080px, the
+    // procedural Advanced fields at 288px or less, and Solid at 2px. A
+    // CanvasTexture allocates immutable GL storage from the size it first saw,
+    // so a smaller canvas later can only reach the GPU as a SUB-image in one
+    // corner — which is what the stage showed: the new gradient inside a 27%
+    // box at the bottom-left, the previous one everywhere else. Recreate the
+    // texture whenever the source size changes, the way the Library renderer
+    // already does (lib/renderer3d.ts).
+    if (bgCanvas.width !== bgTexWidth || bgCanvas.height !== bgTexHeight) {
+      bgTexWidth = bgCanvas.width;
+      bgTexHeight = bgCanvas.height;
+      bgTex.dispose();
+      bgTex = new THREE.CanvasTexture(bgCanvas);
+      bgTex.colorSpace = THREE.SRGBColorSpace;
+      scene.background = bgTex;
     }
     bgTex.needsUpdate = true;
   }


### PR DESCRIPTION
## The bug

In **Mockup**, the Background gradient controls only reached a 27% corner of the stage. Switching the gradient from Basic to Advanced left the old gradient covering the rest of the frame, and switching Fill from Gradient to **Solid did nothing at all**.

The Mockup stage bakes its background into the three.js scene as a `CanvasTexture` (this is what makes the exported JPEG/WebM frames match the preview). The texture is created from a 2×2 canvas, and `paintBackground` then resizes that same canvas per gradient kind:

| Gradient | Raster max edge |
| --- | ---: |
| Basic linear / radial | 1080 |
| Advanced, no flow | 288 |
| Advanced mesh / warped field, flowing | 160 |
| Solid | 2 |

A `CanvasTexture` allocates immutable GL storage from the size it first saw, so a smaller canvas afterwards can only be uploaded as a **sub-image in one corner** — the rest of the texture keeps the previous pixels.

## The fix

Recreate the texture whenever the source canvas changes size, exactly the way the Library renderer already does in `lib/renderer3d.ts`. One file, 19 lines.

## Measured

`.three3d-stage` photographed before and after each change; pixels whose colour did not move are pixels the GPU never received. The figure is the bounding box of the changed pixels as a fraction of the stage.

| Change | Before | After |
| --- | --- | --- |
| Basic linear → Advanced mesh | 0.267 × 0.268 box at the bottom-left (6.9% of pixels) | full stage (65.2% of pixels; the rest is the device) |
| Advanced mesh → Basic linear | same 27% corner | full stage |
| Gradient → Solid | no change at all | full stage |

`0.267 = 288 / 1080`, i.e. exactly the ratio of the two rasters — the signature of a sub-image upload.

`npm test` passes (13 suites) and `tsc --noEmit` is clean.

## Out of scope, but worth knowing

`three3d/cartoon.ts` (the **3D** tab, not Mockup) has the same pattern: `wallGradientTex` is created from a 2×2 canvas and `syncWallGradient` resizes that canvas without ever recreating the texture. Same defect, same one-line shape of fix. Not touched here — say the word and it goes in its own PR.